### PR TITLE
ci: run the suite on every push, and prepare 0.2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,65 @@
+name: tests
+
+# Pull requests and pushes to main. Not tags: a tag points at a commit that
+# has already been tested here, so re-running proves nothing new.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # a second push to the same branch supersedes the first
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest · ubuntu · python 3.12
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}          # -l so the conda env is actually active
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # conda-forge, not pip: cartopy and netCDF4 are painful to build from
+      # source, and ESMF_RegridWeightGen is an executable pip cannot install at
+      # all. Installing the real environment.yml is what makes a green check
+      # here mean the same thing as a green run on a laptop.
+      - name: Install the conda environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: environment.yml
+          environment-name: gmpas
+          # environment.yml says `python >=3.10`, which would let the solver
+          # drift onto whatever is newest. Pin the version CI is meant to test.
+          create-args: python=3.12
+          cache-environment: true
+
+      - name: Install gmpas
+        # --no-deps: every dependency came from conda above. Letting pip
+        # resolve them again can shadow the conda build of a compiled package
+        # with a wheel, which is how a working environment silently breaks.
+        run: pip install -e . --no-deps
+
+      - name: Report what is actually installed
+        # a failure three steps down is much easier to read with this above it
+        run: |
+          python -c "import gmpas; print('gmpas', gmpas.__version__)"
+          python -c "import numpy, scipy, xarray, netCDF4, matplotlib, cartopy; print('numpy', numpy.__version__, 'scipy', scipy.__version__, 'xarray', xarray.__version__, 'netCDF4', netCDF4.__version__, 'matplotlib', matplotlib.__version__, 'cartopy', cartopy.__version__)"
+          which ESMF_RegridWeightGen ncremap || echo "remap tools NOT on PATH"
+
+      # No ruff step yet, deliberately. `ruff check src tests` currently reports
+      # 42 pre-existing violations (mostly E501 in the embedded viewer page), so
+      # gating on it would mean this workflow is red from its first run for
+      # reasons unrelated to whether the code works. Tracked separately; turn it
+      # on once the tree is clean.
+
+      - name: Run the test suite
+        # Agg: the runner is headless, and a rendering test that tries for a
+        # display fails in a way that looks nothing like the real problem
+        env:
+          MPLBACKEND: Agg
+        run: pytest -q --durations=10

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nmathewa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.1.1"
+version = "0.2.0"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -42,7 +42,8 @@ test = ["pytest>=7.0"]
 dev = ["gmpas[plot,test]", "ruff>=0.4"]
 
 [project.urls]
-Homepage = "https://github.com/nalex2023/gmpas"
+Homepage = "https://github.com/nmathewa/gmpas-lib"
+Issues = "https://github.com/nmathewa/gmpas-lib/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gmpas"]

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -28,7 +28,9 @@ from .plot import cell_field, edge_field, mesh_structure, vectors
 from .raster import RASTER_THRESHOLD, rasterize, should_raster, target_grid
 from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
-__version__ = "0.1.1"
+# kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
+# the built wheel disagreeing is the kind of thing only noticed after a release
+__version__ = "0.2.0"
 
 __all__ = [
     # entry points

--- a/src/gmpas/prep/layout.py
+++ b/src/gmpas/prep/layout.py
@@ -34,7 +34,8 @@ body{margin:0;font:13px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-ser
      background:var(--bg);color:var(--fg);display:flex;height:100vh;overflow:hidden}
 #side{width:250px;flex:none;background:var(--panel);border-right:1px solid var(--line);
       display:flex;flex-direction:column;overflow:hidden}
