### PR TITLE
mesh: never write the cache through a writable mmap

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import faulthandler
+import io
 import sys
 import time
 from pathlib import Path
@@ -657,6 +659,18 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv=None) -> int:
+    # A fatal signal is not an exception and cannot be caught below: SIGBUS
+    # from a memory-mapped page the filesystem could not supply kills the
+    # process where it stands, and all the user sees is `Bus error`. This
+    # installs a C-level handler that prints the Python traceback first, so
+    # such a death at least says which line and which array (issue #19).
+    # It writes to a real file descriptor, which a captured or wrapped stderr
+    # does not have -- and a missing crash dump is not worth failing over.
+    try:
+        faulthandler.enable()
+    except (AttributeError, ValueError, io.UnsupportedOperation):
+        pass
+
     # Python block-buffers stdout when it is not a terminal, so under a job
     # scheduler or through a pipe none of the progress appears until the run
     # ends -- which looks exactly like a command producing no output at all.
@@ -673,11 +687,12 @@ def main(argv=None) -> int:
         parser.print_help()
         return 0
 
+    from .mesh import MeshCacheError
     from .remap import RemapError
 
     try:
         return args.func(args)
-    except RemapError as exc:
+    except (RemapError, MeshCacheError) as exc:
         print(f"\ngmpas: {exc}", file=sys.stderr)
         return 1
     except (FileNotFoundError, KeyError, ValueError) as exc:

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -46,6 +48,14 @@ CACHED_ARRAYS = ("lon_cell", "lat_cell", "cell_verts", "cell_wrapped",
 
 #: fraction of its sphere a mesh must cover before it counts as global
 GLOBAL_COVERAGE = 0.9
+
+#: headroom demanded on top of the computed cache size, so the build does not
+#: start against a filesystem it will fill exactly
+SPACE_MARGIN = 64 * 1024 * 1024
+
+
+class MeshCacheError(OSError):
+    """The mesh cache could not be written -- almost always out of room."""
 
 
 def has_mesh(ds: xr.Dataset) -> bool:
@@ -345,8 +355,131 @@ class _Bounds:
         return (lo, hi, self.lat[0], self.lat[1])
 
 
-def _open_memmap(path: Path, dtype, shape):
-    return np.lib.format.open_memmap(path, mode="w+", dtype=dtype, shape=shape)
+class _NpyWriter:
+    """Stream one `.npy` out chunk by chunk, through ordinary writes.
+
+    Deliberately not `open_memmap(mode="w+")`. A writable mapping creates the
+    file at its full size but *sparse*, so nothing is reserved: the assignment
+    into the mapping always appears to succeed and the allocation failure lands
+    later, in page writeback, where there is no caller left to return it to.
+
+    Measured on a 120 MB volume, writing a 356 MB array through such a mapping:
+    every write returned cleanly, `flush()` returned cleanly, and after
+    unmounting and remounting two thirds of the array read back as zeros. On
+    Linux the same overcommit arrives instead as SIGBUS, which kills the
+    process outright with no traceback -- the symptom in issue #19.
+
+    An ordinary buffered write has neither failure mode: it returns ENOSPC (or
+    EDQUOT, over a quota) as an `OSError` the build can clean up after and the
+    user can read. The chunking is unchanged, so peak memory is the same.
+    """
+
+    def __init__(self, path: Path, dtype, shape: tuple[int, ...]):
+        self.path = Path(path)
+        self.dtype = np.dtype(dtype)
+        self.shape = tuple(int(n) for n in shape)
+        self._rows = 0
+        self._fp = open(self.path, "wb")
+        np.lib.format.write_array_header_1_0(self._fp, {
+            "descr": np.lib.format.dtype_to_descr(self.dtype),
+            "fortran_order": False,
+            "shape": self.shape,
+        })
+
+    def append(self, block: np.ndarray) -> None:
+        block = np.ascontiguousarray(block, dtype=self.dtype)
+        with _writing(self.path):
+            block.tofile(self._fp)
+        self._rows += block.shape[0]
+
+    def close(self) -> None:
+        if self._rows != self.shape[0]:
+            raise MeshCacheError(
+                f"{self.path.name}: wrote {self._rows} rows of {self.shape[0]}"
+            )
+        # fsync so a deferred allocation failure is raised here, as an error
+        # about this file, rather than surfacing as a corrupt read much later
+        with _writing(self.path):
+            self._fp.flush()
+            os.fsync(self._fp.fileno())
+        self._fp.close()
+
+
+@contextmanager
+def _writing(path: Path):
+    """Say which cached array failed, and that running out of room is why.
+
+    numpy reports a short write as `1000000 requested and 0 written`, which
+    names neither the file nor the cause. Out of room is overwhelmingly the
+    reason a cache write fails, and the user can act on that sentence.
+    """
+    try:
+        yield
+    except OSError as exc:
+        raise MeshCacheError(
+            f"failed writing {path.name} to the mesh cache: {exc}\n"
+            f"  Most likely {path.parent.parent} is full or over quota. "
+            f"Free some space, or set GMPAS_CACHE_DIR to somewhere larger."
+        ) from exc
+
+
+def _save(path: Path, arr: np.ndarray) -> None:
+    """`np.save` that has actually reached the disk when it returns."""
+    with _writing(path), open(path, "wb") as fp:
+        np.lib.format.write_array(fp, np.ascontiguousarray(arr))
+        fp.flush()
+        os.fsync(fp.fileno())
+
+
+def _cache_bytes(nc) -> int:
+    """Size of the finished cache, from the netCDF header alone -- no reads.
+
+    Every cached array is a fixed multiple of nCells or nEdges, so this is
+    exact rather than an estimate, and it costs nothing to compute before
+    deciding whether the build can succeed at all.
+    """
+    n_cells = len(nc.dimensions["nCells"])
+    n_edges = len(nc.dimensions["nEdges"])
+    max_edges = len(nc.dimensions["maxEdges"])
+    v = nc.variables
+
+    def width(name: str) -> int:
+        return v[name].dtype.itemsize
+
+    return (
+        n_cells * max_edges * 2 * width("lonVertex")     # cell_verts
+        + n_edges * 2 * 2 * width("lonVertex")           # edge_segs
+        + n_cells + n_edges                              # the two bool arrays
+        + n_cells * 3 * width("xCell")                   # xyz_cell
+        + n_cells * width("areaCell")                    # area_cell
+        + n_cells * 2 * width("lonCell")                 # lon_cell, lat_cell
+        + n_edges * 2 * width("lonEdge")                 # lon_edge, lat_edge
+        + n_edges * width("angleEdge")                   # angle_edge
+    )
+
+
+def _size(n: float) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} GB"
+
+
+def _check_space(where: Path, need: int, mesh: Path) -> None:
+    """Refuse to start a build that cannot fit, and say so in bytes."""
+    free = shutil.disk_usage(where).free
+    if free >= need + SPACE_MARGIN:
+        return
+
+    raise MeshCacheError(
+        f"not enough room to cache {mesh.name}: its geometry needs "
+        f"{_size(need)} and {where} has {_size(free)} free.\n"
+        f"  Free some space, or send the cache somewhere larger with "
+        f"GMPAS_CACHE_DIR=/path/with/room\n"
+        f"  (this reads free space, not your quota -- on a shared filesystem "
+        f"a quota can bind well before the disk does)."
+    )
 
 
 def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
