### PR TITLE
view: one server for the run, its mesh and its distance function

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,32 @@ mesh generation is meant to be the third
 remapping tools, JIGSAW would be an external executable gmpas shells out to,
 not a Python dependency.
 
+### One server, one port
+
+A run, the mesh it is on, and the distance function behind that mesh are the
+three things one wants side by side, and they used to be three processes on
+three ports — three SSH tunnels from a compute node. They are now one:
+
+```bash
+gmpas view /path/to/run/ --hfun hfun.py     # data + mesh + hfun
+gmpas prep view mesh.nc --hfun hfun.py      # mesh + hfun
+gmpas prep hfun hfun.py --mesh mesh.nc      # hfun + mesh
+```
+
+```
+2 sources on one port:
+  /mesh  mesh — maritime.region.nc · 8,228 cells
+  /hfun  hfun — hfun.py · 12 to 60 km · gradient 0.0300
+```
+
+`/` lists what is available and each page carries a switcher, so one tunnel
+reaches all of them. Opening a run gives the mesh page for free — a run always
+brings its mesh with it. Every source is constructed before the server binds,
+so a bad path is an error at the prompt rather than a 500 in a browser tab.
+
+A single source is unchanged: it is served at the root, with no index and no
+switcher, on exactly the paths it always used.
+
 ### Looking at a mesh before it exists
 
 ```bash

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -513,30 +513,36 @@ def _remap(args) -> int:
     return 1 if failures else 0
 
 
-def _view(args) -> int:
-    from .viewer import serve
+def _dashboard(args, data_path=None, mesh_path="", hfun_path="") -> int:
+    """Serve whatever sources were asked for, on one port.
 
-    # an explicit --port is usually an SSH tunnel already pointing at it, so
-    # silently listening elsewhere would be worse than failing
-    serve(args.path, args.mesh or "", port=args.port, host=args.host,
-          nx=args.width, ny=args.height, open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT)
+    Every command that opens a browser goes through here, so a run, the mesh it
+    is on and the distance function behind that mesh are one server and one
+    tunnel rather than three. An explicit --port is usually a tunnel already
+    pointing at it, so listening elsewhere would be worse than failing.
+    """
+    from .dashboard import build, serve
+
+    sources, banner = build(data_path, mesh_path, hfun_path,
+                            nx=args.width, ny=args.height)
+    serve(sources, port=args.port, host=args.host,
+          open_browser=not args.no_browser,
+          strict_port=args.port != DEFAULT_PORT, banner=banner)
     return 0
+
+
+def _view(args) -> int:
+    return _dashboard(args, data_path=args.path, mesh_path=args.mesh or "",
+                      hfun_path=args.hfun or "")
 
 
 def _prep_view(args) -> int:
-    from .prep.meshview import serve
-
-    # same rule as `view`: an explicit --port is usually a tunnel already
-    # pointing at it, so listening elsewhere would be worse than failing
-    serve(args.mesh_file, port=args.port, host=args.host,
-          nx=args.width, ny=args.height, open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT)
-    return 0
+    return _dashboard(args, mesh_path=args.mesh_file,
+                      hfun_path=args.hfun or "")
 
 
 def _prep_hfun(args) -> int:
-    from .prep.hfunview import HfunViewer, report, serve
+    from .prep.hfunview import HfunViewer, report
 
     # --check is the whole point on a login node or in a script: the numbers
     # without a server, so a bad transition is caught before JIGSAW runs
@@ -544,10 +550,8 @@ def _prep_hfun(args) -> int:
         print(report(HfunViewer(args.hfun_file)))
         return 0
 
-    serve(args.hfun_file, port=args.port, host=args.host,
-          nx=args.width, ny=args.height, open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT)
-    return 0
+    return _dashboard(args, mesh_path=args.mesh or "",
+                      hfun_path=args.hfun_file)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -630,6 +634,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     v = sub.add_parser("view", help="browse a file interactively in a browser")
     common(v)
+    v.add_argument("--hfun", help="also serve the JIGSAW hfun.py behind this "
+                                  "mesh, as a third page on the same port")
     v.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
                    help=f"port (default {DEFAULT_PORT}; the default wanders "
                         f"if busy, an explicit one fails instead)")
@@ -658,6 +664,9 @@ def build_parser() -> argparse.ArgumentParser:
     pv = presub.add_parser("view", help="browse a mesh file on its own, "
                                         "with no output data")
     pv.add_argument("mesh_file", metavar="MESH", help="MPAS mesh file")
+    pv.add_argument("--hfun", help="also serve the JIGSAW hfun.py behind this "
+                                   "mesh, so intent and result are one click "
+                                   "apart")
     pv.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
                     help=f"port (default {DEFAULT_PORT}; the default wanders "
                          f"if busy, an explicit one fails instead)")
@@ -680,6 +689,9 @@ def build_parser() -> argparse.ArgumentParser:
     ph.add_argument("--check", action="store_true",
                     help="print the resolution report and exit, without "
                          "serving anything")
+    ph.add_argument("--mesh", help="also serve a mesh built from this hfun, "
+                                   "to compare what was asked for against "
+                                   "what came out")
     ph.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
                     help=f"port (default {DEFAULT_PORT}; the default wanders "
                          f"if busy, an explicit one fails instead)")

--- a/src/gmpas/dashboard.py
+++ b/src/gmpas/dashboard.py
@@ -1,0 +1,262 @@
+"""One server, one port, several things to look at.
+
+`gmpas view`, `gmpas prep view` and `gmpas prep hfun` each serve a complete
+page, and each used to be its own process on its own port. On a laptop that is
+merely untidy. On a compute node it is three SSH tunnels to look at one
+experiment -- and the run, the mesh it is on, and the distance function that
+produced that mesh are exactly the three things one wants side by side.
+
+So this mounts them together. Each page keeps its own handler, its own routes
+and its own logic, unchanged; this adds a prefix in front of each, an index at
+`/` listing what is available, and a switcher across the top of every page.
+
+The one thing the pages had to give up is absolute API URLs. A page mounted at
+`/mesh/` that fetched `/api/meta` would reach the wrong viewer, so they now
+fetch `api/meta` relative to wherever they are served. Mounted at the root --
+which is what a single source still gets -- that resolves to exactly the paths
+they used before.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from .viewer import PageHandler
+
+#: inserted right after <body>, so neither page template has to know about it
+_NAV = """
+<div id="gmpas-nav">
+  <a href="/" title="all sources">gmpas</a>
+  __LINKS__
+</div>
+<style>
+#gmpas-nav{position:fixed;top:0;right:0;z-index:99;display:flex;gap:2px;
+  padding:4px 6px;background:#1e2127;border:0 solid #2c313a;border-width:0 0 1px 1px;
+  border-bottom-left-radius:6px;
+  font:11px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+#gmpas-nav a{color:#9aa3b0;text-decoration:none;padding:4px 8px;border-radius:4px}
+#gmpas-nav a:hover{color:#e6e8ec;background:#252932}
+#gmpas-nav a.on{color:#16181c;background:#5dcaa5}
+</style>
+"""
+
+_INDEX = """<!doctype html>
+<html><head><meta charset="utf-8"><title>gmpas</title>
+<style>
+body{margin:0;font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+     background:#16181c;color:#e6e8ec;display:flex;align-items:center;
+     justify-content:center;min-height:100vh}
+main{width:min(560px,90vw)}
+h1{font-size:15px;font-weight:500;margin:0 0 2px}
+p.sub{color:#9aa3b0;margin:0 0 20px;font-size:12px}
+a.card{display:block;text-decoration:none;color:inherit;background:#1e2127;
+  border:1px solid #2c313a;border-radius:8px;padding:14px 16px;margin-bottom:8px}
+a.card:hover{border-color:#5dcaa5}
+a.card b{display:block;font-weight:500;margin-bottom:2px}
+a.card span{color:#9aa3b0;font-size:12px}
+</style></head><body><main>
+<h1>gmpas</h1>
+<p class="sub">__COUNT__ on this server &middot; one port, one tunnel</p>
+__CARDS__
+</main></body></html>
+"""
+
+
+@dataclass
+class Source:
+    """One mounted page: what it is called, and what serves it."""
+
+    slug: str            # "run", "mesh", "hfun" -- also the URL prefix
+    label: str           # what the switcher says
+    detail: str          # one line on the index card
+    handler: object      # a BaseHTTPRequestHandler subclass serving "/" + "api/*"
+
+
+def nav(sources: list[Source], current: str) -> str:
+    links = "".join(
+        f'<a href="/{s.slug}/" class="{"on" if s.slug == current else ""}">'
+        f'{s.label}</a>'
+        for s in sources
+    )
+    return _NAV.replace("__LINKS__", links)
+
+
+def index_page(sources: list[Source]) -> str:
+    cards = "".join(
+        f'<a class="card" href="/{s.slug}/"><b>{s.label}</b>'
+        f'<span>{s.detail}</span></a>'
+        for s in sources
+    )
+    n = len(sources)
+    return (_INDEX.replace("__CARDS__", cards)
+                  .replace("__COUNT__", f"{n} source{'' if n == 1 else 's'}"))
+
+
+def with_nav(html: str, sources: list[Source], current: str) -> str:
+    """Splice the switcher into a page without either page knowing about it."""
+    marker = "<body>"
+    at = html.find(marker)
+    if at < 0:                       # not our page; leave it exactly as it is
+        return html
+    at += len(marker)
+    return html[:at] + nav(sources, current) + html[at:]
+
+
+def router(sources: list[Source]):
+    """Dispatch by prefix to each source's own handler.
+
+    The delegation is deliberate: each mounted handler is called with `self`
+    and a rewritten `self.path`, so it runs its own `do_GET` against its own
+    viewer and never learns it is not at the root.
+    """
+    index = index_page(sources).encode()
+    by_slug = {s.slug: s for s in sources}
+
+    # One source needs no index and no switcher: it is mounted at the root as
+    # well as under its slug, so `gmpas prep view mesh.nc` serves exactly the
+    # paths it always did and costs nobody an extra click.
+    only = sources[0] if len(sources) == 1 else None
+
+    class Router(PageHandler):
+        def do_GET(self):
+            url = urlparse(self.path)
+            parts = url.path.lstrip("/").split("/", 1)
+            slug = parts[0]
+
+            if only is not None and slug != only.slug:
+                return only.handler.do_GET(self)
+
+            if url.path in ("", "/"):
+                return self._send(index, "text/html; charset=utf-8")
+
+            source = by_slug.get(slug)
+            if source is None:
+                return self.send_error(404)
+
+            # /mesh must become /mesh/ before the page loads, or every relative
+            # api/... in it would resolve against / and reach the wrong viewer
+            if len(parts) == 1 and not url.path.endswith("/"):
+                self.send_response(301)
+                self.send_header("Location", f"/{slug}/")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
+            rest = "/" + (parts[1] if len(parts) > 1 else "")
+            self.path = rest + (f"?{url.query}" if url.query else "")
+            return source.handler.do_GET(self)
+
+    return Router
+
+
+def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
+          open_browser: bool = True, strict_port: bool = False,
+          banner: str = ""):
+    """Start one server carrying every source, and block until interrupted."""
+    import socket
+    import threading
+    import webbrowser
+
+    from .viewer import bind
+
+    server = bind(router(sources), port, host=host, strict=strict_port)
+    port = server.server_address[1]
+
+    if banner:
+        print(banner)
+    print(f"{len(sources)} sources on one port:")
+    for s in sources:
+        print(f"  /{s.slug:<5} {s.label} — {s.detail}")
+
+    node = socket.gethostname()
+    if host in ("127.0.0.1", "localhost"):
+        print(f"listening on 127.0.0.1:{port} — this machine only")
+        print(f"  open  http://127.0.0.1:{port}")
+        print(f"  if {node} is a remote node, this is NOT reachable through a "
+              f"tunnel to a login node; restart with --host 0.0.0.0")
+    else:
+        print(f"listening on {host}:{port} — reachable as {node}:{port}")
+        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
+        print(f"  then open           http://localhost:{port}")
+    print("ctrl-c to stop")
+
+    if open_browser:
+        threading.Timer(0.5, webbrowser.open,
+                        args=(f"http://127.0.0.1:{port}",)).start()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    finally:
+        server.server_close()
+
+
+# ----------------------------------------------------------------- assembly
+
+
+def build(data_path=None, mesh_path: str = "", hfun_path: str = "",
+          nx: int = 1200, ny: int = 700) -> tuple[list[Source], str]:
+    """Assemble the sources the user actually asked for, and a banner.
+
+    A run always brings its mesh with it, so opening one gives both the data
+    page and the mesh page without asking for either; `--hfun` adds the third.
+    Every source is constructed before the server binds, so a bad path is an
+    error on the command line rather than a 500 in a browser tab.
+    """
+    from .prep.hfunview import HfunViewer, report
+    from .prep.hfunview import _handler as hfun_handler
+    from .prep.layout import page as prep_page
+    from .prep.meshview import MeshViewer
+    from .prep.meshview import _handler as mesh_handler
+    from .viewer import PAGE, Viewer
+    from .viewer import _handler as run_handler
+
+    built, lines = [], []
+
+    if data_path is not None:
+        run = Viewer(data_path, mesh_path, nx=nx, ny=ny)
+        n_vars = len(run.series.variables("nCells"))
+        built.append(("run", "data",
+                      f"{len(run.series)} steps · {n_vars} cell variables", run))
+        built.append(("mesh", "mesh",
+                      f"{run.mesh.path.name} · {run.mesh.n_cells:,} cells",
+                      MeshViewer(run.mesh.path, nx=nx, ny=ny)))
+    elif mesh_path:
+        mv = MeshViewer(mesh_path, nx=nx, ny=ny)
+        built.append(("mesh", "mesh",
+                      f"{mv.mesh.path.name} · {mv.mesh.n_cells:,} cells", mv))
+
+    if hfun_path:
+        hv = HfunViewer(hfun_path, nx=nx, ny=ny)
+        lines.append(report(hv))
+        built.append(("hfun", "hfun",
+                      f"{hv.hfun.path.name} · {hv.diagnosis.h_min:.4g} to "
+                      f"{hv.diagnosis.h_max:.4g} km · gradient "
+                      f"{hv.diagnosis.max_gradient:.4f}", hv))
+
+    if not built:
+        raise ValueError("nothing to view: give a run, a mesh, or an hfun file")
+
+    # the switcher has to name every source, so the list is completed first and
+    # the pages -- which embed it -- are built in a second pass. With only one
+    # source there is nothing to switch to, so the bar is left off entirely
+    sources = [Source(slug, label, detail, None)
+               for slug, label, detail, _viewer in built]
+
+    def dressed(html: str, slug: str) -> str:
+        return html if len(sources) == 1 else with_nav(html, sources, slug)
+
+    for source, (slug, _label, _detail, viewer) in zip(sources, built):
+        if slug == "run":
+            source.handler = run_handler(viewer, dressed(PAGE, slug))
+        elif slug == "mesh":
+            source.handler = mesh_handler(
+                viewer, dressed(prep_page(f"gmpas · {viewer.mesh.path.name}"),
+                                slug))
+        else:
+            source.handler = hfun_handler(
+                viewer, dressed(prep_page(f"gmpas · {viewer.hfun.path.name}"),
+                                slug))
+
+    return sources, "\n".join(lines)

--- a/src/gmpas/prep/hfunview.py
+++ b/src/gmpas/prep/hfunview.py
@@ -24,13 +24,12 @@ import json
 import socket
 import threading
 import webbrowser
-from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 
 from ..raster import target_grid
-from ..viewer import _overlay, _png, bind, ramp
+from ..viewer import PageHandler, _overlay, _png, bind, ramp
 from .hfun import GRADIENT_GUIDELINE, Hfun, diagnose
 from .layout import page
 
@@ -120,7 +119,15 @@ class HfunViewer:
             if key not in self._frames:
                 lon, lat = target_grid(tuple(extent), nx, ny)
                 lon2, lat2 = np.meshgrid(lon, lat)
-                self._frames[key] = self.hfun.sample_degrees(lon2, lat2)
+                h = self.hfun.sample_degrees(lon2, lat2)
+
+                # Past a pole there is no sphere left to have a grid distance.
+                # get_hfun answers anyway -- sin and cos are periodic, so it
+                # folds back and returns a mirror image of the other side --
+                # and that fabricated band has no coastline to sit under.
+                # Frames are rendered 1.4x wider than the window, so a global
+                # view always asks for some of it. Blank it instead.
+                self._frames[key] = np.where(np.abs(lat2) > 90.0, np.nan, h)
             h = self._frames[key]
 
         if field == "cell_width_km":
@@ -150,18 +157,7 @@ class HfunViewer:
 
 
 def _handler(viewer: HfunViewer, html: str):
-    class Handler(BaseHTTPRequestHandler):
-        def log_message(self, *a):          # keep the console quiet
-            pass
-
-        def _send(self, body: bytes, ctype: str):
-            self.send_response(200)
-            self.send_header("Content-Type", ctype)
-            self.send_header("Content-Length", str(len(body)))
-            self.send_header("Cache-Control", "no-store")
-            self.end_headers()
-            self.wfile.write(body)
-
+    class Handler(PageHandler):
         def do_GET(self):
             url = urlparse(self.path)
             q = {k: v[0] for k, v in parse_qs(url.query).items()}

--- a/src/gmpas/prep/layout.py
+++ b/src/gmpas/prep/layout.py
@@ -265,7 +265,7 @@ function colorbar(){
 
 async function overlay(){
   const b=outset(boxOf(view));
-  $("#over").src=`/api/overlay?extent=${b.join(",")}`+
+  $("#over").src=`api/overlay?extent=${b.join(",")}`+
                  `&nx=${Math.round(M.nx*OUTSET)}&ny=${Math.round(M.ny*OUTSET)}`;
 }
 // show the frame we already have, transformed into place, until the real one
@@ -290,7 +290,7 @@ async function draw(){
     const p=new URLSearchParams({field:cur.name, extent:b.join(","),
       nx:Math.round(M.nx*OUTSET), ny:Math.round(M.ny*OUTSET)});
     const t0=performance.now();
-    const r=await fetch("/api/frame?"+p);
+    const r=await fetch("api/frame?"+p);
     if(!r.ok){ say((await r.json()).error); return; }
     const url=URL.createObjectURL(await r.blob());
     const img=$("#data"), old=img.src;
@@ -405,7 +405,7 @@ $("#grid").onchange = graticule;
 addEventListener("resize", ()=>{ layout(); scalebar(); graticule(); });
 
 async function boot(){
-  M = await (await fetch("/api/meta")).json();
+  M = await (await fetch("api/meta")).json();
   $("#title").textContent = M.file;
   home = fit(M.home); view = {...home}; rendered = null;
   layout(); subtitle(); fillFields(); panel();

--- a/src/gmpas/prep/meshview.py
+++ b/src/gmpas/prep/meshview.py
@@ -26,13 +26,12 @@ import json
 import socket
 import threading
 import webbrowser
-from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 
 from ..mesh import MpasMesh
-from ..viewer import ViewIndex, _overlay, _png, bind, ramp
+from ..viewer import PageHandler, ViewIndex, _overlay, _png, bind, ramp
 from .layout import page
 
 #: the one colormap this section uses. Sequential and perceptually uniform,
@@ -142,18 +141,7 @@ class MeshViewer:
 
 
 def _handler(viewer: MeshViewer, html: str):
-    class Handler(BaseHTTPRequestHandler):
-        def log_message(self, *a):          # keep the console quiet
-            pass
-
-        def _send(self, body: bytes, ctype: str):
-            self.send_response(200)
-            self.send_header("Content-Type", ctype)
-            self.send_header("Content-Length", str(len(body)))
-            self.send_header("Cache-Control", "no-store")
-            self.end_headers()
-            self.wfile.write(body)
-
+    class Handler(PageHandler):
         def do_GET(self):
             url = urlparse(self.path)
             q = {k: v[0] for k, v in parse_qs(url.query).items()}

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -127,7 +127,16 @@ def _overlay(extent, nx: int, ny: int) -> bytes:
 
     fig = plt.figure(figsize=(nx / 100, ny / 100), dpi=100)
     ax = fig.add_axes([0, 0, 1, 1], projection=src)
-    ax.set_extent((lon_min - central, lon_max - central, lat_min, lat_max), crs=src)
+
+    # Limits set directly, NOT through set_extent. set_extent clamps latitude
+    # to the projection's valid domain, so a box reaching past a pole -- which
+    # every global view does, because frames are rendered 1.4x wider than the
+    # window -- came back covering only +-90 but still stretched to fill the
+    # figure. The data raster spans the box it was asked for, so the two
+    # disagreed by the amount of overshoot, and since that amount changes with
+    # zoom the coastlines appeared to slide over the field as you zoomed.
+    ax.set_xlim(lon_min - central, lon_max - central)
+    ax.set_ylim(lat_min, lat_max)
 
     # GeoAxes defaults to aspect="equal", which letterboxes the extent inside
     # the figure box and leaves margins. The data raster spans the extent
@@ -351,25 +360,39 @@ class Viewer:
 # ----------------------------------------------------------------- serving
 
 
-def _handler(viewer: Viewer):
-    class Handler(BaseHTTPRequestHandler):
-        def log_message(self, *a):          # keep the console quiet
-            pass
+class PageHandler(BaseHTTPRequestHandler):
+    """What every gmpas page handler has in common.
 
-        def _send(self, body: bytes, ctype: str):
-            self.send_response(200)
-            self.send_header("Content-Type", ctype)
-            self.send_header("Content-Length", str(len(body)))
-            self.send_header("Cache-Control", "no-store")
-            self.end_headers()
-            self.wfile.write(body)
+    Shared rather than copied because the dashboard mounts these handlers
+    behind a prefix by calling one's `do_GET` with another's `self`. That only
+    works if `_send` is part of the contract between them, so it lives here
+    instead of being repeated identically in each.
+    """
 
+    def log_message(self, *a):              # keep the console quiet
+        pass
+
+    def _send(self, body: bytes, ctype: str):
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _handler(viewer: Viewer, html: str = ""):
+    """Routes for one run. `html` overrides the page, which is how the
+    dashboard splices its source switcher in without forking `PAGE`."""
+    html = html or PAGE
+
+    class Handler(PageHandler):
         def do_GET(self):
             url = urlparse(self.path)
             q = {k: v[0] for k, v in parse_qs(url.query).items()}
             try:
                 if url.path == "/":
-                    return self._send(PAGE.encode(), "text/html; charset=utf-8")
+                    return self._send(html.encode(), "text/html; charset=utf-8")
                 if url.path == "/api/status":
                     # cheap: how the time axis stands while the scan runs
                     return self._send(json.dumps({
@@ -729,7 +752,7 @@ function clamp(){
 }
 
 async function boot(){
-  M = await (await fetch("/api/meta")).json();
+  M = await (await fetch("api/meta")).json();
   $("#title").textContent = M.file;
   M.cmaps.forEach(c=>{const o=document.createElement("option");o.textContent=c;$("#cmap").append(o)});
   home = fit(M.home); view = {...home}; rendered = null;
@@ -766,7 +789,7 @@ function pick(name){
 }
 async function pollScan(){
   if(!M||!M.scanning) return;
-  const s=await (await fetch("/api/status")).json();
+  const s=await (await fetch("api/status")).json();
   const keep=$("#time").value;
   M.steps=s.steps; M.labels=s.labels; M.scanning=s.scanning;
   $("#time").max=M.steps-1; $("#time").value=keep;
@@ -776,7 +799,7 @@ async function pollScan(){
 
 async function overlay(){
   const b=outset(boxOf(view));
-  $("#over").src=`/api/overlay?extent=${b.join(",")}`+
+  $("#over").src=`api/overlay?extent=${b.join(",")}`+
                  `&nx=${Math.round(M.nx*OUTSET)}&ny=${Math.round(M.ny*OUTSET)}`;
 }
 
@@ -896,7 +919,7 @@ async function draw(){
   if($("#vmin").value) p.set("vmin",$("#vmin").value);
   if($("#vmax").value) p.set("vmax",$("#vmax").value);
   const t0=performance.now();
-  const r=await fetch("/api/frame?"+p);
+  const r=await fetch("api/frame?"+p);
   if(!r.ok){ say((await r.json()).error); return; }
   const [lo,hi]=r.headers.get("X-Range").split(",").map(Number);
   const url=URL.createObjectURL(await r.blob());
@@ -959,7 +982,7 @@ async function animLoad(){
       const p=new URLSearchParams({var:cur.name, time:i, level:$("#level").value,
         extent:b.join(","), cmap:$("#cmap").value, nx, ny, vmin:lo, vmax:hi,
         compress:$("#quality").value});
-      const r=await fetch("/api/frame?"+p);
+      const r=await fetch("api/frame?"+p);
       if(!r.ok) throw new Error((await r.json()).error);
       urls[i]=URL.createObjectURL(await r.blob());
       await new Promise(res=>{ const im=new Image(); im.onload=im.onerror=res; im.src=urls[i]; });
@@ -1049,7 +1072,7 @@ async function exportAs(kind, label){
   }
   const t0=performance.now();
   try{
-    const r=await fetch(`/api/export/${kind}?`+p);
+    const r=await fetch(`api/export/${kind}?`+p);
     if(!r.ok) throw new Error((await r.json()).error);
     const blob=await r.blob();
     const name=(r.headers.get("Content-Disposition")||"").match(/filename="(.+?)"/);
@@ -1133,7 +1156,7 @@ $("#wrap").onpointerup = async ev=>{
   const lat=b[3]-((ev.clientY-r.top)/r.height)*(b[3]-b[2]);
   const q=new URLSearchParams({lon,lat,var:cur.name,
     time:$("#time").value,level:$("#level").value});
-  const d=await (await fetch("/api/probe?"+q)).json();
+  const d=await (await fetch("api/probe?"+q)).json();
   $("#probe2").innerHTML=`cell ${d.cell}<br>${d.lat}\u00b0, ${d.lon}\u00b0<br>`+
                          `<b>${d.value.toPrecision(6)}</b>`;
 };

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,213 @@
+"""Several things to look at, on one port.
+
+These go through a real socket rather than calling the handlers directly: the
+whole point of the change is the routing, and prefix stripping, redirects and
+relative URL resolution are exactly what a direct call would skip.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.client import HTTPConnection
+
+import pytest
+
+from conftest import write_mesh
+from gmpas.dashboard import Source, build, index_page, router, with_nav
+from gmpas.viewer import bind
+
+HFUN = """
+import numpy as np
+
+hfun_min = 200.0
+
+def get_hfun(lon, lat):
+    return np.full(lon.size, hfun_min)
+"""
+
+
+@pytest.fixture
+def mesh_file(tmp_path):
+    return write_mesh(tmp_path / "dash.mesh.nc",
+                      [(float(i) * 3.0, 0.0) for i in range(12)])
+
+
+@pytest.fixture
+def hfun_file(tmp_path):
+    p = tmp_path / "hfun.py"
+    p.write_text(HFUN)
+    return p
+
+
+@pytest.fixture
+def server(mesh_file, hfun_file):
+    """A live two-source dashboard: a mesh and an hfun."""
+    sources, _banner = build(mesh_path=str(mesh_file), hfun_path=str(hfun_file),
+                             nx=40, ny=30)
+    srv = bind(router(sources), 0)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}", sources
+    srv.shutdown()
+    srv.server_close()
+
+
+def get(base, path):
+    with urllib.request.urlopen(base + path) as r:
+        return r.status, r.read()
+
+
+# ------------------------------------------------------------------ routing
+
+
+def test_the_index_lists_every_source(server):
+    base, sources = server
+    status, body = get(base, "/")
+    html = body.decode()
+
+    assert status == 200
+    assert [s.slug for s in sources] == ["mesh", "hfun"]
+    for s in sources:
+        assert f'href="/{s.slug}/"' in html
+        assert s.detail in html
+
+
+def test_each_source_serves_its_own_page(server):
+    base, _ = server
+    for slug in ("mesh", "hfun"):
+        status, body = get(base, f"/{slug}/")
+        assert status == 200
+        assert b"<!doctype html>" in body.lower()
+
+
+def test_each_source_has_its_own_api(server):
+    base, _ = server
+    mesh = json.loads(get(base, "/mesh/api/meta")[1])
+    hfun = json.loads(get(base, "/hfun/api/meta")[1])
+
+    assert mesh["facts_label"] == "mesh"
+    assert mesh["cells"] == 12
+    assert hfun["facts_label"] == "distance function"
+    assert "cells" not in hfun
+
+
+def test_a_prefix_without_a_slash_redirects_to_one(server):
+    """`/mesh` must become `/mesh/`, or every relative api/... in the page
+    would resolve against `/` and reach the wrong viewer."""
+    base, _ = server
+    host, port = base.rsplit("/", 1)[-1].split(":")
+    conn = HTTPConnection(host, int(port))
+    conn.request("GET", "/mesh")
+    resp = conn.getresponse()
+    assert resp.status == 301
+    assert resp.getheader("Location") == "/mesh/"
+    conn.close()
+
+
+def test_an_unknown_source_is_a_404_not_a_traceback(server):
+    base, _ = server
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        get(base, "/nope/api/meta")
+    assert exc.value.code == 404
+
+
+def test_a_frame_comes_back_from_the_right_source(server):
+    base, _ = server
+    extent = "-40,40,-20,20"
+    _, mesh_png = get(base, f"/mesh/api/frame?extent={extent}&field=cell_width_km")
+    _, hfun_png = get(base, f"/hfun/api/frame?extent={extent}&field=cell_width_km")
+
+    assert mesh_png[:8] == b"\x89PNG\r\n\x1a\n"
+    assert hfun_png[:8] == b"\x89PNG\r\n\x1a\n"
+    assert mesh_png != hfun_png
+
+
+# -------------------------------------------------------------- the switcher
+
+
+def test_every_page_carries_a_switcher_naming_the_others(server):
+    base, sources = server
+    for s in sources:
+        html = get(base, f"/{s.slug}/")[1].decode()
+        assert 'id="gmpas-nav"' in html
+        for other in sources:
+            assert f'href="/{other.slug}/"' in html
+
+
+def test_the_current_source_is_marked_in_its_own_switcher(server):
+    base, _ = server
+    html = get(base, "/hfun/")[1].decode()
+    assert '<a href="/hfun/" class="on">' in html
+    assert '<a href="/mesh/" class="">' in html
+
+
+def test_a_page_without_a_body_tag_is_left_alone():
+    """Splicing is by string, so it must no-op rather than corrupt."""
+    assert with_nav("not html at all", [], "x") == "not html at all"
+
+
+def test_the_index_is_singular_for_one_source():
+    src = [Source("mesh", "mesh", "one.nc", None)]
+    assert "1 source " in index_page(src)
+
+
+# ------------------------------------------------------------------ assembly
+
+
+def test_a_mesh_and_an_hfun_are_two_sources(mesh_file, hfun_file):
+    sources, banner = build(mesh_path=str(mesh_file), hfun_path=str(hfun_file))
+    assert [s.slug for s in sources] == ["mesh", "hfun"]
+    assert "max cell size gradient" in banner       # the hfun report is printed
+
+
+def test_a_mesh_alone_is_one_source(mesh_file):
+    sources, banner = build(mesh_path=str(mesh_file))
+    assert [s.slug for s in sources] == ["mesh"]
+    assert banner == ""
+
+
+def test_nothing_to_view_is_refused_before_binding():
+    with pytest.raises(ValueError, match="nothing to view"):
+        build()
+
+
+def test_a_bad_hfun_fails_on_the_command_line_not_in_a_tab(mesh_file, tmp_path):
+    """Sources are constructed before the server binds, so this is an error
+    the user sees at the prompt rather than a 500 in a browser."""
+    from gmpas.prep.hfun import HfunError
+
+    bad = tmp_path / "hfun.py"
+    bad.write_text("hfun_min = 12.0\n")
+    with pytest.raises(HfunError):
+        build(mesh_path=str(mesh_file), hfun_path=str(bad))
+
+
+# ------------------------------------------------- one source, as it always was
+
+
+@pytest.fixture
+def solo(mesh_file):
+    """A one-source server: `gmpas prep view mesh.nc` with nothing added."""
+    sources, _ = build(mesh_path=str(mesh_file), nx=40, ny=30)
+    srv = bind(router(sources), 0)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}"
+    srv.shutdown()
+    srv.server_close()
+
+
+def test_one_source_still_serves_at_the_root(solo):
+    """The paths `prep view` always used must keep working unchanged."""
+    assert get(solo, "/")[0] == 200
+    assert json.loads(get(solo, "/api/meta")[1])["cells"] == 12
+    assert get(solo, "/api/frame?extent=-40,40,-20,20")[1][:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_one_source_gets_no_switcher(solo):
+    """A bar offering one destination is noise, not navigation."""
+    assert 'id="gmpas-nav"' not in get(solo, "/")[1].decode()
+
+
+def test_one_source_is_also_reachable_under_its_slug(solo):
+    assert json.loads(get(solo, "/mesh/api/meta")[1])["cells"] == 12

--- a/tests/test_hfun.py
+++ b/tests/test_hfun.py
@@ -280,3 +280,17 @@ def test_a_bad_hfun_file_is_reported_not_traced(tmp_path, capsys):
     path.write_text("hfun_min = 12.0\n")
     assert main(["prep", "hfun", str(path), "--check"]) == 1
     assert "get_hfun" in capsys.readouterr().err
+
+
+def test_nothing_is_drawn_past_a_pole(viewer):
+    """get_hfun answers for |lat| > 90 -- sin and cos are periodic, so it folds
+    back and mirrors the other hemisphere. There is no sphere there and no
+    coastline to sit under it, so the frame must be blank instead."""
+    values = viewer.values("cell_width_km", [-180.0, 180.0, -126.0, 126.0],
+                           40, 60)
+    lat = np.linspace(-126.0, 126.0, 60, endpoint=False) + 126.0 / 60
+
+    past = np.abs(lat) > 90.0
+    assert past.any()                              # the test is testing something
+    assert np.isnan(values[past]).all()
+    assert np.isfinite(values[~past]).all()

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -94,13 +94,15 @@ def test_the_view_index_is_reused_across_frames(viewer, simple_mesh):
 
 def test_the_page_drops_the_postprocessing_controls():
     html = page("gmpas prep view")
-    for gone in ("#vmin", "#vmax", "id=\"cmap\"", "animate", "/api/export/",
-                 "/api/probe", "id=\"time\"", "id=\"level\""):
+    for gone in ("#vmin", "#vmax", "id=\"cmap\"", "animate", "api/export/",
+                 "api/probe", "id=\"time\"", "id=\"level\""):
         assert gone not in html
-    # but keeps what a preprocessing step needs
+    # but keeps what a preprocessing step needs. The API paths are relative so
+    # the page works mounted under a prefix as well as at the root
     for kept in ("id=\"elon0\"", "applyext", "copyext", "id=\"grat\"",
-                 "id=\"scalebar\"", "/api/frame", "/api/overlay"):
+                 "id=\"scalebar\"", "api/frame", "api/overlay"):
         assert kept in html
+    assert "/api/" not in html
 
 
 def test_the_page_splices_in_a_step_panel():

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -278,3 +278,37 @@ def test_gif_export_holds_every_step(tmp_path):
             assert im.n_frames == 4
     finally:
         v.series.close()
+
+
+def test_coastlines_stay_at_their_own_latitudes_past_a_pole():
+    """Frames are rendered 1.4x wider than the window, so every global view
+    asks for latitudes past +-90. `set_extent` used to clamp those to +-90 and
+    then stretch the result to fill the figure, drawing the coastlines about
+    1.4x too tall while the data raster spanned the box it was asked for. The
+    two slid apart, and because the overshoot changes with zoom, they slid by a
+    different amount at every zoom level.
+    """
+    import io
+
+    import numpy as np
+    from PIL import Image
+
+    from gmpas.viewer import _overlay
+
+    nx, ny = 400, 300
+    lat_max = 126.0
+    png = _overlay((-252.0, 252.0, -lat_max, lat_max), nx, ny)
+    ink = np.array(Image.open(io.BytesIO(png)).convert("RGBA"))[..., 3] > 0
+
+    rows = np.where(ink.any(axis=1))[0]
+    top = lat_max - (rows.min() + 0.5) / ny * 2 * lat_max
+    bottom = lat_max - (rows.max() + 0.5) / ny * 2 * lat_max
+
+    # no land is drawn past a pole, so no ink may appear there either
+    assert abs(top) <= 90.0
+    assert abs(bottom) <= 90.0
+    # and the band that is inked has to be real: northern Greenland reaches
+    # into the 80s, so a coastline drawn only within +-60 would mean the
+    # opposite mistake -- squashed rather than stretched
+    assert top > 60.0
+    assert bottom < -60.0


### PR DESCRIPTION
Integrates `prep hfun` into the `view` server, as requested, and fixes two
rendering bugs it exposed.

## One server, one port

`view`, `prep view` and `prep hfun` each served a complete page, and each was
its own process on its own port — three SSH tunnels from a compute node to look
at one experiment.

```bash
gmpas view /path/to/run/ --hfun hfun.py     # data + mesh + hfun
gmpas prep view mesh.nc --hfun hfun.py      # mesh + hfun
gmpas prep hfun hfun.py --mesh mesh.nc      # hfun + mesh
```

```
2 sources on one port:
  /mesh  mesh — maritime.region.nc · 8,228 cells
  /hfun  hfun — hfun.py · 12 to 60 km · gradient 0.0300