-#side h1{font-size:13px;font-weight:500;margin:0;padding:12px 14px;border-bottom:1px solid var(--line)}
+#side h1{font-size:13px;font-weight:500;margin:0;padding:12px 14px;
+         border-bottom:1px solid var(--line)}
 #side h1 small{display:block;color:var(--dim);font-weight:400;margin-top:2px}
 .sec{padding:10px 14px;border-bottom:1px solid var(--line);flex:none}
 .sec label{display:block;color:var(--dim);font-size:11px;letter-spacing:.04em;
@@ -111,7 +112,8 @@ button:hover{border-color:var(--accent)}
 </div>
 <div id="main">
   <div id="top">
-    <span>zoom</span><input type="range" id="zoom" min="0" max="800" value="0" style="width:140px">
+    <span>zoom</span>
+    <input type="range" id="zoom" min="0" max="800" value="0" style="width:140px">
     <label style="white-space:nowrap"><input type="checkbox" id="grid" checked
       style="vertical-align:-1px"> grid</label>
     <button id="home">reset view</button>
@@ -138,9 +140,15 @@ button:hover{border-color:var(--accent)}
 <div id="right">
   <h1>options</h1>
   <div class="sec"><label>extent</label>
-    <div class="row"><input type="text" id="elon0" placeholder="lon min"><input type="text" id="elon1" placeholder="lon max"></div>
-    <div class="row" style="margin-top:6px"><input type="text" id="elat0" placeholder="lat min"><input type="text" id="elat1" placeholder="lat max"></div>
-    <div class="row" style="margin-top:6px"><button id="applyext">apply</button><button id="copyext">copy</button></div>
+    <div class="row">
+      <input type="text" id="elon0" placeholder="lon min">
+      <input type="text" id="elon1" placeholder="lon max"></div>
+    <div class="row" style="margin-top:6px">
+      <input type="text" id="elat0" placeholder="lat min">
+      <input type="text" id="elat1" placeholder="lat max"></div>
+    <div class="row" style="margin-top:6px">
+      <button id="applyext">apply</button>
+      <button id="copyext">copy</button></div>
     <div class="hint" id="exthint"></div>
   </div>
 __PANEL__

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,36 @@
+"""The version is written in two places; they must not drift apart.
+
+`gmpas --version` reads `gmpas.__version__`, while the wheel and the sdist take
+theirs from `pyproject.toml`. Nothing links the two, so a release can ship a
+package whose own CLI reports the previous version -- which is only ever
+noticed afterwards.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import gmpas
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _declared_version() -> str:
+    try:
+        import tomllib
+    except ModuleNotFoundError:                      # py3.10
+        pytest.skip("tomllib needs Python 3.11+")
+    return tomllib.loads(PYPROJECT.read_text())["project"]["version"]
+
+
+@pytest.mark.skipif(not PYPROJECT.exists(),
+                    reason="installed without the source tree")
+def test_the_two_version_strings_agree():
+    assert gmpas.__version__ == _declared_version()
+
+
+def test_the_version_is_a_release_number():
+    assert re.fullmatch(r"\d+\.\d+\.\d+", gmpas.__version__), gmpas.__version__


### PR DESCRIPTION
Sets up GitHub Actions and the groundwork for the first release.

## CI

`.github/workflows/tests.yml` — pull requests, pushes to `main`, and manual dispatch. Ubuntu, Python 3.12.

The environment comes from `environment.yml` via micromamba rather than pip: cartopy and netCDF4 are painful to build from source, and `ESMF_RegridWeightGen` is an executable pip cannot install at all — a pip job would silently skip the remapping tests and show a green check that means less than it looks like.

**No ruff step yet, deliberately.** `ruff check src tests` currently reports 42 pre-existing violations (mostly E501 in the embedded viewer page), so gating on it would make this workflow red from its first run for reasons unrelated to whether the code works. The 5 violations this branch would have added are fixed. Tracked separately.

## Release prep

- **Version 0.1.1 → 0.2.0.** `main` is 17 commits past the `v0.1.1` tag and has gained the whole `prep` section plus the remap CLI.
- **`tests/test_version.py`** — the version was written in both `pyproject.toml` and `__init__.py` with nothing keeping them in step, so `gmpas --version` could disagree with the wheel. Now asserted.
- **`LICENSE`** — pyproject has declared MIT since the beginning with no file to back it. ⚠️ The copyright line reads `Copyright (c) 2026 nmathewa`; change it if you want your legal name there.
- **`[project.urls] Homepage`** pointed at `github.com/nalex2023/gmpas`, which is not this repository.

## Verification

194 tests pass locally (192 + 2 new). Workflow YAML parses. The conda solve itself is unproven until this runs on the runner — that is what the first CI run will tell us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)