@@ -360,7 +493,9 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
     impossible to cache rather than merely slow.
 
     Writes to a temporary directory and renames, so an interrupted build never
-    leaves a half-written cache that looks complete.
+    leaves a half-written cache that looks complete -- and removes that
+    directory if it fails, so a build that ran out of room does not leave its
+    partial output behind to make the next attempt worse.
     """
     import netCDF4
 
@@ -379,6 +514,8 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
                 f"{missing}). Pass the mesh/init/static file instead."
             )
 
+        _check_space(cache.parent, _cache_bytes(nc), path)
+
         lon_v = _wrap180(nc.variables["lonVertex"][:] * R2D)
         lat_v = nc.variables["latVertex"][:] * R2D
         dt = lon_v.dtype
@@ -389,8 +526,8 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
 
         bounds = _Bounds()
 
-        verts = _open_memmap(tmp / "cell_verts.npy", dt, (n_cells, max_edges, 2))
-        cw = _open_memmap(tmp / "cell_wrapped.npy", bool, (n_cells,))
+        verts = _NpyWriter(tmp / "cell_verts.npy", dt, (n_cells, max_edges, 2))
+        cw = _NpyWriter(tmp / "cell_wrapped.npy", bool, (n_cells,))
         voc_var, ne_var = nc.variables["verticesOnCell"], nc.variables["nEdgesOnCell"]
         for i in range(0, n_cells, chunk):
             j = min(i + chunk, n_cells)
@@ -405,13 +542,13 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             block[..., 1] = lat_v[voc]
             block, wrapped = _unwrap_polygons(block)
 
-            verts[i:j] = block
-            cw[i:j] = wrapped
+            verts.append(block)
+            cw.append(wrapped)
             bounds.update(block)
-        verts.flush(); cw.flush(); del verts, cw
+        verts.close(); cw.close()
 
-        segs = _open_memmap(tmp / "edge_segs.npy", dt, (n_edges, 2, 2))
-        ew = _open_memmap(tmp / "edge_wrapped.npy", bool, (n_edges,))
+        segs = _NpyWriter(tmp / "edge_segs.npy", dt, (n_edges, 2, 2))
+        ew = _NpyWriter(tmp / "edge_wrapped.npy", bool, (n_edges,))
         voe_var = nc.variables["verticesOnEdge"]
         for i in range(0, n_edges, chunk):
             j = min(i + chunk, n_edges)
@@ -420,9 +557,9 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             block[..., 0] = lon_v[voe]
             block[..., 1] = lat_v[voe]
             block, wrapped = _unwrap_polygons(block)
-            segs[i:j] = block
-            ew[i:j] = wrapped
-        segs.flush(); ew.flush(); del segs, ew
+            segs.append(block)
+            ew.append(wrapped)
+        segs.close(); ew.close()
 
         xyz = np.stack([nc.variables["xCell"][:], nc.variables["yCell"][:],
                         nc.variables["zCell"][:]], axis=-1)
@@ -434,13 +571,13 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             radius = EARTH_RADIUS
             area = area * EARTH_RADIUS**2
 
-        np.save(tmp / "xyz_cell.npy", xyz)
-        np.save(tmp / "area_cell.npy", area)
-        np.save(tmp / "lon_cell.npy", _wrap180(nc.variables["lonCell"][:] * R2D))
-        np.save(tmp / "lat_cell.npy", nc.variables["latCell"][:] * R2D)
-        np.save(tmp / "lon_edge.npy", _wrap180(nc.variables["lonEdge"][:] * R2D))
-        np.save(tmp / "lat_edge.npy", nc.variables["latEdge"][:] * R2D)
-        np.save(tmp / "angle_edge.npy", nc.variables["angleEdge"][:])
+        _save(tmp / "xyz_cell.npy", xyz)
+        _save(tmp / "area_cell.npy", area)
+        _save(tmp / "lon_cell.npy", _wrap180(nc.variables["lonCell"][:] * R2D))
+        _save(tmp / "lat_cell.npy", nc.variables["latCell"][:] * R2D)
+        _save(tmp / "lon_edge.npy", _wrap180(nc.variables["lonEdge"][:] * R2D))
+        _save(tmp / "lat_edge.npy", nc.variables["latEdge"][:] * R2D)
+        _save(tmp / "angle_edge.npy", nc.variables["angleEdge"][:])
 
         coverage = float(area.sum() / (4.0 * np.pi * radius**2))
         extent = ((-180.0, 180.0, -90.0, 90.0) if coverage >= GLOBAL_COVERAGE
@@ -453,6 +590,11 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             "n_edges": n_edges,
             "cache_version": CACHE_VERSION,
         }, indent=2))
+    except BaseException:
+        # a build that died because the filesystem was full must not leave its
+        # partial output sitting on that filesystem
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
     finally:
         nc.close()
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -351,10 +351,12 @@ def test_an_interrupted_build_leaves_no_usable_cache(tmp_path):
     # .undo() on that would also revert the autouse GMPAS_CACHE_DIR
     # isolation and write the retry into the real user cache
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(mesh_mod, "_open_memmap", explode)
+        mp.setattr(mesh_mod, "_NpyWriter", explode)
         with pytest.raises(RuntimeError):
             MpasMesh.load(path)
         assert not (cache / "meta.json").exists()
+        # and nothing partial left behind on a filesystem that may be full
+        assert not cache.with_name(cache.name + ".partial").exists()
 
     assert MpasMesh.load(path).n_cells == 2      # recovers on the next try
     assert cache.is_relative_to(tmp_path)        # and stayed inside the sandbox
@@ -453,3 +455,88 @@ def test_reconstruction_is_zero_for_zero_flow(simple_mesh):
                                                np.zeros(simple_mesh.n_edges))
     assert zonal == pytest.approx(0.0)
     assert meridional == pytest.approx(0.0)
+
+
+# --------------------------------------------------------- running out of room
+
+
+def test_cache_files_are_not_sparse(tmp_path):
+    """The cache must occupy the blocks it claims, not promise them.
+
+    `open_memmap(mode="w+")` reserves nothing: the file is created at full size
+    and sparse, the writes into the mapping report success whatever the
+    filesystem can actually take, and the allocation failure lands later in
+    page writeback -- as SIGBUS on Linux, and as silently zeroed data on macOS.
+    Asking that the blocks are really allocated is what pins the write path to
+    ordinary writes, which fail loudly and in the caller's own frame.
+    """
+    import os
+
+    path = write_mesh(tmp_path / "solid.nc", [(float(i), 0.0) for i in range(200)])
+    MpasMesh.load(path)
+
+    cache = cache_path(path)
+    for name in ("cell_verts.npy", "edge_segs.npy"):
+        f = cache / name
+        allocated = os.stat(f).st_blocks * 512
+        assert allocated >= os.path.getsize(f) * 0.9, f"{name} is sparse"
+
+
+def test_a_build_that_cannot_fit_says_so_before_it_starts(tmp_path, monkeypatch):
+    """Better a sentence about free space than a build that dies mid-way."""
+    from gmpas import mesh as mesh_mod
+
+    path = write_mesh(tmp_path / "toobig.nc", [(0.0, 0.0), (10.0, 0.0)])
+
+    Usage = type("Usage", (), {"free": 1024})           # 1 KB free
+    monkeypatch.setattr(mesh_mod.shutil, "disk_usage", lambda p: Usage())
+
+    with pytest.raises(mesh_mod.MeshCacheError) as exc:
+        MpasMesh.load(path)
+
+    msg = str(exc.value)
+    assert "toobig.nc" in msg                            # which mesh
+    assert "GMPAS_CACHE_DIR" in msg                      # and what to do
+    assert "quota" in msg                                # and the trap it hides
+
+
+def test_predicted_cache_size_matches_what_is_written(tmp_path):
+    """The preflight is only worth having if its number is the real one."""
+    import netCDF4
+
+    from gmpas.mesh import _cache_bytes
+
+    path = write_mesh(tmp_path / "sized.nc",
+                      [(float(i), 0.0) for i in range(500)])
+    with netCDF4.Dataset(path) as nc:
+        predicted = _cache_bytes(nc)
+
+    cache = cache_path(MpasMesh.load(path).path)
+    written = sum(f.stat().st_size for f in cache.glob("*.npy"))
+
+    # headers are the only difference: 11 arrays, 128 bytes of header at most
+    assert predicted <= written <= predicted + 11 * 128
+
+
+def test_streaming_writer_refuses_a_short_array(tmp_path):
+    """A file with fewer rows than its header claims would map as garbage."""
+    from gmpas.mesh import MeshCacheError, _NpyWriter
+
+    w = _NpyWriter(tmp_path / "short.npy", np.float64, (10, 2))
+    w.append(np.zeros((4, 2)))
+    with pytest.raises(MeshCacheError, match="4 rows of 10"):
+        w.close()
+
+
+def test_streamed_cache_round_trips_exactly(tmp_path):
+    """Switching off the writable mapping must not change a single byte."""
+    path = write_mesh(tmp_path / "exact.nc",
+                      [(float(i), float(i % 30) - 15.0) for i in range(400)],
+                      n_verts=[4 + (i % 3) for i in range(400)])
+
+    built = MpasMesh.load(path, use_cache=False)
+    cached = MpasMesh.load(path)
+
+    for field in ("cell_verts", "cell_wrapped", "edge_segs", "edge_wrapped"):
+        assert np.array_equal(np.asarray(getattr(cached, field)),
+                              getattr(built, field), equal_nan=False)


### PR DESCRIPTION
Fixes #19.

## What the bug is

`_build_to_dir` wrote `cell_verts` and `edge_segs` through
`np.lib.format.open_memmap(mode="w+")`. That creates the `.npy` at its full
size but **sparse** — nothing is reserved. The assignment into the mapping and
the later `flush()` both report success whatever the filesystem can actually
take, and the allocation failure lands in page writeback, where there is no
caller left to return it to.

Measured on a 120 MB volume, writing a 356 MB array through such a mapping:

| | |
|---|---|
| `open_memmap` | succeeded |
| apparent size | 356 MB |
| blocks actually allocated | **20 KiB** |
| every write into the mapping | no error |
| `flush()` | no error |
| after unmount + remount | **31,393,296 of 46,695,936 elements read back as zeros** |

macOS loses the data silently. Linux delivers the same overcommit as **SIGBUS**,
killing the process with no traceback — the symptom in #19.

This also explains the two things that looked odd in that report. It is
size-dependent because a small mesh fits and a large one does not. And 345 GiB
free is entirely consistent with it: `statvfs` reports the filesystem's free
space, not the user's remaining quota, and `Bus error (core dumped)` is
glibc/bash wording rather than macOS zsh — so the crash was on a Linux node,
where `~/.cache` is usually quota-bound.

## What the bug is not

Both were open candidates in the issue; both are now closed off.

- **Not cell count.** A synthetic 5M-cell / 35M-edge mesh builds its 2.6 GB
  cache and renders a first frame in 7.6 s end to end, on this hardware.
- **Not an out-of-bounds read into a mapping.** Every indexed read in the build
  is numpy fancy indexing, which bounds-checks and raises `IndexError`. It
  cannot reach a mapping out of range.

## The change

- **`_NpyWriter`** replaces the writable mapping: `.npy` header, then each
  chunk out through an ordinary buffered write. Those return ENOSPC — or
  EDQUOT, over a quota — as an `OSError` the build can clean up after and the
  user can read. Same chunking, so peak memory is unchanged.
- **`_cache_bytes`** sizes the finished cache from the netCDF header alone (no
  reads, and exact rather than an estimate), so a build that cannot fit says so
  before it starts, in bytes, naming the mesh and `GMPAS_CACHE_DIR`.
- **A failed write names the array** and what is most likely wrong, instead of
  numpy's bare `1000000 requested and 0 written`.
- **The `.partial` directory is removed on failure**, so a build that ran out of
  room does not leave its output behind on the filesystem that is already full.
- **`faulthandler.enable()`** in `main()`, guarded — any fatal signal that still
  gets through now prints a Python traceback rather than nothing. The issue is
  right that a silent death is a defect on its own, whatever the cause.

The read path still maps the cache with `mmap_mode="r"`. Mapping a complete
file read-only was never the problem, and that is what keeps a large mesh
openable.

## Verification

- All 11 cached arrays are **byte-identical** to the previous build on the
  5M-cell mesh, compared file by file. Build time went from 4.59 s to 4.12 s.
- Suite is 199 passed. Five new tests, of which the load-bearing one asserts the
  cached files are **not sparse** (`st_blocks * 512` against the apparent size) —
  that is what stops the writable mapping coming back.
- The preflight, the wrapped write error and the `.partial` cleanup were each
  exercised against a real 120 MB volume, not only against mocks.

## Still open

`Maritime.grid.nc` is not on this machine, so this fixes a demonstrated defect
that matches the report in every detail, but does not *prove* it was that
crash. The issue's third candidate — something specific to a JIGSAW-stage
`.grid.nc` rather than to size — is untested for the same reason. `ncdump -h`
and the cell count would close it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