```

`/` lists what is available, and every page carries a switcher. Opening a run
gives the mesh page for free, since a run always brings its mesh with it. Every
source is constructed before the server binds, so a bad path is an error at the
prompt rather than a 500 in a browser tab.

**A single source is unchanged.** It is mounted at the root as well as under
its slug, with no index and no switcher, so `gmpas prep view mesh.nc` serves
exactly the paths it always did — there is a test for that.

Each page keeps its own handler and routes. The only thing they gave up is
absolute API URLs: one mounted at `/mesh/` that fetched `/api/meta` would reach
the wrong viewer, so they fetch `api/meta` relative to where they are served,
which at the root resolves to what they used before. `_send` moves to a shared
`PageHandler` base — mounting works by calling one handler's `do_GET` with
another's `self`, so that helper is a contract between them, not a coincidence
worth copy-pasting three times.

## Two rendering bugs, both fixed

**Coastlines slid over the field as you zoomed.** Reported against the hfun
page. `_overlay` set its limits through `set_extent`, which clamps latitude to
the projection's valid domain — but frames are rendered 1.4× wider than the
window, so every global view asks for latitudes past a pole. The clamped ±90
was then stretched to fill the figure by `set_aspect("auto")`, drawing the
coastlines as though they spanned ±117 while the data raster spanned the ±126
it was asked for:

| | inked rows map to |
|---|---|
| before | lat **117.2 … −117.2** (stretched) |
| after | lat **84.4 … −86.1** (real coastline latitudes) |

Since the overshoot changes with zoom, so did the offset — which is exactly the
"positions change as you zoom" symptom. Limits are now set directly, with no
clamping.

**The hfun frame invented data past the pole.** `get_hfun` answers for
|lat| > 90 — sin and cos are periodic, so it folds back and mirrors the other
hemisphere — and that band has no coastline to sit under. It is blanked now.

Neither bug was introduced by the dashboard. A regional mesh never reaches ±90,
and the hfun page is simply the first one that is always global.

## Verification

- **242 passed**, 20 new. The dashboard tests go through a real socket rather
  than calling handlers directly, since prefix stripping, the `/mesh` → `/mesh/`
  redirect and relative-URL resolution are exactly what a direct call skips.
- The coastline fix has a regression test asserting no ink past ±90 **and** ink
  beyond ±60 — the opposite mistake, squashing rather than stretching, would
  otherwise pass.
- Checked in a browser against the real `maritime.region.nc` and the tutorial's
  `hfun.py`, at the global view and zoomed in: the switcher navigates, and
  Florida, Cuba, Yucatán, Hudson Bay, Britain and Iberia all sit correctly on
  the field at both zoom levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
