### PR TITLE
prep: a preprocessing section, starting with a mesh-only viewer

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -522,6 +522,17 @@ def _view(args) -> int:
     return 0
 
 
+def _prep_view(args) -> int:
+    from .prep.meshview import serve
+
+    # same rule as `view`: an explicit --port is usually a tunnel already
+    # pointing at it, so listening elsewhere would be worse than failing
+    serve(args.mesh_file, port=args.port, host=args.host,
+          nx=args.width, ny=args.height, open_browser=not args.no_browser,
+          strict_port=args.port != DEFAULT_PORT)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gmpas",
@@ -613,6 +624,35 @@ def build_parser() -> argparse.ArgumentParser:
     v.add_argument("--no-browser", action="store_true",
                    help="do not open a browser (useful over an SSH tunnel)")
     v.set_defaults(func=_view)
+
+    # -- preprocessing ---------------------------------------------------
+    # Everything above is postprocessing: it opens a run and renders, remaps or
+    # exports it. `prep` is the other end of the pipeline -- building a mesh and
+    # looking at it before any model output exists -- so it gets its own
+    # namespace rather than more top-level verbs. Mesh generation (#15) belongs
+    # here next, as `gmpas prep generate`.
+    pre = sub.add_parser("prep", help="preprocessing: inspect and build meshes",
+                         description="Preprocessing steps, which run before "
+                                     "there is any model output to plot.")
+    presub = pre.add_subparsers(dest="prep_cmd", metavar="{view}")
+    # a bare `gmpas prep` should list its steps, not error
+    pre.set_defaults(func=lambda _a, _p=pre: (_p.print_help(), 0)[1])
+
+    pv = presub.add_parser("view", help="browse a mesh file on its own, "
+                                        "with no output data")
+    pv.add_argument("mesh_file", metavar="MESH", help="MPAS mesh file")
+    pv.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+                    help=f"port (default {DEFAULT_PORT}; the default wanders "
+                         f"if busy, an explicit one fails instead)")
+    pv.add_argument("--host", default="127.0.0.1",
+                    help="interface to bind. Use 0.0.0.0 on an HPC compute "
+                         "node so a tunnel from the login node can reach it")
+    pv.add_argument("--width", type=int, default=1200,
+                    help="raster width in pixels")
+    pv.add_argument("--height", type=int, default=700)
+    pv.add_argument("--no-browser", action="store_true",
+                    help="do not open a browser (useful over an SSH tunnel)")
+    pv.set_defaults(func=_prep_view)
     return p
 
 

--- a/src/gmpas/prep/__init__.py
+++ b/src/gmpas/prep/__init__.py
@@ -1,0 +1,23 @@
+"""Preprocessing: everything that happens *before* there is model output.
+
+The rest of gmpas is postprocessing -- it opens a run and renders, remaps or
+exports it. This subpackage is the other end: building a mesh and looking at it
+on its own, with no history file in sight.
+
+Nothing here modifies the postprocessing path. `gmpas view`, `plot`, `remap`
+and friends behave exactly as before; the preprocessing commands live under
+`gmpas prep` and reuse the viewer's plumbing (`ViewIndex`, the palette PNG
+encoder, the coastline overlay, `bind`) by importing it, never by changing it.
+
+`layout.page()` is the shared browser layout for this section: the same map,
+graticule, scale bar and extent box, with a slot for whatever controls a given
+step needs. Mesh viewing is the first user; mesh generation is meant to be the
+second.
+"""
+
+from __future__ import annotations
+
+from .layout import page
+from .meshview import MeshViewer, serve
+
+__all__ = ["MeshViewer", "page", "serve"]

