### PR TITLE
prep: browse a JIGSAW distance function before any mesh exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ gmpas view       /path/to/run/
 gmpas scrip      history.2012-02-25_12.00.00.nc -o src.scrip.nc
 gmpas target     -o dst.scrip.nc
 gmpas prep view  mesh.nc
+gmpas prep hfun  hfun.py
 ```
 
 `info` summarises the mesh and lists variables grouped by the element they
@@ -286,11 +287,60 @@ extent box stay — the last because reading a domain off a mesh is how one
 picks a region.
 
 `prep.layout.page(title, panel=..., script=...)` is that layout as a reusable
-shell, with slots for a step's own controls. Mesh generation with JIGSAW is
-meant to be the second user
+shell, with slots for a step's own controls. The sidebar's facts block is
+data-driven — a step sends `subtitle` and `stats`, so one with no cells or
+edges reuses the shell rather than forking it. `prep hfun` is the second user;
+mesh generation is meant to be the third
 ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)); like the
 remapping tools, JIGSAW would be an external executable gmpas shells out to,
 not a Python dependency.
+
+### Looking at a mesh before it exists
+
+```bash
+gmpas prep hfun hfun.py            # browse it
+gmpas prep hfun hfun.py --check    # just the numbers, no server
+```
+
+In the JIGSAW workflow for MPAS-Atmosphere, a variable-resolution mesh is
+defined entirely by a small Python file. `create_hfun.py` samples it onto a
+lat-lon grid to write `HFUN.msh`, JIGSAW turns that into generating points, and
+`mkgrid` turns those into `grid.nc`. Every design decision lives in that one
+file, so this reads it on its own — no JIGSAW, no mesh, no generation time:
+
+```
+hfun.py: hfun_min 12 km, grid distance 12 to 60 km
+max cell size gradient 0.0300 at 75.64, -95.05 (within the 0.03 guideline)
+measured on the 3336 x 1668 lat-lon grid create_hfun.py would write (12 km spacing)
+```
+
+The contract is the mini-tutorial's: a module-level `hfun_min` in km, and
+`get_hfun(lon, lat)` taking **radians** and returning **km**. That function is
+called once with whole arrays and may do expensive setup — a real one might
+interpolate a raster — so it is called once per view here, never per pixel.
+
+**The gradient is the number worth having.** The tutorial's guidance is to keep
+cell size changing by no more than a few percent per km of distance, with 0.03
+generally safe, and `mesh_quality.py` reports exactly that from a finished
+`grid.nc`:
+
+```python
+nominalDx = r_earth * nominalMinDc * (1.0 / meshDensity) ** 0.25
+gradient  = abs(nominalDx[c0] - nominalDx[c1]) / dcEdge / r_earth
+```
+
+Since `meshDensity` is `(hfun_min / h) ** 4` and `nominalMinDc` is `hfun_min`,
+that is the change in grid distance between neighbouring cells over the
+distance between them. Its continuous limit is `|grad h|` with respect to arc
+length, which is what is computed here — on the same lat-lon grid
+`create_hfun.py` would write, so the number is comparable both to the 0.03
+guideline and to what `mesh_quality.py` will say once the mesh exists. The two
+polar rows are excluded: every longitude at a pole is the same point, so the
+zonal derivative there is 0/0 rather than a gradient.
+
+Two fields are offered, neither invented here: `cell_width_km` is `get_hfun`
+straight out, and `mesh_density` is `(hfun_min / h) ** 4` — MPAS's own
+`meshDensity`, 1.0 where the mesh is finest.
 
 Nothing in `prep/` modifies the postprocessing path. It imports the viewer's
 rasterizing, PNG encoding, coastline overlay and port binding, and changes
@@ -478,9 +528,10 @@ KD-tree gives area weights by supersampling a target cell and counting which
 source cells the samples land in, which — unlike barycentric sampling —
 actually conserves cell integrals.
 
-Preprocessing has begun: `gmpas prep view` is implemented, `gmpas prep
-generate` — building a mesh with JIGSAW — is not
+Preprocessing has begun: `gmpas prep view` and `gmpas prep hfun` are
+implemented — the two ends of looking at a mesh, one after it exists and one
+before. `gmpas prep generate` — actually running JIGSAW — is not
 ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)). That one is
 blocked on a question rather than on effort: JIGSAW writes its own `.msh`
 format, and converting it to a mesh `MpasMesh.load()` can open conventionally
-needs a second external tool from MPAS-Tools.
+needs `mkgrid`, which wants MPI and PnetCDF.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     # entry points

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -535,6 +535,21 @@ def _prep_view(args) -> int:
     return 0
 
 
+def _prep_hfun(args) -> int:
+    from .prep.hfunview import HfunViewer, report, serve
+
+    # --check is the whole point on a login node or in a script: the numbers
+    # without a server, so a bad transition is caught before JIGSAW runs
+    if args.check:
+        print(report(HfunViewer(args.hfun_file)))
+        return 0
+
+    serve(args.hfun_file, port=args.port, host=args.host,
+          nx=args.width, ny=args.height, open_browser=not args.no_browser,
+          strict_port=args.port != DEFAULT_PORT)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gmpas",
@@ -636,7 +651,7 @@ def build_parser() -> argparse.ArgumentParser:
     pre = sub.add_parser("prep", help="preprocessing: inspect and build meshes",
                          description="Preprocessing steps, which run before "
                                      "there is any model output to plot.")
-    presub = pre.add_subparsers(dest="prep_cmd", metavar="{view}")
+    presub = pre.add_subparsers(dest="prep_cmd", metavar="{view,hfun}")
     # a bare `gmpas prep` should list its steps, not error
     pre.set_defaults(func=lambda _a, _p=pre: (_p.print_help(), 0)[1])
 
@@ -655,6 +670,28 @@ def build_parser() -> argparse.ArgumentParser:
     pv.add_argument("--no-browser", action="store_true",
                     help="do not open a browser (useful over an SSH tunnel)")
     pv.set_defaults(func=_prep_view)
+
+    ph = presub.add_parser("hfun", help="browse a JIGSAW distance function "
+                                        "before any mesh exists")
+    ph.add_argument("hfun_file", metavar="HFUN",
+                    help="a JIGSAW hfun.py defining hfun_min and "
+                         "get_hfun(lon, lat); a directory is read as its "
+                         "hfun.py")
+    ph.add_argument("--check", action="store_true",
+                    help="print the resolution report and exit, without "
+                         "serving anything")
+    ph.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+                    help=f"port (default {DEFAULT_PORT}; the default wanders "
+                         f"if busy, an explicit one fails instead)")
+    ph.add_argument("--host", default="127.0.0.1",
+                    help="interface to bind. Use 0.0.0.0 on an HPC compute "
+                         "node so a tunnel from the login node can reach it")
+    ph.add_argument("--width", type=int, default=1200,
+                    help="raster width in pixels")
+    ph.add_argument("--height", type=int, default=700)
+    ph.add_argument("--no-browser", action="store_true",
+                    help="do not open a browser (useful over an SSH tunnel)")
+    ph.set_defaults(func=_prep_hfun)
     return p
 
 

--- a/src/gmpas/prep/__init__.py
+++ b/src/gmpas/prep/__init__.py
@@ -17,7 +17,10 @@ second.
 
 from __future__ import annotations
 
+from .hfun import Hfun, HfunError, diagnose
+from .hfunview import HfunViewer
 from .layout import page
 from .meshview import MeshViewer, serve
 
-__all__ = ["MeshViewer", "page", "serve"]
+__all__ = ["Hfun", "HfunError", "HfunViewer", "MeshViewer", "diagnose",
+           "page", "serve"]

--- a/src/gmpas/prep/hfun.py
+++ b/src/gmpas/prep/hfun.py
@@ -1,0 +1,269 @@
+"""A JIGSAW mesh distance function, before any mesh exists.
+
+In the JIGSAW workflow for MPAS-Atmosphere, a variable-resolution mesh is
+defined entirely by a small Python file, `hfun.py`, which says how large a cell
+should be at every point on the sphere. Everything after it is mechanical:
+`create_hfun.py` samples it onto a lat-lon grid and writes `HFUN.msh`, JIGSAW
+turns that into generating points, and `mkgrid` turns those into `grid.nc`.
+
+So the design decisions all live in that one file, and until now the only way
+to see what they produced was to run the whole chain and look at the finished
+mesh. This module reads `hfun.py` on its own, which is enough to draw the
+resolution and to check the guidelines it has to satisfy.
+
+The contract, from the mini-tutorial (Duda, MPAS/WRF Users Workshop 2026):
+
+    hfun_min            module-level float, the minimum grid distance in km
+    get_hfun(lon, lat)  lon/lat in RADIANS, returns grid distance in KM
+
+with one property that shapes everything here -- `get_hfun` is called *once*,
+with whole arrays, and so is allowed to do expensive setup. A real one may
+interpolate a raster dataset. Nothing in this module may call it per pixel.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from ..paths import resolve_path
+
+#: MPAS-Atmosphere's assumed Earth radius (km), as the tutorial scripts use it
+R_EARTH_KM = 6371.229
+
+#: km per degree of great circle, the constant `create_hfun.py` derives
+DEG_TO_KM = 2.0 * np.pi * R_EARTH_KM / 360.0
+
+#: "Limit gradients (km of cell size) / (km of distance) to a few percent!
+#: Experience suggests a value of 0.03 is generally safe."
+GRADIENT_GUIDELINE = 0.03
+
+#: cap on the analysis grid, so a very fine `hfun_min` cannot ask for an array
+#: that does not fit in memory. Only bites below hfun_min ~ 6 km.
+MAX_ANALYSIS_POINTS = 20_000_000
+
+
+class HfunError(ValueError):
+    """An `hfun.py` that does not meet the contract."""
+
+
+@dataclass
+class Hfun:
+    """A loaded `hfun.py`, validated far enough to be worth drawing."""
+
+    path: Path
+    hfun_min: float
+    _get_hfun: object
+
+    @classmethod
+    def load(cls, path: str | Path) -> "Hfun":
+        p = resolve_path(path)
+        if p.is_dir():                       # `gmpas prep hfun somedir/`
+            p = p / "hfun.py"
+        if not p.exists():
+            raise FileNotFoundError(f"No such hfun file: {p}")
+
+        module = _import_isolated(p)
+
+        if not hasattr(module, "get_hfun"):
+            raise HfunError(
+                f"{p.name} defines no get_hfun(lon, lat). A JIGSAW hfun file "
+                f"must define get_hfun and the module-level float hfun_min."
+            )
+        if not hasattr(module, "hfun_min"):
+            raise HfunError(
+                f"{p.name} defines no hfun_min. It is the minimum grid "
+                f"distance in km, and create_hfun.py sizes its lat-lon grid "
+                f"from it."
+            )
+        try:
+            hfun_min = float(module.hfun_min)
+        except (TypeError, ValueError):
+            raise HfunError(
+                f"{p.name}: hfun_min is {module.hfun_min!r}, not a number"
+            ) from None
+        if not np.isfinite(hfun_min) or hfun_min <= 0.0:
+            raise HfunError(
+                f"{p.name}: hfun_min is {hfun_min}, which is not a positive "
+                f"grid distance in km"
+            )
+
+        self = cls(path=p, hfun_min=hfun_min, _get_hfun=module.get_hfun)
+        self._probe()
+        return self
+
+    # -- sampling --------------------------------------------------------
+
+    def _probe(self) -> None:
+        """Call it once on four points, so a broken file fails here.
+
+        Better a message naming the file than a traceback out of the middle of
+        a render, or a blank page with the error in a JSON body.
+        """
+        lon = np.radians(np.array([[0.0, 90.0], [180.0, 270.0]]))
+        lat = np.radians(np.array([[0.0, 45.0], [-45.0, 10.0]]))
+        try:
+            out = self.sample_radians(lon, lat)
+        except Exception as exc:
+            raise HfunError(
+                f"{self.path.name}: get_hfun raised {type(exc).__name__}: {exc}"
+            ) from exc
+        if not np.all(np.isfinite(out)):
+            raise HfunError(
+                f"{self.path.name}: get_hfun returned non-finite grid distances"
+            )
+        if np.any(out <= 0.0):
+            raise HfunError(
+                f"{self.path.name}: get_hfun returned a grid distance <= 0"
+            )
+
+    def sample_radians(self, lon: np.ndarray, lat: np.ndarray) -> np.ndarray:
+        """Grid distance (km) at each point, in ONE call to `get_hfun`.
+
+        The tutorial's own `get_hfun` flattens its inputs and returns a 1-d
+        array whatever shape it was handed -- `create_hfun.py` never notices
+        because it flattens the result anyway. Reshaping here means the rest of
+        this package can treat the field as the 2-d thing it is.
+        """
+        lon = np.asarray(lon, dtype=np.float64)
+        lat = np.asarray(lat, dtype=np.float64)
+        out = np.asarray(self._get_hfun(lon, lat), dtype=np.float64)
+        if out.size != lon.size:
+            raise HfunError(
+                f"{self.path.name}: get_hfun returned {out.size} values for "
+                f"{lon.size} points"
+            )
+        return out.reshape(lon.shape)
+
+    def sample_degrees(self, lon: np.ndarray, lat: np.ndarray) -> np.ndarray:
+        return self.sample_radians(np.radians(lon), np.radians(lat))
+
+
+def _import_isolated(path: Path):
+    """Import an `hfun.py` by path, without letting it collide with ours.
+
+    Its own directory goes on `sys.path` for the duration: a real hfun file may
+    import a sibling of its own, exactly as `create_hfun.py` imports `hfun`.
+    The module is given a private name and is not left in `sys.modules`, so
+    loading a second hfun file in the same process gets the second file.
+    """
+    name = "_gmpas_user_hfun"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise HfunError(f"{path} is not importable as a Python module")
+
+    module = importlib.util.module_from_spec(spec)
+    parent = str(path.parent.resolve())
+    added = parent not in sys.path
+    if added:
+        sys.path.insert(0, parent)
+    previous = sys.modules.get(name)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        raise HfunError(
+            f"{path.name} failed to import: {type(exc).__name__}: {exc}"
+        ) from exc
+    finally:
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+        if added:
+            try:
+                sys.path.remove(parent)
+            except ValueError:
+                pass
+    return module
+
+
+# ------------------------------------------------------------- diagnostics
+
+
+def analysis_grid(hfun_min: float) -> tuple[np.ndarray, np.ndarray]:
+    """The lat-lon grid `create_hfun.py` would build for this `hfun_min`.
+
+    Reproduced rather than approximated, including the `meshgrid(lats, lons)`
+    argument order, so that the field analysed here is the same field JIGSAW
+    is going to be handed. Coarsened only if it would be enormous, and the
+    caller is told when that happens.
+    """
+    nlat = int(180.0 * DEG_TO_KM / hfun_min) + 1
+    while nlat * 2 * nlat > MAX_ANALYSIS_POINTS:
+        nlat //= 2
+    lats = np.linspace(-0.5 * np.pi, 0.5 * np.pi, num=nlat, endpoint=True)
+    lons = np.linspace(-np.pi, np.pi, num=2 * nlat, endpoint=True)
+    return lons, lats
+
+
+@dataclass
+class Diagnosis:
+    """What can be said about a mesh before generating it."""
+
+    h_min: float                 # km, smallest grid distance the function asks for
+    h_max: float                 # km
+    max_gradient: float          # km of cell size per km of arc distance
+    at_lon: float                # degrees, where that maximum is
+    at_lat: float
+    spacing_km: float            # analysis grid spacing at the equator
+    nlon: int
+    nlat: int
+    coarsened: bool              # analysis grid reduced from create_hfun.py's
+
+    @property
+    def within_guideline(self) -> bool:
+        return self.max_gradient <= GRADIENT_GUIDELINE
+
+
+def diagnose(hfun: Hfun) -> Diagnosis:
+    """Measure the resolution gradient the way `mesh_quality.py` does.
+
+    That script reads a finished `grid.nc` and reports
+
+        nominalDx = r_earth * nominalMinDc * (1 / meshDensity) ** 0.25
+        gradient  = |nominalDx[c0] - nominalDx[c1]| / dcEdge / r_earth
+
+    which, since `meshDensity` is `(h_min / h)**4` sampled at cell centres and
+    `nominalMinDc` is `h_min`, is exactly the difference in grid distance
+    between neighbouring cells divided by the distance between them. Its
+    continuous limit is |grad h| with respect to arc length, and that is what
+    is computed here -- so the number is comparable both to the 0.03 guideline
+    and to what `mesh_quality.py` will report once the mesh exists.
+
+    The two polar rows are excluded. Every longitude at a pole is the same
+    point, so the zonal derivative there is 0/0 rather than a real gradient.
+    """
+    lons, lats = analysis_grid(hfun.hfun_min)
+    latgrid, longrid = np.meshgrid(lats, lons)      # (nlon, nlat), as create_hfun
+    h = hfun.sample_radians(longrid, latgrid)
+
+    dlon = float(lons[1] - lons[0])
+    dlat = float(lats[1] - lats[0])
+
+    # metres of arc per radian, along each axis; the zonal one shrinks with
+    # cos(lat), which is what makes a degree of longitude worth less near a pole
+    dh_dy = np.gradient(h, axis=1) / (dlat * R_EARTH_KM)
+    dh_dlon = np.gradient(h, axis=0) / dlon
+    dh_dx = dh_dlon / (R_EARTH_KM * np.cos(latgrid))
+
+    grad = np.hypot(dh_dx, dh_dy)[:, 1:-1]          # drop the polar rows
+    flat = int(np.argmax(grad))
+    i, j = np.unravel_index(flat, grad.shape)
+
+    nlat = lats.size
+    return Diagnosis(
+        h_min=float(h.min()),
+        h_max=float(h.max()),
+        max_gradient=float(grad[i, j]),
+        at_lon=float(np.degrees(lons[i])),
+        at_lat=float(np.degrees(lats[j + 1])),
+        spacing_km=float(dlat * R_EARTH_KM),
+        nlon=int(lons.size),
+        nlat=int(nlat),
+        coarsened=nlat < int(180.0 * DEG_TO_KM / hfun.hfun_min) + 1,
+    )

--- a/src/gmpas/prep/hfunview.py
+++ b/src/gmpas/prep/hfunview.py
@@ -1,0 +1,267 @@
+"""Browse a JIGSAW distance function, with no mesh anywhere near it.
+
+`gmpas prep view` needs a mesh file; this needs only the `hfun.py` that would
+produce one. It answers the question you actually have while writing that file
+-- where does it refine, how fast does it get there, and is the transition
+gentle enough -- without spending the generation time first.
+
+The fields are the two quantities the workflow itself derives from `hfun.py`,
+neither of them invented here:
+
+    cell_width_km   get_hfun, straight out                     (create_hfun.py)
+    mesh_density    (hfun_min / h)**4, MPAS's meshDensity      (create_density.py)
+
+Rendering is the mesh viewer's, imported and not modified. There is no mesh, so
+there is no KD-tree and no `ViewIndex`: the distance function is defined at
+every point, and a frame is one call to `get_hfun` on the pixel centres. That
+call may be expensive by design -- the contract says it is made once with whole
+arrays -- so frames are computed per view box and kept.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+
+from ..raster import target_grid
+from ..viewer import _overlay, _png, bind, ramp
+from .hfun import GRADIENT_GUIDELINE, Hfun, diagnose
+from .layout import page
+
+#: sequential and perceptually uniform, and the same way round as
+#: `prep view`'s cell_width_km: small grid distance dark, large light. A
+#: refinement region then reads as the dark blob it is on the tutorial's own
+#: HFUN plots, and the two viewers agree on what "fine" looks like.
+CMAP = "viridis"
+
+FIELDS = {
+    "cell_width_km": "grid distance (km)",
+    "mesh_density": "meshDensity",
+}
+
+
+class HfunViewer:
+    """Everything the distance-function routes need, built once at startup."""
+
+    def __init__(self, hfun_path, nx: int = 1200, ny: int = 700):
+        self.hfun = Hfun.load(hfun_path)
+        self.nx, self.ny = nx, ny
+        self.diagnosis = diagnose(self.hfun)
+
+        # a distance function is defined over the whole sphere, so there is no
+        # domain to fit to -- the home view is the world
+        self.home = (-180.0, 180.0, -90.0, 90.0)
+        self._frames: dict[tuple, np.ndarray] = {}
+        self._overlays: dict[tuple, bytes] = {}
+        self._lock = threading.Lock()
+
+    # -- fields ----------------------------------------------------------
+
+    def limits(self, field: str) -> tuple[float, float]:
+        """Fixed whole-sphere limits, so a band keeps its colour while you pan.
+
+        Taken from the diagnosis, which sampled the same grid `create_hfun.py`
+        will, rather than from whatever happens to be in the current view.
+        """
+        d = self.diagnosis
+        if field == "cell_width_km":
+            return d.h_min, d.h_max
+        if field == "mesh_density":
+            return (self.hfun.hfun_min / d.h_max) ** 4, (
+                self.hfun.hfun_min / d.h_min
+            ) ** 4
+        raise KeyError(f"unknown hfun field: {field}, "
+                       f"expected one of {', '.join(FIELDS)}")
+
+    def describe(self) -> dict:
+        d = self.diagnosis
+        fields = []
+        for name, label in FIELDS.items():
+            vmin, vmax = self.limits(name)
+            fields.append({"name": name, "label": label,
+                           "vmin": float(vmin), "vmax": float(vmax)})
+
+        verdict = "within" if d.within_guideline else "ABOVE"
+        return {
+            "file": self.hfun.path.name,
+            "subtitle": f"distance function · {d.h_min:.4g} to "
+                        f"{d.h_max:.4g} km · max gradient "
+                        f"{d.max_gradient:.4f}",
+            "facts_label": "distance function",
+            "stats": [
+                ["hfun_min", f"{self.hfun.hfun_min:.4g} km"],
+                ["h min", f"{d.h_min:.4g} km"],
+                ["h max", f"{d.h_max:.4g} km"],
+                ["max gradient", f"{d.max_gradient:.4f}"],
+                ["guideline", f"{verdict} {GRADIENT_GUIDELINE}"],
+                ["steepest at", f"{d.at_lat:.1f}, {d.at_lon:.1f}"],
+                ["HFUN grid", f"{d.nlon} x {d.nlat}"],
+            ],
+            "home": list(self.home),
+            "nx": self.nx,
+            "ny": self.ny,
+            "cmap": CMAP,
+            "ramp": ramp(CMAP),
+            "fields": fields,
+        }
+
+    # -- frames ----------------------------------------------------------
+
+    def values(self, field: str, extent, nx: int, ny: int) -> np.ndarray:
+        """The field on this view's pixel centres, from one `get_hfun` call."""
+        key = (*(round(float(v), 6) for v in extent), nx, ny)
+        with self._lock:
+            if key not in self._frames:
+                lon, lat = target_grid(tuple(extent), nx, ny)
+                lon2, lat2 = np.meshgrid(lon, lat)
+                self._frames[key] = self.hfun.sample_degrees(lon2, lat2)
+            h = self._frames[key]
+
+        if field == "cell_width_km":
+            return h
+        if field == "mesh_density":
+            return (self.hfun.hfun_min / h) ** 4
+        raise KeyError(f"unknown hfun field: {field}, "
+                       f"expected one of {', '.join(FIELDS)}")
+
+    def overlay(self, extent, nx=None, ny=None) -> bytes:
+        nx, ny = nx or self.nx, ny or self.ny
+        key = (*(round(float(v), 6) for v in extent), nx, ny)
+        with self._lock:
+            if key not in self._overlays:
+                self._overlays[key] = _overlay(extent, nx, ny)
+            return self._overlays[key]
+
+    def frame(self, field: str, extent, nx=None, ny=None,
+              compress: int = 1) -> tuple[bytes, float, float]:
+        nx, ny = nx or self.nx, ny or self.ny
+        img = self.values(field, extent, nx, ny)
+        lo, hi = self.limits(field)
+        return _png(img, CMAP, lo, hi, compress), float(lo), float(hi)
+
+
+# ------------------------------------------------------------------ serving
+
+
+def _handler(viewer: HfunViewer, html: str):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):          # keep the console quiet
+            pass
+
+        def _send(self, body: bytes, ctype: str):
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            url = urlparse(self.path)
+            q = {k: v[0] for k, v in parse_qs(url.query).items()}
+            try:
+                if url.path == "/":
+                    return self._send(html.encode(), "text/html; charset=utf-8")
+                if url.path == "/api/meta":
+                    return self._send(json.dumps(viewer.describe()).encode(),
+                                      "application/json")
+                if url.path == "/api/frame":
+                    extent = [float(v) for v in q["extent"].split(",")]
+                    png, lo, hi = viewer.frame(
+                        q.get("field", "cell_width_km"), extent,
+                        int(q["nx"]) if q.get("nx") else None,
+                        int(q["ny"]) if q.get("ny") else None,
+                        int(q.get("compress", 1)),
+                    )
+                    self.send_response(200)
+                    self.send_header("Content-Type", "image/png")
+                    self.send_header("X-Range", f"{lo},{hi}")
+                    self.send_header("Content-Length", str(len(png)))
+                    self.end_headers()
+                    return self.wfile.write(png)
+                if url.path == "/api/overlay":
+                    extent = [float(v) for v in q["extent"].split(",")]
+                    return self._send(viewer.overlay(
+                        extent,
+                        int(q["nx"]) if q.get("nx") else None,
+                        int(q["ny"]) if q.get("ny") else None), "image/png")
+            except Exception as exc:                      # surface, don't hang
+                body = json.dumps({"error": f"{type(exc).__name__}: {exc}"}).encode()
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                return self.wfile.write(body)
+            self.send_error(404)
+
+    return Handler
+
+
+def report(viewer: HfunViewer) -> str:
+    """The startup summary, also what `gmpas prep hfun --check` prints."""
+    d = viewer.diagnosis
+    lines = [
+        f"{viewer.hfun.path.name}: hfun_min {viewer.hfun.hfun_min:.4g} km, "
+        f"grid distance {d.h_min:.4g} to {d.h_max:.4g} km",
+        f"max cell size gradient {d.max_gradient:.4f} at "
+        f"{d.at_lat:.2f}, {d.at_lon:.2f} "
+        f"({'within' if d.within_guideline else 'ABOVE'} the "
+        f"{GRADIENT_GUIDELINE} guideline)",
+        f"measured on the {d.nlon} x {d.nlat} lat-lon grid create_hfun.py "
+        f"would write ({d.spacing_km:.3g} km spacing)",
+    ]
+    if d.coarsened:
+        lines.append(
+            "  note: that grid was coarsened to fit in memory, so the "
+            "gradient above is a lower bound on the real one"
+        )
+    if not d.within_guideline:
+        lines.append(
+            "  a gradient above a few percent changes cell size too quickly; "
+            "widen the transition region or raise hfun_min"
+        )
+    return "\n".join(lines)
+
+
+def serve(hfun_path, port: int = 8765, nx: int = 1200, ny: int = 700,
+          open_browser: bool = True, host: str = "127.0.0.1",
+          strict_port: bool = False):
+    """Start the distance-function viewer and block until interrupted.
+
+    Same tunnelling rules as `gmpas view` and `gmpas prep view`.
+    """
+    viewer = HfunViewer(hfun_path, nx=nx, ny=ny)
+    server = bind(_handler(viewer, page(f"gmpas prep hfun · "
+                                        f"{viewer.hfun.path.name}")),
+                  port, host=host, strict=strict_port)
+    port = server.server_address[1]
+
+    print(report(viewer))
+
+    node = socket.gethostname()
+    if host in ("127.0.0.1", "localhost"):
+        print(f"listening on 127.0.0.1:{port} — this machine only")
+        print(f"  open  http://127.0.0.1:{port}")
+        print(f"  if {node} is a remote node, this is NOT reachable through a "
+              f"tunnel to a login node; restart with --host 0.0.0.0")
+    else:
+        print(f"listening on {host}:{port} — reachable as {node}:{port}")
+        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
+        print(f"  then open           http://localhost:{port}")
+    print("ctrl-c to stop")
+
+    if open_browser:
+        threading.Timer(0.5, webbrowser.open,
+                        args=(f"http://127.0.0.1:{port}",)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    finally:
+        server.server_close()

--- a/src/gmpas/prep/layout.py
+++ b/src/gmpas/prep/layout.py
@@ -102,12 +102,8 @@ button:hover{border-color:var(--accent)}
 <div id="side">
   <h1><span id="title">loading&hellip;</span><small id="sub"></small></h1>
   <div class="sec"><label>field</label><div id="fields"></div></div>
-  <div class="sec" id="facts"><label>mesh</label>
-    <div class="kv"><span>cells</span><b id="f_cells">&ndash;</b></div>
-    <div class="kv"><span>edges</span><b id="f_edges">&ndash;</b></div>
-    <div class="kv"><span>coverage</span><b id="f_cov">&ndash;</b></div>
-    <div class="kv"><span>width min</span><b id="f_wmin">&ndash;</b></div>
-    <div class="kv"><span>width max</span><b id="f_wmax">&ndash;</b></div>
+  <div class="sec" id="facts"><label id="factlabel">mesh</label>
+    <div id="factrows"></div>
   </div>
 </div>
 <div id="main">
@@ -319,15 +315,22 @@ function panel(){
   $("#exthint").textContent=`${b[0].toFixed(2)}, ${b[1].toFixed(2)}, `+
                             `${b[2].toFixed(2)}, ${b[3].toFixed(2)}`;
 }
+// The facts block is whatever the step says it is. A mesh has cells, edges and
+// coverage; a distance function has none of those, and inventing values for it
+// would be worse than leaving the rows out. So the server sends `subtitle` and
+// `stats` (a list of [label, value] pairs) and this just renders them.
 function subtitle(){
-  $("#sub").textContent = `${M.cells.toLocaleString()} cells \\u00b7 `+
-    `${M.regional?"regional":"global"} \\u00b7 ${M.coverage}% of its sphere`;
-  $("#f_cells").textContent=M.cells.toLocaleString();
-  $("#f_edges").textContent=M.edges.toLocaleString();
-  $("#f_cov").textContent=M.coverage+"%";
-  const w=M.fields.find(f=>f.name==="cell_width_km");
-  if(w){ $("#f_wmin").textContent=w.vmin.toPrecision(4)+" km";
-         $("#f_wmax").textContent=w.vmax.toPrecision(4)+" km"; }
+  $("#sub").textContent = M.subtitle || "";
+  $("#factlabel").textContent = M.facts_label || "mesh";
+  $("#factrows").innerHTML = "";
+  (M.stats || []).forEach(([label, value])=>{
+    const d=document.createElement("div");
+    d.className="kv";
+    d.innerHTML=`<span></span><b></b>`;
+    d.firstChild.textContent=label;
+    d.lastChild.textContent=value;
+    $("#factrows").append(d);
+  });
 }
 function fillFields(){
   $("#fields").innerHTML="";

--- a/src/gmpas/prep/meshview.py
+++ b/src/gmpas/prep/meshview.py
@@ -82,12 +82,28 @@ class MeshViewer:
                 "vmin": float(np.nanmin(v)),
                 "vmax": float(np.nanmax(v)),
             })
+        cells, edges = int(self.mesh.n_cells), int(self.mesh.n_edges)
+        coverage = round(self.mesh.coverage * 100, 1)
+        regional = not self.mesh.is_global
+        width = next(f for f in fields if f["name"] == "cell_width_km")
         return {
             "file": self.mesh.path.name,
-            "cells": int(self.mesh.n_cells),
-            "edges": int(self.mesh.n_edges),
-            "regional": not self.mesh.is_global,
-            "coverage": round(self.mesh.coverage * 100, 1),
+            "cells": cells,
+            "edges": edges,
+            "regional": regional,
+            "coverage": coverage,
+            # the sidebar is data-driven now, so a step with no cells or edges
+            # can reuse the same shell rather than fork it
+            "subtitle": f"{cells:,} cells · {'regional' if regional else 'global'}"
+                        f" · {coverage}% of its sphere",
+            "facts_label": "mesh",
+            "stats": [
+                ["cells", f"{cells:,}"],
+                ["edges", f"{edges:,}"],
+                ["coverage", f"{coverage}%"],
+                ["width min", f"{width['vmin']:.4g} km"],
+                ["width max", f"{width['vmax']:.4g} km"],
+            ],
             "home": list(self.home),
             "nx": self.nx,
             "ny": self.ny,

--- a/tests/test_hfun.py
+++ b/tests/test_hfun.py
@@ -1,0 +1,282 @@
+"""Reading a JIGSAW distance function, and what can be said about it.
+
+The synthetic `hfun.py` files here follow the mini-tutorial's contract exactly,
+including the awkward part of it: the tutorial's own `get_hfun` flattens its
+inputs and hands back a 1-d array whatever shape it was given.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from gmpas.prep.hfun import (
+    DEG_TO_KM,
+    GRADIENT_GUIDELINE,
+    Hfun,
+    HfunError,
+    analysis_grid,
+    diagnose,
+)
+
+#: coarse enough that the analysis grid is small and the tests are quick
+COARSE = 200.0
+
+
+def write_hfun(path, body: str, hfun_min: float = COARSE):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"import numpy as np\n\nhfun_min = {hfun_min}\n\n{body}\n")
+    return path
+
+
+UNIFORM = """
+def get_hfun(lon, lat):
+    return np.full(lon.size, hfun_min)
+"""
+
+
+def radial(h_max: float, t_begin: float, t_end: float,
+           lon_c: float = 0.0, lat_c: float = 0.0) -> str:
+    """The tutorial's own shape: flat, linear transition, flat."""
+    return f"""
+def get_hfun(lon, lat):
+    r_earth = 6371.229
+    lam, phi = np.radians({lon_c}), np.radians({lat_c})
+    c = np.array([np.cos(lam) * np.cos(phi),
+                  np.sin(lam) * np.cos(phi),
+                  np.sin(phi)])
+    p = np.column_stack([(np.cos(lon) * np.cos(lat)).flatten(),
+                         (np.sin(lon) * np.cos(lat)).flatten(),
+                         np.sin(lat).flatten()])
+    r = r_earth * np.arccos(np.clip(p @ c, -1.0, 1.0))
+    ret = np.full(r.shape, hfun_min)
+    mid = np.logical_and(r >= {t_begin}, r < {t_end})
+    ret[mid] = hfun_min + (r[mid] - {t_begin}) * ({h_max} - hfun_min) \\
+                          / ({t_end} - {t_begin})
+    ret[r >= {t_end}] = {h_max}
+    return ret
+"""
+
+
+# ---------------------------------------------------------------- the contract
+
+
+def test_a_file_defining_the_contract_loads(tmp_path):
+    h = Hfun.load(write_hfun(tmp_path / "hfun.py", UNIFORM))
+    assert h.hfun_min == COARSE
+    assert h.sample_degrees(np.array([0.0, 90.0]),
+                            np.array([0.0, 10.0])) == pytest.approx(COARSE)
+
+
+def test_a_directory_is_read_as_its_hfun_py(tmp_path):
+    write_hfun(tmp_path / "hfun.py", UNIFORM)
+    assert Hfun.load(tmp_path).hfun_min == COARSE
+
+
+def test_a_missing_get_hfun_says_what_the_contract_is(tmp_path):
+    path = tmp_path / "hfun.py"
+    path.write_text("hfun_min = 12.0\n")
+    with pytest.raises(HfunError, match="get_hfun"):
+        Hfun.load(path)
+
+
+def test_a_missing_hfun_min_says_what_it_is_for(tmp_path):
+    path = tmp_path / "hfun.py"
+    path.write_text("def get_hfun(lon, lat):\n    return lon\n")
+    with pytest.raises(HfunError, match="hfun_min"):
+        Hfun.load(path)
+
+
+def test_a_negative_hfun_min_is_refused(tmp_path):
+    with pytest.raises(HfunError, match="positive"):
+        Hfun.load(write_hfun(tmp_path / "hfun.py", UNIFORM, hfun_min=-5.0))
+
+
+def test_a_get_hfun_that_raises_is_reported_against_its_file(tmp_path):
+    body = "def get_hfun(lon, lat):\n    raise RuntimeError('no dataset')\n"
+    with pytest.raises(HfunError, match="RuntimeError: no dataset"):
+        Hfun.load(write_hfun(tmp_path / "hfun.py", body))
+
+
+def test_a_get_hfun_returning_zero_is_refused(tmp_path):
+    body = "def get_hfun(lon, lat):\n    return np.zeros(lon.size)\n"
+    with pytest.raises(HfunError, match="<= 0"):
+        Hfun.load(write_hfun(tmp_path / "hfun.py", body))
+
+
+def test_a_flattened_return_is_reshaped_to_the_input(tmp_path):
+    """The tutorial's get_hfun returns 1-d for a 2-d meshgrid; ours must not."""
+    h = Hfun.load(write_hfun(tmp_path / "hfun.py", UNIFORM))
+    lon, lat = np.meshgrid(np.linspace(-180, 180, 7), np.linspace(-80, 80, 5))
+    assert h.sample_degrees(lon, lat).shape == (5, 7)
+
+
+def test_a_wrong_length_return_is_caught(tmp_path):
+    body = "def get_hfun(lon, lat):\n    return np.full(3, hfun_min)\n"
+    h_path = write_hfun(tmp_path / "hfun.py", body)
+    with pytest.raises(HfunError, match="3 values for 4 points"):
+        Hfun.load(h_path)
+
+
+def test_two_hfun_files_do_not_shadow_each_other(tmp_path):
+    """Loading a second one in the same process must not reuse the first."""
+    a = write_hfun(tmp_path / "a" / "hfun.py", UNIFORM, hfun_min=10.0)
+    b = write_hfun(tmp_path / "b" / "hfun.py", UNIFORM, hfun_min=99.0)
+
+    assert Hfun.load(a).hfun_min == 10.0
+    assert Hfun.load(b).hfun_min == 99.0
+    assert Hfun.load(a).hfun_min == 10.0
+
+
+# ----------------------------------------------------------------- the grid
+
+
+def test_the_analysis_grid_is_the_one_create_hfun_would_write(tmp_path):
+    """Not an approximation of it -- the same formula, the same shape."""
+    for hfun_min in (60.0, 120.0, 200.0):
+        lons, lats = analysis_grid(hfun_min)
+        assert lats.size == int(180.0 * DEG_TO_KM / hfun_min) + 1
+        assert lons.size == 2 * lats.size
+        assert lats[0] == pytest.approx(-0.5 * np.pi)
+        assert lats[-1] == pytest.approx(0.5 * np.pi)
+        assert lons[0] == pytest.approx(-np.pi)
+        assert lons[-1] == pytest.approx(np.pi)
+
+
+def test_a_very_fine_hfun_min_coarsens_rather_than_exhausting_memory():
+    lons, lats = analysis_grid(0.5)              # would be ~3.2e9 points
+    assert lons.size * lats.size <= 20_000_000
+
+
+# ---------------------------------------------------------------- gradients
+
+
+def test_a_uniform_function_has_no_gradient(tmp_path):
+    d = diagnose(Hfun.load(write_hfun(tmp_path / "hfun.py", UNIFORM)))
+    assert d.h_min == pytest.approx(COARSE)
+    assert d.h_max == pytest.approx(COARSE)
+    assert d.max_gradient == pytest.approx(0.0, abs=1e-12)
+    assert d.within_guideline
+
+
+def test_the_gradient_is_the_slope_of_the_transition(tmp_path):
+    """The one number this is all for, against a case with a known answer.
+
+    A linear transition from h_min to h_max over a radial distance w has slope
+    exactly (h_max - h_min) / w everywhere inside it, so the measured maximum
+    has an analytic value to be checked against.
+    """
+    h_max, t_begin, width = 800.0, 2000.0, 4000.0
+    path = write_hfun(tmp_path / "hfun.py",
+                      radial(h_max, t_begin, t_begin + width))
+    d = diagnose(Hfun.load(path))
+
+    expected = (h_max - COARSE) / width
+    assert d.max_gradient == pytest.approx(expected, rel=0.02)
+    assert d.h_min == pytest.approx(COARSE)
+    assert d.h_max == pytest.approx(h_max)
+
+
+def test_a_transition_that_is_too_steep_fails_the_guideline(tmp_path):
+    steep = write_hfun(tmp_path / "steep" / "hfun.py",
+                       radial(800.0, 2000.0, 2400.0))
+    gentle = write_hfun(tmp_path / "gentle" / "hfun.py",
+                        radial(800.0, 2000.0, 42000.0))
+
+    assert diagnose(Hfun.load(steep)).max_gradient > GRADIENT_GUIDELINE
+    assert not diagnose(Hfun.load(steep)).within_guideline
+    assert diagnose(Hfun.load(gentle)).within_guideline
+
+
+def test_the_steepest_point_is_inside_the_transition_ring(tmp_path):
+    t_begin, t_end = 2000.0, 6000.0
+    path = write_hfun(tmp_path / "hfun.py",
+                      radial(800.0, t_begin, t_end, lon_c=0.0, lat_c=0.0))
+    d = diagnose(Hfun.load(path))
+
+    # great-circle distance from the refinement centre at (0, 0)
+    r = 6371.229 * np.arccos(np.cos(np.radians(d.at_lat))
+                             * np.cos(np.radians(d.at_lon)))
+    assert t_begin <= r <= t_end
+
+
+def test_the_poles_do_not_produce_an_infinite_gradient(tmp_path):
+    """cos(lat) is zero there, so the zonal derivative is 0/0, not a gradient."""
+    path = write_hfun(tmp_path / "hfun.py",
+                      radial(800.0, 2000.0, 6000.0, lat_c=90.0))
+    d = diagnose(Hfun.load(path))
+    assert np.isfinite(d.max_gradient)
+    assert d.max_gradient < 1.0
+
+
+# ------------------------------------------------------------------- viewer
+
+
+@pytest.fixture
+def viewer(tmp_path):
+    from gmpas.prep.hfunview import HfunViewer
+
+    path = write_hfun(tmp_path / "hfun.py", radial(800.0, 2000.0, 6000.0))
+    return HfunViewer(path, nx=60, ny=40)
+
+
+def test_meta_is_json_serialisable_and_has_no_cell_counts(viewer):
+    import json
+
+    meta = json.loads(json.dumps(viewer.describe()))
+    assert "cells" not in meta and "edges" not in meta
+    assert meta["facts_label"] == "distance function"
+    assert [name for name, _ in (r for r in meta["stats"])][0] == "hfun_min"
+
+
+def test_mesh_density_is_one_where_the_mesh_is_finest(viewer):
+    """rho(x_fine) = 1.0, as MPAS defines meshDensity."""
+    vmin, vmax = viewer.limits("mesh_density")
+    assert vmax == pytest.approx(1.0)
+    assert vmin == pytest.approx((COARSE / 800.0) ** 4)
+
+
+def test_the_scale_is_the_whole_sphere_not_the_view(viewer):
+    """Panning must not recolour a transition band."""
+    lo, hi = viewer.limits("cell_width_km")
+    _, zoom_lo, zoom_hi = viewer.frame("cell_width_km", [-1.0, 1.0, -1.0, 1.0])
+    assert (zoom_lo, zoom_hi) == (lo, hi)
+    assert hi == pytest.approx(800.0)
+
+
+def test_get_hfun_is_called_once_per_view_not_once_per_pixel(viewer):
+    """The contract allows expensive setup, so this is a correctness matter."""
+    calls = []
+    inner = viewer.hfun._get_hfun
+    viewer.hfun._get_hfun = lambda lon, lat: (calls.append(lon.size),
+                                              inner(lon, lat))[1]
+
+    viewer.frame("cell_width_km", [-180.0, 180.0, -90.0, 90.0])
+    viewer.frame("mesh_density", [-180.0, 180.0, -90.0, 90.0])
+    assert calls == [60 * 40]                 # both fields, one sampling
+
+
+def test_an_unknown_field_says_what_it_offers(viewer):
+    with pytest.raises(KeyError, match="cell_width_km"):
+        viewer.limits("nope")
+
+
+def test_prep_hfun_check_prints_the_report(tmp_path, capsys):
+    from gmpas.cli import main
+
+    path = write_hfun(tmp_path / "hfun.py", radial(800.0, 2000.0, 2400.0))
+    assert main(["prep", "hfun", str(path), "--check"]) == 0
+
+    out = capsys.readouterr().out
+    assert "max cell size gradient" in out
+    assert "ABOVE" in out                      # 600 km over 400 km is steep
+    assert "create_hfun.py would write" in out
+
+
+def test_a_bad_hfun_file_is_reported_not_traced(tmp_path, capsys):
+    from gmpas.cli import main
+
+    path = tmp_path / "hfun.py"
+    path.write_text("hfun_min = 12.0\n")
+    assert main(["prep", "hfun", str(path), "--check"]) == 1
+    assert "get_hfun" in capsys.readouterr().err


### PR DESCRIPTION
Adds `gmpas prep hfun`, and bumps to **0.3.0**.

## Why

In the JIGSAW workflow, a variable-resolution mesh is defined entirely by
`hfun.py`. Everything after it is mechanical — `create_hfun.py` samples it onto
a lat-lon grid, JIGSAW turns that into generating points, `mkgrid` turns those
into `grid.nc`. So every design decision lives in that one file, and until now
the only way to see what those decisions produced was to run the whole chain
and look at the finished mesh.

```bash
gmpas prep hfun hfun.py            # browse it
gmpas prep hfun hfun.py --check    # just the numbers, no server
```

```
hfun.py: hfun_min 12 km, grid distance 12 to 60 km
max cell size gradient 0.0300 at 75.64, -95.05 (within the 0.03 guideline)
measured on the 3336 x 1668 lat-lon grid create_hfun.py would write (12 km spacing)
```

## The gradient

This is the number the feature is for. `mesh_quality.py` reports it from a
finished `grid.nc`:

```python
nominalDx = r_earth * nominalMinDc * (1.0 / meshDensity) ** 0.25
gradient  = abs(nominalDx[c0] - nominalDx[c1]) / dcEdge / r_earth
```

Since `meshDensity` is `(hfun_min / h) ** 4` and `nominalMinDc` is `hfun_min`,
that is the change in grid distance between neighbouring cells over the
distance between them. Its continuous limit is `|grad h|` with respect to arc
length, and that is what is computed here — on **the same lat-lon grid
`create_hfun.py` would write**, reproduced including the `meshgrid(lats, lons)`
argument order, so the field analysed is the field JIGSAW will be handed.

That makes the number comparable both to the tutorial's 0.03 guideline and to
what `mesh_quality.py` will report once the mesh exists. On the tutorial's own
`hfun.py` it measures **0.0300**, against an analytic 48 km / 1600 km = 0.03,
and locates the steepest point inside the transition ring.

Two things the naive version gets wrong, both handled and both tested:

- **The poles.** `cos(lat)` is zero there, so the zonal derivative is 0/0. The
  two polar rows are excluded rather than allowed to produce an infinity.
- **A very fine `hfun_min`.** `nlat` scales as `1/hfun_min`, so `hfun_min = 0.5`
  km asks for ~3.2e9 points. The grid coarsens instead, and the report says so
  and that the gradient is then a lower bound.

## Contract details that are handled, not assumed away

- **`get_hfun` is called once with whole arrays and may do expensive setup** —
  the deck is explicit about this, and slide 61 shows one interpolating a
  raster. So it is called once per view, never per pixel, and a test counts the
  calls.
- **The tutorial's own `get_hfun` returns a 1-d array whatever shape it was
  handed.** `create_hfun.py` never notices because it flattens the result
  anyway. We reshape to the input.
- A user's `hfun.py` may import a sibling module, so its directory goes on
  `sys.path` for the duration of the import, under a private module name that
  is not left in `sys.modules` — loading a second file in one process gets the
  second file.

## Fields

Both derived by the workflow itself, neither invented here:

| field | definition | source |
|---|---|---|
| `cell_width_km` | `get_hfun` straight out | `create_hfun.py` |
| `mesh_density` | `(hfun_min / h) ** 4`, 1.0 where finest | `create_density.py`, slide 22 |

## Layout

`prep/layout.py`'s facts block is now data-driven — a step sends `subtitle` and
`stats` — so a viewer with no cells and no edges reuses the shell rather than
forking it, which is what the module docstring always said it was for.
`meshview` supplies the same rows it previously hardcoded, and its `describe()`
keeps every key it had.

## Verification

- Suite is **223 passed**, 24 of them new.
- Checked against the real `mpas_jigsaw_tutorial/hfun.py`, not only synthetic
  ones: gradient 0.0300 matching the analytic slope, `meshDensity` exactly 1.0
  in the refinement region and `(12/60)**4` outside, refinement centred at
  38 N / 95 W and correctly wider in longitude at higher latitudes.

## Not included

`gmpas prep generate` — actually running JIGSAW — is still
[issue #15](https://github.com/nmathewa/gmpas-lib/issues/15). `mkgrid` needs
MPI and PnetCDF, which is a separate problem.

The tutorial also gives guidance on refinement-region size ("several hundred
cells in diameter") and neighbour size ratio (">35% larger is an order of
magnitude too quickly"). Both are computable from `hfun.py` alone, but each
needs a definition decision, so they are deliberately left out of this PR
rather than invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