--- a/src/gmpas/prep/layout.py
+++ b/src/gmpas/prep/layout.py
@@ -1,0 +1,417 @@
+"""The shared browser layout for preprocessing steps.
+
+A deliberately reduced version of the `gmpas view` page. What a preprocessing
+step needs is geography -- pan, zoom, a graticule, a scale bar and an extent
+box to read a domain off -- and nothing that belongs to a model run. So the
+timestep slider, the level slider, the colormap picker, the vmin/vmax boxes,
+the animation panel, the exports and the probe are all absent, not hidden.
+
+The colour scale is fixed per field rather than adjustable: a mesh field like
+cell width does not change with the view, and rescaling it while panning would
+make the same refinement band change colour as you move. The legend is there to
+read values off; there is nothing to tune.
+
+`page()` fills three slots so a later step (mesh generation) can reuse this
+shell instead of forking it:
+
+    title    what the tab and the sidebar heading say
+    panel    extra HTML for the right-hand column, under the extent box
+    script   extra JS, run after `boot()` has fetched /api/meta into `M`
+
+A step that supplies neither `panel` nor `script` gets exactly the mesh viewer.
+The server contract is four routes: `/`, `/api/meta`, `/api/frame` and
+`/api/overlay`.
+"""
+
+from __future__ import annotations
+
+_PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>__TITLE__</title>
+<style>
+:root{--bg:#16181c;--panel:#1e2127;--line:#2c313a;--fg:#e6e8ec;--dim:#9aa3b0;--accent:#5dcaa5}
+*{box-sizing:border-box}
+body{margin:0;font:13px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+     background:var(--bg);color:var(--fg);display:flex;height:100vh;overflow:hidden}
+#side{width:250px;flex:none;background:var(--panel);border-right:1px solid var(--line);
+      display:flex;flex-direction:column;overflow:hidden}
+#side h1{font-size:13px;font-weight:500;margin:0;padding:12px 14px;border-bottom:1px solid var(--line)}
+#side h1 small{display:block;color:var(--dim);font-weight:400;margin-top:2px}
+.sec{padding:10px 14px;border-bottom:1px solid var(--line);flex:none}
+.sec label{display:block;color:var(--dim);font-size:11px;letter-spacing:.04em;
+           text-transform:uppercase;margin-bottom:6px}
+input[type=text]{width:100%;background:#14161a;color:var(--fg);
+  border:1px solid var(--line);border-radius:4px;padding:5px 6px;font:inherit}
+input[type=range]{width:100%;accent-color:var(--accent)}
+#fields{padding:2px 0}
+#fields div{padding:4px 14px;margin:0 -14px;cursor:pointer;white-space:nowrap;
+            overflow:hidden;text-overflow:ellipsis}
+#fields div:hover{background:#252932}
+#fields div.on{background:var(--accent);color:#08201a}
+#facts{flex:1;overflow-y:auto}
+#main{flex:1;display:flex;flex-direction:column;min-width:0}
+#right{width:220px;flex:none;background:var(--panel);border-left:1px solid var(--line);
+       overflow-y:auto}
+#right h1{font-size:13px;font-weight:500;margin:0;padding:12px 14px;
+          border-bottom:1px solid var(--line)}
+#right .row{display:flex;gap:6px}
+.kv{display:flex;justify-content:space-between;color:var(--dim);font-size:11px;
+    margin-bottom:4px}
+.kv b{color:var(--fg);font-weight:500;font-variant-numeric:tabular-nums}
+.hint{color:var(--dim);font-size:11px;margin-top:6px;line-height:1.45;
+      font-variant-numeric:tabular-nums;word-break:break-word}
+#top{padding:8px 14px;border-bottom:1px solid var(--line);display:flex;gap:14px;
+     align-items:center;color:var(--dim);flex-wrap:wrap}
+#top b{color:var(--fg);font-weight:500;white-space:nowrap}
+#stage{flex:1;display:flex;align-items:center;justify-content:center;position:relative;
+       padding:12px;min-height:0;overflow:hidden}
+#frame{display:grid;grid-template-columns:auto auto;grid-template-rows:auto auto}
+#latax{position:relative;width:52px}
+#lonax{position:relative;height:18px}
+#corner{width:52px;height:18px}
+#latax span,#lonax span{position:absolute;color:var(--dim);font-size:11px;
+  font-variant-numeric:tabular-nums;white-space:nowrap}
+#latax span{right:6px;transform:translateY(-50%)}
+#lonax span{top:2px;transform:translateX(-50%)}
+#grat{position:absolute;inset:0;pointer-events:none}
+#grat i{position:absolute;background:#fff;opacity:.28}
+#grat i.v{top:0;bottom:0;width:1px}
+#grat i.h{left:0;right:0;height:1px}
+#wrap{position:relative;line-height:0;box-shadow:0 0 0 1px var(--line);overflow:hidden;
+      cursor:grab}
+#wrap.drag{cursor:grabbing}
+#wrap img{display:block;width:100%;height:100%;transform-origin:0 0;will-change:transform}
+#over{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+#scale{position:absolute;left:14px;bottom:14px;color:#fff;font-size:11px;
+       text-shadow:0 0 3px #000,0 0 6px #000;pointer-events:none}
+#scalebar{height:5px;border:1px solid #fff;border-top:none;box-shadow:0 0 3px #000;
+          margin-top:2px}
+#scaletext{display:block;font-variant-numeric:tabular-nums}
+#msg{position:absolute;top:14px;left:50%;transform:translateX(-50%);background:#000a;
+     padding:4px 10px;border-radius:4px;color:var(--dim);opacity:0;transition:opacity .2s;
+     pointer-events:none}
+#bar{padding:8px 14px;border-top:1px solid var(--line)}
+#ramp{height:14px;border-radius:2px;border:1px solid var(--line)}
+#ticks{display:flex;justify-content:space-between;margin-top:3px;color:var(--dim);
+       font-size:11px;font-variant-numeric:tabular-nums}
+#cblabel{color:var(--dim);font-size:11px;margin-bottom:4px}
+button{background:#252932;color:var(--fg);border:1px solid var(--line);border-radius:4px;
+       padding:5px 9px;font:inherit;cursor:pointer}
+button:hover{border-color:var(--accent)}
+</style></head><body>
+<div id="side">
+  <h1><span id="title">loading&hellip;</span><small id="sub"></small></h1>
+  <div class="sec"><label>field</label><div id="fields"></div></div>
+  <div class="sec" id="facts"><label>mesh</label>
+    <div class="kv"><span>cells</span><b id="f_cells">&ndash;</b></div>
+    <div class="kv"><span>edges</span><b id="f_edges">&ndash;</b></div>
+    <div class="kv"><span>coverage</span><b id="f_cov">&ndash;</b></div>
+    <div class="kv"><span>width min</span><b id="f_wmin">&ndash;</b></div>
+    <div class="kv"><span>width max</span><b id="f_wmax">&ndash;</b></div>
+  </div>
+</div>
+<div id="main">
+  <div id="top">
+    <span>zoom</span><input type="range" id="zoom" min="0" max="800" value="0" style="width:140px">
+    <label style="white-space:nowrap"><input type="checkbox" id="grid" checked
+      style="vertical-align:-1px"> grid</label>
+    <button id="home">reset view</button>
+  </div>
+  <div id="stage">
+    <div id="frame">
+      <div id="latax"></div>
+      <div id="wrap">
+        <img id="data"><img id="over">
+        <div id="grat"></div>
+        <div id="scale"><span id="scaletext"></span><div id="scalebar"></div></div>
+      </div>
+      <div id="corner"></div>
+      <div id="lonax"></div>
+    </div>
+    <div id="msg"></div>
+  </div>
+  <div id="bar">
+    <div id="cblabel"></div>
+    <div id="ramp"></div>
+    <div id="ticks"></div>
+  </div>
+</div>
+<div id="right">
+  <h1>options</h1>
+  <div class="sec"><label>extent</label>
+    <div class="row"><input type="text" id="elon0" placeholder="lon min"><input type="text" id="elon1" placeholder="lon max"></div>
+    <div class="row" style="margin-top:6px"><input type="text" id="elat0" placeholder="lat min"><input type="text" id="elat1" placeholder="lat max"></div>
+    <div class="row" style="margin-top:6px"><button id="applyext">apply</button><button id="copyext">copy</button></div>
+    <div class="hint" id="exthint"></div>
+  </div>
+__PANEL__
+</div>
+<script>
+const $=s=>document.querySelector(s);
+let M=null, cur=null, busy=false, pend=false;
+let view=null, home=null, rendered=null;      // geographic state
+const ZMAX=800;                               // slider units, 100 per doubling
+
+function say(t){const m=$("#msg");m.textContent=t;m.style.opacity=t?1:0;}
+function aspect(){ return M.nx/M.ny; }
+
+// a view is a centre plus a longitude span; latitude span follows the image
+// aspect so nothing is ever stretched
+function boxOf(v){
+  const h=v.w/aspect();
+  return [v.clon-v.w/2, v.clon+v.w/2, v.clat-h/2, v.clat+h/2];
+}
+function fit(box){
+  const [a,b,c,d]=box, clon=(a+b)/2, clat=(c+d)/2;
+  return {clon, clat, w: Math.max(b-a, (d-c)*aspect())};
+}
+function clamp(){
+  view.w = Math.min(view.w, home.w);                 // never wider than the mesh
+  view.w = Math.max(view.w, home.w/Math.pow(2,ZMAX/100));
+  const h=view.w/aspect(), hh=home.w/aspect();
+  const dx=Math.max(0,(home.w-view.w)/2), dy=Math.max(0,(hh-h)/2);
+  view.clon=Math.min(home.clon+dx, Math.max(home.clon-dx, view.clon));
+  view.clat=Math.min(home.clat+dy, Math.max(home.clat-dy, view.clat));
+  $("#zoom").value = Math.round(Math.log2(home.w/view.w)*100);
+}
+
+// Frames are rendered wider than the window. Without a margin, dragging slid
+// the image off its own edge and exposed blank background until the redraw
+// landed. 1.4x costs ~2x the pixels and buys a screen-width of slack.
+const OUTSET=1.4;
+const GUTTER_X=52, GUTTER_Y=18;
+function outset(b, f=OUTSET){
+  const cx=(b[0]+b[1])/2, cy=(b[2]+b[3])/2, w=(b[1]-b[0])*f/2, h=(b[3]-b[2])*f/2;
+  return [cx-w, cx+w, cy-h, cy+h];
+}
+function covers(outer, inner){
+  return outer && outer[0]<=inner[0]+1e-9 && outer[1]>=inner[1]-1e-9
+                && outer[2]<=inner[2]+1e-9 && outer[3]>=inner[3]-1e-9;
+}
+function layout(){
+  if(!M) return;
+  const st=$("#stage"), cs=getComputedStyle(st), pad=parseFloat(cs.padding)||0;
+  const availW=st.clientWidth-2*pad-GUTTER_X, availH=st.clientHeight-2*pad-GUTTER_Y;
+  const a=aspect();
+  let w=availW, h=w/a;
+  if(h>availH){ h=availH; w=h*a; }
+  const wrap=$("#wrap");
+  wrap.style.width=Math.max(80,Math.floor(w))+"px";
+  wrap.style.height=Math.max(60,Math.floor(h))+"px";
+}
+
+const STEPS=[0.05,0.1,0.2,0.25,0.5,1,2,2.5,5,10,15,20,30,45,60];
+function niceStep(span, want){
+  for(const s of STEPS) if(span/s <= want) return s;
+  return STEPS[STEPS.length-1];
+}
+function fmtLon(v){
+  let x=((v+180)%360+360)%360-180;                 // a view can run past +180
+  const r=Math.round(x*100)/100;
+  if(r===0) return "0\\u00b0";
+  if(Math.abs(r)===180) return "180\\u00b0";       // the antimeridian is neither
+  return `${Math.abs(r)}\\u00b0${r>0?"E":"W"}`;
+}
+function fmtLat(v){
+  const r=Math.round(v*100)/100;
+  return r===0?"0\\u00b0":`${Math.abs(r)}\\u00b0${r>0?"N":"S"}`;
+}
+function graticule(){
+  const g=$("#grat"), la=$("#latax"), lo=$("#lonax");
+  g.innerHTML=""; la.innerHTML=""; lo.innerHTML="";
+  if(!$("#grid").checked) return;
+  const b=boxOf(view);
+  const w=$("#wrap").clientWidth, h=$("#wrap").clientHeight;
+  la.style.height=h+"px"; lo.style.width=w+"px";
+
+  const sx=niceStep(b[1]-b[0], 7), sy=niceStep(b[3]-b[2], 6);
+  for(let v=Math.ceil(b[0]/sx)*sx; v<=b[1]+1e-9; v+=sx){
+    const f=(v-b[0])/(b[1]-b[0]);
+    g.insertAdjacentHTML("beforeend",`<i class="v" style="left:${f*100}%"></i>`);
+    lo.insertAdjacentHTML("beforeend",`<span style="left:${f*w}px">${fmtLon(v)}</span>`);
+  }
+  for(let v=Math.ceil(b[2]/sy)*sy; v<=b[3]+1e-9; v+=sy){
+    const f=(b[3]-v)/(b[3]-b[2]);
+    g.insertAdjacentHTML("beforeend",`<i class="h" style="top:${f*100}%"></i>`);
+    la.insertAdjacentHTML("beforeend",`<span style="top:${f*h}px">${fmtLat(v)}</span>`);
+  }
+}
+function scalebar(){
+  const b=boxOf(view), wkm=(b[1]-b[0])*111.320*Math.cos(view.clat*Math.PI/180);
+  const px=$("#wrap").clientWidth||600;
+  let target=wkm*0.25, mag=Math.pow(10,Math.floor(Math.log10(target)));
+  const nice=[1,2,5,10].map(n=>n*mag).filter(n=>n<=wkm*0.45);
+  const len=nice.length?nice[nice.length-1]:target;
+  $("#scalebar").style.width=(len/wkm*px)+"px";
+  $("#scaletext").textContent = len>=1 ? `${len.toLocaleString()} km`
+                                       : `${Math.round(len*1000).toLocaleString()} m`;
+}
+
+// The scale is a property of the field, not of the view: it is fixed once,
+// from the whole mesh, so a refinement band keeps its colour while you pan.
+function colorbar(){
+  $("#ramp").style.background=`linear-gradient(90deg,${M.ramp.join(",")})`;
+  const n=5, out=[];
+  for(let i=0;i<n;i++){
+    const v=cur.vmin+(cur.vmax-cur.vmin)*i/(n-1);
+    out.push(`<span>${Math.abs(v)>=1e4||(v!==0&&Math.abs(v)<1e-3)?v.toExponential(2):v.toPrecision(4)}</span>`);
+  }
+  $("#ticks").innerHTML=out.join("");
+  $("#cblabel").textContent=cur?cur.label:"";
+}
+
+async function overlay(){
+  const b=outset(boxOf(view));
+  $("#over").src=`/api/overlay?extent=${b.join(",")}`+
+                 `&nx=${Math.round(M.nx*OUTSET)}&ny=${Math.round(M.ny*OUTSET)}`;
+}
+// show the frame we already have, transformed into place, until the real one
+// lands. Without this a zoom looks like nothing happens and then it jumps.
+function preview(){
+  if(!rendered){ return; }
+  const b=boxOf(view), s=(rendered[1]-rendered[0])/(b[1]-b[0]);
+  const fx=(b[0]-rendered[0])/(rendered[1]-rendered[0]);
+  const fy=(rendered[3]-b[3])/(rendered[3]-rendered[2]);
+  const t=`translate(${-fx*s*100}%, ${-fy*s*100}%) scale(${s})`;
+  $("#data").style.transform=t; $("#over").style.transform=t;
+}
+
+async function draw(){
+  if(!cur) return;
+  if(busy){ pend=true; return; }
+  busy=true;
+  // under try/finally: a fetch that rejects must not leave `busy` set, or the
+  // viewer never draws again and pan/zoom look broken
+  try{
+    const b=outset(boxOf(view));
+    const p=new URLSearchParams({field:cur.name, extent:b.join(","),
+      nx:Math.round(M.nx*OUTSET), ny:Math.round(M.ny*OUTSET)});
+    const t0=performance.now();
+    const r=await fetch("/api/frame?"+p);
+    if(!r.ok){ say((await r.json()).error); return; }
+    const url=URL.createObjectURL(await r.blob());
+    const img=$("#data"), old=img.src;
+    img.onload=()=>{ if(old.startsWith("blob:")) URL.revokeObjectURL(old); };
+    img.src=url;
+    rendered=b;
+    preview();        // the frame is larger than the window: crop to the view
+    colorbar(); scalebar(); graticule(); panel();
+    say(`${cur.label} \\u00b7 ${Math.round(performance.now()-t0)} ms`);
+  }catch(e){
+    say("render failed: "+e);
+  }finally{
+    busy=false;
+    if(pend){ pend=false; draw(); }      // always drains, however we left
+  }
+}
+
+function panel(){
+  const b=boxOf(view);
+  $("#elon0").placeholder=b[0].toFixed(2); $("#elon1").placeholder=b[1].toFixed(2);
+  $("#elat0").placeholder=b[2].toFixed(2); $("#elat1").placeholder=b[3].toFixed(2);
+  $("#exthint").textContent=`${b[0].toFixed(2)}, ${b[1].toFixed(2)}, `+
+                            `${b[2].toFixed(2)}, ${b[3].toFixed(2)}`;
+}
+function subtitle(){
+  $("#sub").textContent = `${M.cells.toLocaleString()} cells \\u00b7 `+
+    `${M.regional?"regional":"global"} \\u00b7 ${M.coverage}% of its sphere`;
+  $("#f_cells").textContent=M.cells.toLocaleString();
+  $("#f_edges").textContent=M.edges.toLocaleString();
+  $("#f_cov").textContent=M.coverage+"%";
+  const w=M.fields.find(f=>f.name==="cell_width_km");
+  if(w){ $("#f_wmin").textContent=w.vmin.toPrecision(4)+" km";
+         $("#f_wmax").textContent=w.vmax.toPrecision(4)+" km"; }
+}
+function fillFields(){
+  $("#fields").innerHTML="";
+  M.fields.forEach(f=>{
+    const d=document.createElement("div");
+    d.textContent=f.label; d.dataset.name=f.name; d.title=f.name;
+    d.onclick=()=>pick(f.name);
+    $("#fields").append(d);
+  });
+}
+function pick(name){
+  cur = M.fields.find(f=>f.name===name);
+  [...$("#fields").children].forEach(d=>d.classList.toggle("on",d.dataset.name===name));
+  overlay(); draw();
+}
+
+let redrawTimer=null;
+function schedule(ms){ preview(); scalebar(); graticule(); clearTimeout(redrawTimer);
+  redrawTimer=setTimeout(()=>{ overlay(); draw(); }, ms); }
+
+$("#applyext").onclick = ()=>{
+  const g=(id,d)=>{ const v=parseFloat($(id).value); return isFinite(v)?v:d; };
+  const b=boxOf(view);
+  const box=[g("#elon0",b[0]), g("#elon1",b[1]), g("#elat0",b[2]), g("#elat1",b[3])];
+  if(box[1]<=box[0]||box[3]<=box[2]){ say("extent must be min then max"); return; }
+  view=fit(box); clamp(); overlay(); draw(); panel();
+};
+$("#copyext").onclick = ()=>{
+  const b=boxOf(view).map(v=>v.toFixed(4));
+  navigator.clipboard?.writeText(b.join(", "));
+  say("extent copied");
+};
+$("#home").onclick = ()=>{ view={...home}; clamp(); schedule(0); };
+$("#zoom").oninput = e=>{ view.w = home.w/Math.pow(2, e.target.value/100);
+                          clamp(); schedule(180); };
+$("#wrap").onwheel = ev=>{
+  ev.preventDefault();
+  const r=$("#wrap").getBoundingClientRect();   // untransformed reference
+  const fx=(ev.clientX-r.left)/r.width, fy=(ev.clientY-r.top)/r.height;
+  const b=boxOf(view);
+  const lon=b[0]+fx*(b[1]-b[0]), lat=b[3]-fy*(b[3]-b[2]);
+  const k=Math.exp(ev.deltaY*0.0015);        // continuous, not stepped
+  const nw=Math.min(home.w, Math.max(home.w/Math.pow(2,ZMAX/100), view.w*k));
+  const s=nw/view.w;
+  view.clon = lon + (view.clon-lon)*s;       // keep the cursor point fixed
+  view.clat = lat + (view.clat-lat)*s;
+  view.w = nw;
+  clamp(); schedule(160);
+};
+let drag=null;
+$("#wrap").onpointerdown = ev=>{
+  drag={x:ev.clientX, y:ev.clientY, clon:view.clon, clat:view.clat, moved:false};
+  try{ $("#wrap").setPointerCapture(ev.pointerId); }catch(e){}   // may refuse
+  $("#wrap").classList.add("drag");
+};
+$("#wrap").onpointermove = ev=>{
+  if(!drag) return;
+  const r=$("#wrap").getBoundingClientRect(), b=boxOf(view);
+  const dx=(ev.clientX-drag.x)/r.width*(b[1]-b[0]);
+  const dy=(ev.clientY-drag.y)/r.height*(b[3]-b[2]);
+  if(Math.abs(ev.clientX-drag.x)+Math.abs(ev.clientY-drag.y)>3) drag.moved=true;
+  view.clon=drag.clon-dx; view.clat=drag.clat+dy;
+  clamp(); preview(); scalebar(); graticule();
+  if(!covers(rendered, boxOf(view))) schedule(90);   // ran past the margin
+};
+$("#wrap").onpointerup = ()=>{
+  const moved=drag&&drag.moved; drag=null;
+  $("#wrap").classList.remove("drag");
+  if(moved) schedule(0);
+};
+$("#grid").onchange = graticule;
+addEventListener("resize", ()=>{ layout(); scalebar(); graticule(); });
+
+async function boot(){
+  M = await (await fetch("/api/meta")).json();
+  $("#title").textContent = M.file;
+  home = fit(M.home); view = {...home}; rendered = null;
+  layout(); subtitle(); fillFields(); panel();
+  pick(M.fields[0].name);
+__SCRIPT__
+}
+boot();
+</script></body></html>
+"""
+
+
+def page(title: str = "gmpas prep", panel: str = "", script: str = "") -> str:
+    """The preprocessing page, with the step's own controls spliced in.
+
+    `panel` is HTML appended to the right-hand column; `script` is JS run at the
+    end of `boot()`, where `M` (the /api/meta payload) is already populated.
+    """
+    return (_PAGE.replace("__TITLE__", title)
+                 .replace("__PANEL__", panel)
+                 .replace("__SCRIPT__", script))

--- a/src/gmpas/prep/meshview.py
+++ b/src/gmpas/prep/meshview.py
@@ -1,0 +1,220 @@
+"""Browse a mesh file on its own, with no model output anywhere near it.
+
+`gmpas view` is built on a `Series`: it opens a run, finds the mesh alongside
+it, and every route it serves is about a variable at a timestep. That is the
+wrong shape for a mesh you have just generated and want to look at, which has
+no run and no timesteps at all.
+
+So this is the mesh-only half, and it starts from `MpasMesh.load()` -- the only
+thing that has to succeed. The fields it draws are derived from geometry that
+the mesh cache already holds, so nothing is computed twice:
+
+    cell_width_km   where the mesh refines (mesh.cell_width_km)
+    cell_area_km2   the same information as an area, for sizing work
+
+The scale for each is fixed once from the whole mesh rather than autoscaled per
+view, so a refinement band keeps its colour while you pan.
+
+`gmpas view` is untouched: the rendering plumbing here is imported from it --
+`ViewIndex`, the palette PNG encoder, the coastline overlay and `bind` -- and
+none of it is modified.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+
+from ..mesh import MpasMesh
+from ..viewer import ViewIndex, _overlay, _png, bind, ramp
+from .layout import page
+
+#: the one colormap this section uses. Sequential and perceptually uniform,
+#: which is what a width field wants; there is nothing here to diverge about.
+CMAP = "viridis"
+
+#: fields derivable from mesh geometry alone -- label, and how to get it. Both
+#: come off arrays the mesh cache already holds, so neither costs a rebuild.
+FIELDS = {
+    "cell_width_km": ("cell width (km)", lambda m: m.cell_width_km),
+    "cell_area_km2": ("cell area (km²)", lambda m: np.asarray(m.area_cell) / 1.0e6),
+}
+
+
+class MeshViewer:
+    """Everything the mesh-only routes need, built once at startup."""
+
+    def __init__(self, mesh_path, nx: int = 1200, ny: int = 700):
+        self.mesh = MpasMesh.load(mesh_path)
+        self.nx, self.ny = nx, ny
+        self.home = self.mesh.extent
+        self._views: dict[tuple, ViewIndex] = {}
+        self._overlays: dict[tuple, bytes] = {}
+        self._values: dict[str, np.ndarray] = {}
+        self._lock = threading.Lock()
+
+    # -- fields ----------------------------------------------------------
+
+    def values(self, field: str) -> np.ndarray:
+        """The cell array for one field, computed once and kept."""
+        if field not in FIELDS:
+            raise KeyError(f"unknown mesh field: {field}, "
+                           f"expected one of {', '.join(FIELDS)}")
+        if field not in self._values:
+            self._values[field] = np.asarray(FIELDS[field][1](self.mesh))
+        return self._values[field]
+
+    def describe(self) -> dict:
+        fields = []
+        for name, (label, _) in FIELDS.items():
+            v = self.values(name)
+            fields.append({
+                "name": name,
+                "label": label,
+                # fixed, whole-mesh limits: the front end has no vmin/vmax box
+                # because there is nothing view-dependent to tune
+                "vmin": float(np.nanmin(v)),
+                "vmax": float(np.nanmax(v)),
+            })
+        return {
+            "file": self.mesh.path.name,
+            "cells": int(self.mesh.n_cells),
+            "edges": int(self.mesh.n_edges),
+            "regional": not self.mesh.is_global,
+            "coverage": round(self.mesh.coverage * 100, 1),
+            "home": list(self.home),
+            "nx": self.nx,
+            "ny": self.ny,
+            "cmap": CMAP,
+            "ramp": ramp(CMAP),
+            "fields": fields,
+        }
+
+    # -- frames ----------------------------------------------------------
+
+    def view(self, extent, nx=None, ny=None) -> ViewIndex:
+        nx, ny = nx or self.nx, ny or self.ny
+        key = (*(round(float(v), 6) for v in extent), nx, ny)
+        with self._lock:
+            if key not in self._views:
+                self._views[key] = ViewIndex(self.mesh, extent, nx, ny)
+            return self._views[key]
+
+    def overlay(self, extent, nx=None, ny=None) -> bytes:
+        nx, ny = nx or self.nx, ny or self.ny
+        key = (*(round(float(v), 6) for v in extent), nx, ny)
+        with self._lock:
+            if key not in self._overlays:
+                self._overlays[key] = _overlay(extent, nx, ny)
+            return self._overlays[key]
+
+    def frame(self, field: str, extent, nx=None, ny=None,
+              compress: int = 1) -> tuple[bytes, float, float]:
+        v = self.values(field)
+        img = self.view(extent, nx, ny).frame(v)
+        lo, hi = float(np.nanmin(v)), float(np.nanmax(v))
+        return _png(img, CMAP, lo, hi, compress), lo, hi
+
+
+# ------------------------------------------------------------------ serving
+
+
+def _handler(viewer: MeshViewer, html: str):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):          # keep the console quiet
+            pass
+
+        def _send(self, body: bytes, ctype: str):
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            url = urlparse(self.path)
+            q = {k: v[0] for k, v in parse_qs(url.query).items()}
+            try:
+                if url.path == "/":
+                    return self._send(html.encode(), "text/html; charset=utf-8")
+                if url.path == "/api/meta":
+                    return self._send(json.dumps(viewer.describe()).encode(),
+                                      "application/json")
+                if url.path == "/api/frame":
+                    extent = [float(v) for v in q["extent"].split(",")]
+                    png, lo, hi = viewer.frame(
+                        q.get("field", "cell_width_km"), extent,
+                        int(q["nx"]) if q.get("nx") else None,
+                        int(q["ny"]) if q.get("ny") else None,
+                        int(q.get("compress", 1)),
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "image/png")
+                    self.send_header("X-Range", f"{lo},{hi}")
+                    self.send_header("Content-Length", str(len(png)))
+                    self.end_headers()
+                    return self.wfile.write(png)
+                if url.path == "/api/overlay":
+                    extent = [float(v) for v in q["extent"].split(",")]
+                    return self._send(viewer.overlay(
+                        extent,
+                        int(q["nx"]) if q.get("nx") else None,
+                        int(q["ny"]) if q.get("ny") else None), "image/png")
+            except Exception as exc:                      # surface, don't hang
+                body = json.dumps({"error": f"{type(exc).__name__}: {exc}"}).encode()
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                return self.wfile.write(body)
+            self.send_error(404)
+
+    return Handler
+
+
+def serve(mesh_path, port: int = 8765, nx: int = 1200, ny: int = 700,
+          open_browser: bool = True, host: str = "127.0.0.1",
+          strict_port: bool = False):
+    """Start the mesh viewer and block until interrupted.
+
+    Same tunnelling rules as `gmpas view`: loopback is right on a laptop and
+    wrong on a compute node, where an SSH tunnel lands on the login node.
+    """
+    viewer = MeshViewer(mesh_path, nx=nx, ny=ny)
+    server = bind(_handler(viewer, page(f"gmpas prep view · {viewer.mesh.path.name}")),
+                  port, host=host, strict=strict_port)
+    port = server.server_address[1]
+
+    width = viewer.values("cell_width_km")
+    kind = "regional" if not viewer.mesh.is_global else "global"
+    print(f"{viewer.mesh.n_cells:,} cells, {viewer.mesh.n_edges:,} edges, {kind} — "
+          f"cell width {width.min():.3g} to {width.max():.3g} km")
+
+    node = socket.gethostname()
+    if host in ("127.0.0.1", "localhost"):
+        print(f"listening on 127.0.0.1:{port} — this machine only")
+        print(f"  open  http://127.0.0.1:{port}")
+        print(f"  if {node} is a remote node, this is NOT reachable through a "
+              f"tunnel to a login node; restart with --host 0.0.0.0")
+    else:
+        print(f"listening on {host}:{port} — reachable as {node}:{port}")
+        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
+        print(f"  then open           http://localhost:{port}")
+    print("ctrl-c to stop")
+
+    if open_browser:
+        threading.Timer(0.5, webbrowser.open,
+                        args=(f"http://127.0.0.1:{port}",)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    finally:
+        server.server_close()

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1,0 +1,132 @@
+"""The preprocessing section: a mesh viewer that never touches a data file."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from gmpas.cli import build_parser
+from gmpas.prep import page
+from gmpas.prep.meshview import FIELDS, MeshViewer
+
+
+@pytest.fixture
+def viewer(simple_mesh_file):
+    return MeshViewer(simple_mesh_file, nx=64, ny=32)
+
+
+# -- the point of the whole thing: no data file anywhere ---------------------
+
+
+def test_a_mesh_alone_is_enough(viewer, simple_mesh):
+    """`gmpas view` needs a Series; this needs only the mesh."""
+    assert viewer.mesh.n_cells == simple_mesh.n_cells
+    assert viewer.home == simple_mesh.extent
+
+
+def test_meta_describes_the_mesh_and_offers_only_geometry_fields(viewer):
+    meta = viewer.describe()
+    assert meta["cells"] == 4
+    assert meta["regional"] is True
+    assert [f["name"] for f in meta["fields"]] == list(FIELDS)
+    # a fixed ramp is shipped, because the page has no colormap picker
+    assert len(meta["ramp"]) == 32
+    assert meta["ramp"][0].startswith("#")
+
+
+def test_meta_is_json_serialisable(viewer):
+    """It is handed straight to json.dumps by the handler."""
+    assert json.loads(json.dumps(viewer.describe()))["cells"] == 4
+
+
+def test_cell_width_matches_the_mesh(viewer, simple_mesh):
+    assert np.allclose(viewer.values("cell_width_km"), simple_mesh.cell_width_km)
+
+
+def test_area_field_is_in_square_km(viewer, simple_mesh):
+    assert np.allclose(viewer.values("cell_area_km2"),
+                       np.asarray(simple_mesh.area_cell) / 1e6)
+
+
+def test_an_unknown_field_says_what_it_offers(viewer):
+    with pytest.raises(KeyError, match="cell_width_km"):
+        viewer.values("theta")
+
+
+def test_values_are_computed_once(viewer):
+    assert viewer.values("cell_width_km") is viewer.values("cell_width_km")
+
+
+# -- the fixed scale ---------------------------------------------------------
+
+
+def test_the_scale_is_the_whole_mesh_not_the_view(viewer, simple_mesh):
+    """No vmin/vmax controls, so panning must not restretch the colours."""
+    width = simple_mesh.cell_width_km
+    whole = viewer.frame("cell_width_km", simple_mesh.extent)[1:]
+    # a corner of the domain, holding a subset of the cells
+    lon0, lon1, lat0, lat1 = simple_mesh.extent
+    corner = viewer.frame("cell_width_km",
+                          (lon0, (lon0 + lon1) / 2, lat0, (lat0 + lat1) / 2))[1:]
+    assert whole == corner == (pytest.approx(width.min()), pytest.approx(width.max()))
+
+
+# -- rendering ---------------------------------------------------------------
+
+
+def test_a_frame_is_a_png(viewer, simple_mesh):
+    png, lo, hi = viewer.frame("cell_width_km", simple_mesh.extent)
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"
+    assert lo <= hi
+
+
+def test_the_view_index_is_reused_across_frames(viewer, simple_mesh):
+    """The pixel-to-cell map depends on the box, not the field."""
+    viewer.frame("cell_width_km", simple_mesh.extent)
+    viewer.frame("cell_area_km2", simple_mesh.extent)
+    assert len(viewer._views) == 1
+
+
+# -- the layout --------------------------------------------------------------
+
+
+def test_the_page_drops_the_postprocessing_controls():
+    html = page("gmpas prep view")
+    for gone in ("#vmin", "#vmax", "id=\"cmap\"", "animate", "/api/export/",
+                 "/api/probe", "id=\"time\"", "id=\"level\""):
+        assert gone not in html
+    # but keeps what a preprocessing step needs
+    for kept in ("id=\"elon0\"", "applyext", "copyext", "id=\"grat\"",
+                 "id=\"scalebar\"", "/api/frame", "/api/overlay"):
+        assert kept in html
+
+
+def test_the_page_splices_in_a_step_panel():
+    html = page("t", panel="<div id='mine'>hi</div>", script="say('ready');")
+    assert "<div id='mine'>hi</div>" in html
+    assert "say('ready');" in html
+    assert "<title>t</title>" in html
+
+
+# -- the CLI -----------------------------------------------------------------
+
+
+def test_prep_view_parses(simple_mesh_file):
+    args = build_parser().parse_args(["prep", "view", str(simple_mesh_file)])
+    assert args.mesh_file == str(simple_mesh_file)
+    assert args.func.__name__ == "_prep_view"
+
+
+def test_bare_prep_prints_help_rather_than_failing(capsys):
+    args = build_parser().parse_args(["prep"])
+    assert args.func(args) == 0
+    assert "view" in capsys.readouterr().out
+
+
+def test_the_postprocessing_commands_are_untouched():
+    """Adding a section must not move the existing verbs."""
+    p = build_parser()
+    for argv in (["info", "x.nc"], ["plot", "x.nc", "t2m"], ["view", "x.nc"]):
+        assert p.parse_args(argv).func is not None


### PR DESCRIPTION
Everything gmpas did until now was postprocessing: open a run, then render, remap or export it. Building a mesh and looking at it happens before any of that exists, so it gets its own namespace rather than more top-level verbs.

    gmpas prep view <mesh.nc>

`view` could not do this. Viewer is built on a Series, and every route it serves is about a variable at a timestep -- so a mesh with no run has no mesh to reach. Threading a mesh-only mode through it would have meant changing those methods. prep/ instead starts from MpasMesh.load(), which is then the only thing that has to succeed, and imports the plumbing it needs -- ViewIndex, the palette PNG encoder, the coastline overlay, bind -- without modifying any of it. cli.py gains a subparser and loses nothing; view, plot, remap, scrip and target are unchanged.

The layout is the viewer's, reduced to what a preprocessing step actually uses. The timestep and level sliders, the colormap picker, the vmin/vmax boxes, the animation panel, the three exports and the probe all belong to a model run, so they are absent rather than hidden. Pan, zoom, graticule and scale bar stay, and so does the extent box: reading a domain off a mesh is how one will pick a region to cull to.

The colour scale is fixed per field from the whole mesh instead of autoscaling per view. With no vmin/vmax controls, autoscaling would make the same refinement band change colour while panning, which misreads a variable-resolution mesh badly. The legend stays, because the point is to read kilometres off the map.

Fields are geometry alone -- cell_width_km and cell_area_km2 -- both off arrays the mesh cache already holds, so neither costs a rebuild.

layout.page(title, panel=, script=) leaves slots for a step's own controls, so mesh generation (#15, gmpas prep generate) can reuse this shell rather than fork it.

Verified on an 8,228-cell regional mesh: all four routes answer, coastlines register against the raster, and refinement is visible. 192 tests pass.

Refs #16