### PR TITLE
prep: run JIGSAW from an hfun.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ gmpas scrip      history.2012-02-25_12.00.00.nc -o src.scrip.nc
 gmpas target     -o dst.scrip.nc
 gmpas prep view  mesh.nc
 gmpas prep hfun  hfun.py
+gmpas prep generate hfun.py -o mesh/
 ```
 
 `info` summarises the mesh and lists variables grouped by the element they
@@ -320,6 +321,60 @@ so a bad path is an error at the prompt rather than a 500 in a browser tab.
 
 A single source is unchanged: it is served at the root, with no index and no
 switcher, on exactly the paths it always used.
+
+### Generating a mesh with JIGSAW
+
+```bash
+export JIGSAWDIR=/path/to/jigsaw/build/src     # or wherever it installed
+gmpas prep generate hfun.py -o mesh/
+```
+
+Same division of labour as the remapping side: gmpas does not generate the mesh
+itself, it prepares every input JIGSAW needs, shells out, and reads the result
+back. What it adds is everything around the call.
+
+```
+  hfun.py: 12 to 60 km, max gradient 0.0300
+  sampling hfun onto 3336 x 1668 (5.6M points)
+  wrote GEOM.msh, HFUN.msh (32 MB) and MESH.jig
+  running jigsaw — this is the slow part
+  MESH.msh: 9,734 generating points, 19,464 triangles in 8.7 s
+```
+
+`HFUN.msh` is written the way `create_hfun.py` writes it — the same grid, the
+same `meshgrid(lats, lons)` argument order, and therefore the same
+longitude-major value ordering. Getting that order wrong would transpose the
+distance function and refine the wrong part of the planet *without failing*, so
+there is a test comparing the file back against the function elementwise.
+
+**The distance function is checked before any time is spent.** Generation takes
+minutes; measuring the gradient takes a second. A transition steeper than the
+0.03 guideline stops the run rather than producing a mesh you would throw away:
+
+```
+gmpas: hfun.py has a maximum cell size gradient of 0.0501 at 41.2, -95.0,
+above the 0.03 guideline. A mesh built from it will change cell size too
+quickly to be well behaved.
+  Widen the transition region, or raise hfun_min.
+  Pass --allow-steep to generate it anyway.
+```
+
+JIGSAW is found by `--jigsaw`, then `$JIGSAWDIR`, then `PATH` — in that order.
+PATH is last because JIGSAW installs wherever `CMAKE_INSTALL_PREFIX` pointed
+and its build tree leaves the binary in `build/src/`, so on most machines it is
+not on PATH at all. `$JIGSAWDIR` accepts either the binary or the directory
+holding it.
+
+`MESH.msh` is reused if it is already there, unless `--force`. `--init` passes
+an initial point set through to `INIT_FILE`, which is what gives a
+quasi-uniform mesh icosahedral structure — a constant `HFUN` alone produces
+7-sided cells.
+
+**This is the first half of the workflow.** Turning `MESH.msh` into an MPAS
+`grid.nc` still needs `convert_jigsaw.py`, `create_density.py` and then
+`mkgrid`, and gmpas does not run those yet — `mkgrid` needs MPI and PnetCDF,
+which is a separate problem from running JIGSAW. The command says so when it
+finishes.
 
 ### Looking at a mesh before it exists
 
@@ -554,10 +609,12 @@ KD-tree gives area weights by supersampling a target cell and counting which
 source cells the samples land in, which — unlike barycentric sampling —
 actually conserves cell integrals.
 
-Preprocessing has begun: `gmpas prep view` and `gmpas prep hfun` are
-implemented — the two ends of looking at a mesh, one after it exists and one
-before. `gmpas prep generate` — actually running JIGSAW — is not
-([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)). That one is
-blocked on a question rather than on effort: JIGSAW writes its own `.msh`
-format, and converting it to a mesh `MpasMesh.load()` can open conventionally
-needs `mkgrid`, which wants MPI and PnetCDF.
+Preprocessing now covers `prep view`, `prep hfun` and `prep generate` — looking
+at a mesh after it exists, looking at one before it exists, and running JIGSAW
+to get from the second to the first.
+
+What is still missing is the last leg, from JIGSAW's `MESH.msh` to an MPAS
+`grid.nc` ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)).
+`convert_jigsaw.py` and `create_density.py` are small and pure Python;
+`mkgrid` is the real obstacle, since it needs MPI and PnetCDF and so cannot
+simply be vendored.

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -107,6 +107,9 @@ examples:
   gmpas view  run/                          browse interactively in a browser
   gmpas view  run/ --host 0.0.0.0 --no-browser   on an HPC compute node
 
+  gmpas prep hfun     hfun.py --check     the mesh you are about to build
+  gmpas prep generate hfun.py -o mesh/    run JIGSAW and build it
+
 on a cluster the job runs on a compute node but your tunnel lands on the login
 node, so bind all interfaces and tunnel to the node by name:
 
@@ -120,6 +123,8 @@ one time series across files, which is how MPAS writes output.
 environment:
   GMPAS_CACHE_DIR   where cached mesh geometry goes (default ~/.cache/gmpas/mesh)
   GMPAS_DATA_DIR    tried first when resolving relative paths
+  JIGSAWDIR         the jigsaw executable, or the directory holding it,
+                    for `gmpas prep generate`
 """
 
 
@@ -554,6 +559,18 @@ def _prep_hfun(args) -> int:
                       hfun_path=args.hfun_file)
 
 
+def _prep_generate(args) -> int:
+    from .prep.generate import generate, next_steps
+
+    print(banner())
+    print(f"generating a mesh from {args.hfun_file}")
+    result = generate(args.hfun_file, out_dir=args.out, jigsaw=args.jigsaw,
+                      qlim=args.qlim, init=args.init, force=args.force,
+                      allow_steep=args.allow_steep)
+    print(next_steps(result, args.out))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gmpas",
@@ -657,7 +674,7 @@ def build_parser() -> argparse.ArgumentParser:
     pre = sub.add_parser("prep", help="preprocessing: inspect and build meshes",
                          description="Preprocessing steps, which run before "
                                      "there is any model output to plot.")
-    presub = pre.add_subparsers(dest="prep_cmd", metavar="{view,hfun}")
+    presub = pre.add_subparsers(dest="prep_cmd", metavar="{view,hfun,generate}")
     # a bare `gmpas prep` should list its steps, not error
     pre.set_defaults(func=lambda _a, _p=pre: (_p.print_help(), 0)[1])
 
@@ -704,6 +721,29 @@ def build_parser() -> argparse.ArgumentParser:
     ph.add_argument("--no-browser", action="store_true",
                     help="do not open a browser (useful over an SSH tunnel)")
     ph.set_defaults(func=_prep_hfun)
+
+    pg = presub.add_parser("generate", help="run JIGSAW to build a mesh from "
+                                            "an hfun.py")
+    pg.add_argument("hfun_file", metavar="HFUN",
+                    help="a JIGSAW hfun.py defining hfun_min and "
+                         "get_hfun(lon, lat)")
+    pg.add_argument("-o", "--out", default="mesh",
+                   help="directory for the JIGSAW files (default: mesh/)")
+    pg.add_argument("--jigsaw", help="path to the jigsaw executable, or the "
+                                     "directory holding it. Defaults to "
+                                     "$JIGSAWDIR, then PATH")
+    pg.add_argument("--init", help="a JIGSAW mesh file of initial points, for "
+                                   "a quasi-uniform mesh with icosahedral "
+                                   "structure (INIT_FILE)")
+    pg.add_argument("--qlim", type=float, default=0.9375,
+                    help="JIGSAW's OPTM_QLIM mesh-quality limit "
+                         "(default 0.9375)")
+    pg.add_argument("--force", action="store_true",
+                    help="regenerate even if MESH.msh already exists")
+    pg.add_argument("--allow-steep", action="store_true",
+                    help="generate even if the cell size gradient is above "
+                         "the guideline")
+    pg.set_defaults(func=_prep_generate)
     return p
 
 
@@ -737,11 +777,12 @@ def main(argv=None) -> int:
         return 0
 
     from .mesh import MeshCacheError
+    from .prep.generate import GenerateError
     from .remap import RemapError
 
     try:
         return args.func(args)
-    except (RemapError, MeshCacheError) as exc:
+    except (RemapError, MeshCacheError, GenerateError) as exc:
         print(f"\ngmpas: {exc}", file=sys.stderr)
         return 1
     except (FileNotFoundError, KeyError, ValueError) as exc:

--- a/src/gmpas/prep/generate.py
+++ b/src/gmpas/prep/generate.py
@@ -1,0 +1,270 @@
+"""Run JIGSAW from an `hfun.py`, the way `remap` runs ESMF.
+
+Same division of labour as the remapping side: gmpas does not generate the mesh
+itself, it prepares every input JIGSAW needs, shells out, and reads the result
+back. What it adds is everything around the call -- finding the executable,
+checking the distance function before spending the time, reusing work that is
+already done, and turning a non-zero exit into a sentence.
+
+This covers the first half of the mini-tutorial's workflow:
+
+    hfun.py --> HFUN.msh --+
+             GEOM.msh -----+--> jigsaw --> MESH.msh
+             MESH.jig -----+
+
+The second half (`convert_jigsaw.py`, `create_density.py`, then `mkgrid` to get
+`grid.nc`) is not here yet; `mkgrid` needs MPI and PnetCDF, which is a separate
+problem from running JIGSAW.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .hfun import GRADIENT_GUIDELINE, R_EARTH_KM, Hfun, analysis_grid, diagnose
+
+#: environment variable pointing at JIGSAW, for a build that is not on PATH --
+#: which is the normal case, since JIGSAW installs wherever CMAKE_INSTALL_PREFIX
+#: said. Either the executable itself or the directory holding it.
+JIGSAW_ENV = "JIGSAWDIR"
+
+#: what `MESH.jig` says. Straight from the tutorial; MESH_FILE and the two
+#: input files are filled in per run.
+JIG_TEMPLATE = """# written by gmpas prep generate
+VERBOSITY=1
+GEOM_FILE={geom}
+HFUN_FILE={hfun}
+HFUN_SCAL=absolute
+HFUN_HMAX=inf
+HFUN_HMIN=0.0
+MESH_FILE={mesh}
+MESH_DIMS=2
+OPTM_QLIM={qlim}
+"""
+
+#: JIGSAW's mesh-quality limit, as the tutorial sets it
+DEFAULT_QLIM = 0.9375
+
+
+class GenerateError(RuntimeError):
+    """Something the mesh generation cannot proceed without."""
+
+
+@dataclass
+class Generated:
+    """What a run produced."""
+
+    mesh_msh: Path
+    points: int
+    triangles: int
+    seconds: float
+    reused: bool
+
+
+# ------------------------------------------------------------- the executable
+
+
+def find_jigsaw(explicit: str | Path | None = None) -> Path:
+    """Locate the JIGSAW executable: `--jigsaw`, then `$JIGSAWDIR`, then PATH.
+
+    PATH last, not first. JIGSAW installs wherever `CMAKE_INSTALL_PREFIX`
+    pointed and its build tree leaves the binary in `build/src/`, so on most
+    machines it is not on PATH at all and `$JIGSAWDIR` is how you say where it
+    went. Either form works — the directory holding it, or the binary itself —
+    because both are things people reasonably put in that variable.
+    """
+    if explicit:
+        p = Path(explicit).expanduser()
+        if p.is_dir():                       # a build directory, not the binary
+            p = p / "jigsaw"
+        if not p.exists():
+            raise GenerateError(
+                f"no jigsaw executable at {p}. Point --jigsaw or "
+                f"${JIGSAW_ENV} at the binary, or at the directory holding it."
+            )
+        if not os.access(p, os.X_OK):
+            raise GenerateError(f"{p} is not executable")
+        return p.resolve()
+
+    env = os.environ.get(JIGSAW_ENV)
+    if env:
+        return find_jigsaw(env)
+
+    found = shutil.which("jigsaw")
+    if found:
+        return Path(found).resolve()
+
+    raise GenerateError(
+        f"jigsaw is not on your PATH and ${JIGSAW_ENV} is not set, so the "
+        f"mesh cannot be generated. Build it with:\n"
+        f"    git clone https://github.com/dengwirda/jigsaw.git\n"
+        f"    cd jigsaw && mkdir build && cd build\n"
+        f"    cmake .. -DCMAKE_BUILD_TYPE=Release "
+        f"-DCMAKE_INSTALL_PREFIX=<where>\n"
+        f"    make -j 4 install\n"
+        f"then point gmpas at it:\n"
+        f"    export {JIGSAW_ENV}=<where>/bin          # or .../build/src\n"
+        f"or pass --jigsaw. gmpas deliberately does not generate meshes itself."
+    )
+
+
+# ------------------------------------------------------------- JIGSAW inputs
+
+
+def write_geom(path: Path, radius_km: float = R_EARTH_KM) -> Path:
+    """The sphere JIGSAW is meshing. Two lines, and no reason for more."""
+    path.write_text(f"MSHID=3;ellipsoid-mesh\n"
+                    f"RADII={radius_km};{radius_km};{radius_km}\n")
+    return path
+
+
+def write_hfun(hfun: Hfun, path: Path, quiet: bool = False) -> tuple[Path, int]:
+    """Sample the distance function onto JIGSAW's lat-lon grid and write it.
+
+    This is `create_hfun.py`, reproduced rather than approximated: the same
+    grid, the same `meshgrid(lats, lons)` argument order, and therefore the
+    same value ordering in the file. The one difference is that the values are
+    formatted in bulk instead of one f-string per line, because at a 3 km
+    hfun_min that loop is tens of millions of iterations.
+    """
+    lons, lats = analysis_grid(hfun.hfun_min)
+    latgrid, longrid = np.meshgrid(lats, lons)        # (nlon, nlat)
+    values = hfun.sample_radians(longrid, latgrid)
+
+    npts = values.size
+    if not quiet:
+        print(f"  sampling hfun onto {lons.size} x {lats.size} "
+              f"({npts / 1e6:.1f}M points)")
+
+    with open(path, "w") as f:
+        f.write("MSHID=3;ellipsoid-grid\n")
+        f.write("NDIMS=2\n")
+        f.write(f"COORD=1;{lons.size}\n")
+        f.write("\n".join(map(str, lons.tolist())))
+        f.write(f"\nCOORD=2;{lats.size}\n")
+        f.write("\n".join(map(str, lats.tolist())))
+        f.write(f"\nVALUE={npts}; 1\n")
+        # chunked so the joined string never rivals the array itself in size
+        flat = values.ravel()
+        for i in range(0, npts, 1_000_000):
+            f.write("\n".join(map(str, flat[i:i + 1_000_000].tolist())))
+            f.write("\n")
+    return path, npts
+
+
+def write_jig(path: Path, geom: str, hfun: str, mesh: str,
+              qlim: float = DEFAULT_QLIM, init: str | None = None) -> Path:
+    """The config file. Names are relative, since JIGSAW runs in the out dir."""
+    text = JIG_TEMPLATE.format(geom=geom, hfun=hfun, mesh=mesh, qlim=qlim)
+    if init:
+        # an initial point set imposes icosahedral structure, which a uniform
+        # HFUN alone will not give -- it produces 7-sided cells instead
+        text += f"INIT_FILE={init}\n"
+    path.write_text(text)
+    return path
+
+
+# --------------------------------------------------------------- the mesh out
+
+
+def read_msh_counts(path: Path) -> tuple[int, int]:
+    """POINT= and TRIA3= from a JIGSAW mesh file, without reading the body."""
+    points = triangles = 0
+    with open(path) as f:
+        for line in f:
+            if line.startswith("POINT="):
+                points = int(line.split("=", 1)[1])
+            elif line.startswith("TRIA3="):
+                triangles = int(line.split("=", 1)[1])
+                break
+    return points, triangles
+
+
+# ------------------------------------------------------------------- the run
+
+
+def generate(hfun_path, out_dir="mesh", jigsaw: str | Path | None = None,
+             qlim: float = DEFAULT_QLIM, init: str | None = None,
+             force: bool = False, quiet: bool = False,
+             allow_steep: bool = False) -> Generated:
+    """Take an `hfun.py` all the way to a JIGSAW `MESH.msh`.
+
+    Everything is checked before anything is spent: the executable is located,
+    the distance function is loaded and measured, and a transition steeper than
+    the guideline stops the run rather than producing a mesh that has to be
+    thrown away. Generation takes minutes and the check takes a second.
+    """
+    tool = find_jigsaw(jigsaw)
+    hfun = Hfun.load(hfun_path)
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    mesh_msh = out / "MESH.msh"
+
+    if mesh_msh.exists() and not force:
+        points, triangles = read_msh_counts(mesh_msh)
+        if not quiet:
+            print(f"  reusing {mesh_msh} ({points:,} points)")
+        return Generated(mesh_msh, points, triangles, 0.0, reused=True)
+
+    d = diagnose(hfun)
+    if not quiet:
+        print(f"  {hfun.path.name}: {d.h_min:.4g} to {d.h_max:.4g} km, "
+              f"max gradient {d.max_gradient:.4f}")
+    if not d.within_guideline and not allow_steep:
+        raise GenerateError(
+            f"{hfun.path.name} has a maximum cell size gradient of "
+            f"{d.max_gradient:.4f} at {d.at_lat:.2f}, {d.at_lon:.2f}, above "
+            f"the {GRADIENT_GUIDELINE} guideline. A mesh built from it will "
+            f"change cell size too quickly to be well behaved.\n"
+            f"  Widen the transition region, or raise hfun_min.\n"
+            f"  Pass --allow-steep to generate it anyway."
+        )
+
+    write_geom(out / "GEOM.msh")
+    _, npts = write_hfun(hfun, out / "HFUN.msh", quiet=quiet)
+    write_jig(out / "MESH.jig", "GEOM.msh", "HFUN.msh", "MESH.msh",
+              qlim=qlim, init=init)
+    if not quiet:
+        size = (out / "HFUN.msh").stat().st_size / 1e6
+        print(f"  wrote GEOM.msh, HFUN.msh ({size:.0f} MB) and MESH.jig")
+        print(f"  running {tool.name} — this is the slow part")
+
+    t0 = time.perf_counter()
+    done = subprocess.run([str(tool), "MESH.jig"], cwd=out,
+                          capture_output=True, text=True)
+    seconds = time.perf_counter() - t0
+
+    if done.returncode != 0 or not mesh_msh.exists():
+        tail = (done.stdout or done.stderr or "").strip().splitlines()[-8:]
+        raise GenerateError(
+            f"jigsaw failed (exit {done.returncode}) after {seconds:.1f} s.\n"
+            + "\n".join(f"    {line}" for line in tail)
+        )
+
+    points, triangles = read_msh_counts(mesh_msh)
+    if not quiet:
+        print(f"  {mesh_msh.name}: {points:,} generating points, "
+              f"{triangles:,} triangles in {seconds:.1f} s")
+    return Generated(mesh_msh, points, triangles, seconds, reused=False)
+
+
+def next_steps(result: Generated, out_dir) -> str:
+    """What still has to happen to get an MPAS `grid.nc`, and honestly why."""
+    return (
+        f"\n{result.mesh_msh} holds the generating points and their "
+        f"triangulation.\nTurning it into an MPAS grid.nc still needs the "
+        f"tutorial's remaining steps:\n"
+        f"    convert_jigsaw.py  MESH.msh -> SaveVertices, SaveTriangles\n"
+        f"    create_density.py  -> SaveDensity\n"
+        f"    cp hfun.py SaveCode\n"
+        f"    mkgrid <nominalMinDc_metres>  -> grid.nc, graph.info\n"
+        f"gmpas does not run these yet: mkgrid needs MPI and PnetCDF."
+    )

--- a/src/gmpas/prep/hfun.py
+++ b/src/gmpas/prep/hfun.py
@@ -249,6 +249,16 @@ def diagnose(hfun: Hfun) -> Diagnosis:
     # cos(lat), which is what makes a degree of longitude worth less near a pole
     dh_dy = np.gradient(h, axis=1) / (dlat * R_EARTH_KM)
     dh_dlon = np.gradient(h, axis=0) / dlon
+
+    # Longitude is periodic, so the ends of the array are not a boundary and
+    # `np.gradient`'s one-sided difference there is simply wrong -- it is first
+    # order where the interior is second, and the error shows up as a spurious
+    # maximum sitting exactly on the antimeridian. The grid runs -pi to +pi
+    # inclusive, so its first and last columns are the same meridian and the
+    # true neighbours of column 0 are columns 1 and -2.
+    dh_dlon[0] = (h[1] - h[-2]) / (2.0 * dlon)
+    dh_dlon[-1] = dh_dlon[0]
+
     dh_dx = dh_dlon / (R_EARTH_KM * np.cos(latgrid))
 
     grad = np.hypot(dh_dx, dh_dy)[:, 1:-1]          # drop the polar rows

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,280 @@
+"""Preparing JIGSAW's inputs, and running it.
+
+JIGSAW itself is an external executable that most machines will not have, so
+the tests that need it are skipped when it is absent — exactly as the remapping
+tests treat ESMF. Everything up to the call is tested unconditionally, because
+that is the part gmpas is actually responsible for.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import numpy as np
+import pytest
+
+from gmpas.prep.generate import (
+    GenerateError,
+    find_jigsaw,
+    generate,
+    read_msh_counts,
+    write_geom,
+    write_hfun,
+    write_jig,
+)
+from gmpas.prep.hfun import Hfun
+
+COARSE = 200.0
+
+GENTLE = """
+import numpy as np
+
+hfun_min = {h_min}
+R = 6371.229
+
+def get_hfun(lon, lat):
+    lam, phi = np.radians(0.0), np.radians(0.0)
+    c = np.array([np.cos(lam) * np.cos(phi),
+                  np.sin(lam) * np.cos(phi), np.sin(phi)])
+    p = np.column_stack([(np.cos(lon) * np.cos(lat)).ravel(),
+                         (np.sin(lon) * np.cos(lat)).ravel(),
+                         np.sin(lat).ravel()])
+    r = R * np.arccos(np.clip(p @ c, -1.0, 1.0))
+    return np.interp(r, [0, 2000, {t_end}],
+                     [hfun_min, hfun_min, {h_max}]).reshape(np.shape(lon))
+"""
+
+
+def write_hfun_py(path, h_min=COARSE, h_max=400.0, t_end=20000.0):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(GENTLE.format(h_min=h_min, h_max=h_max, t_end=t_end))
+    return path
+
+
+jigsaw_available = pytest.mark.skipif(
+    shutil.which("jigsaw") is None and not os.environ.get("JIGSAWDIR"),
+    reason="jigsaw is not installed (set JIGSAWDIR or put it on PATH)",
+)
+
+
+# ------------------------------------------------------------- the executable
+
+
+def test_a_missing_jigsaw_says_how_to_get_one(monkeypatch):
+    monkeypatch.delenv("JIGSAWDIR", raising=False)
+    monkeypatch.setattr(shutil, "which", lambda _n: None)
+
+    with pytest.raises(GenerateError) as exc:
+        find_jigsaw()
+    msg = str(exc.value)
+    assert "github.com/dengwirda/jigsaw" in msg      # where to get it
+    assert "JIGSAWDIR" in msg                        # and how to point at it
+    assert "--jigsaw" in msg
+
+
+def test_jigsawdir_may_be_the_directory_or_the_binary(tmp_path, monkeypatch):
+    """Both are things people reasonably put in a variable called *DIR."""
+    exe = tmp_path / "jigsaw"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+
+    monkeypatch.setenv("JIGSAWDIR", str(tmp_path))
+    assert find_jigsaw() == exe.resolve()
+
+    monkeypatch.setenv("JIGSAWDIR", str(exe))
+    assert find_jigsaw() == exe.resolve()
+
+
+def test_an_explicit_jigsaw_beats_the_environment(tmp_path, monkeypatch):
+    good = tmp_path / "good" / "jigsaw"
+    good.parent.mkdir()
+    good.write_text("#!/bin/sh\n")
+    good.chmod(0o755)
+    monkeypatch.setenv("JIGSAWDIR", "/nowhere/at/all")
+
+    assert find_jigsaw(good) == good.resolve()
+
+
+def test_an_explicit_path_that_is_not_there_is_named(tmp_path):
+    with pytest.raises(GenerateError, match="no jigsaw executable at"):
+        find_jigsaw(tmp_path / "nope")
+
+
+def test_a_build_directory_resolves_to_the_binary_inside_it(tmp_path):
+    exe = tmp_path / "jigsaw"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    assert find_jigsaw(tmp_path) == exe.resolve()
+
+
+def test_a_non_executable_file_is_refused(tmp_path):
+    exe = tmp_path / "jigsaw"
+    exe.write_text("not runnable")
+    exe.chmod(0o644)
+    with pytest.raises(GenerateError, match="not executable"):
+        find_jigsaw(exe)
+
+
+# ------------------------------------------------------------ JIGSAW's inputs
+
+
+def test_geom_is_the_sphere_jigsaw_expects(tmp_path):
+    text = write_geom(tmp_path / "GEOM.msh").read_text()
+    assert text.startswith("MSHID=3;ellipsoid-mesh")
+    assert "RADII=6371.229;6371.229;6371.229" in text
+
+
+def test_the_jig_file_carries_the_tutorial_settings(tmp_path):
+    text = write_jig(tmp_path / "MESH.jig", "GEOM.msh", "HFUN.msh",
+                     "MESH.msh").read_text()
+    for line in ("GEOM_FILE=GEOM.msh", "HFUN_FILE=HFUN.msh",
+                 "MESH_FILE=MESH.msh", "HFUN_SCAL=absolute",
+                 "HFUN_HMAX=inf", "HFUN_HMIN=0.0", "MESH_DIMS=2",
+                 "OPTM_QLIM=0.9375"):
+        assert line in text
+    assert "INIT_FILE" not in text            # only when one is asked for
+
+
+def test_an_init_file_is_added_only_when_given(tmp_path):
+    text = write_jig(tmp_path / "MESH.jig", "GEOM.msh", "HFUN.msh", "MESH.msh",
+                     init="ICOS.msh").read_text()
+    assert "INIT_FILE=ICOS.msh" in text
+
+
+def test_hfun_msh_matches_what_create_hfun_would_write(tmp_path):
+    """The header, the grid and the value ordering, against the script itself.
+
+    `create_hfun.py` builds its grid with `meshgrid(lats, lons)` and flattens
+    the result, so the values run longitude-major. Getting that order wrong
+    would transpose the whole distance function and JIGSAW would refine the
+    wrong place, without failing.
+    """
+    hfun = Hfun.load(write_hfun_py(tmp_path / "hfun.py"))
+    path, npts = write_hfun(hfun, tmp_path / "HFUN.msh", quiet=True)
+
+    lines = path.read_text().splitlines()
+    assert lines[0] == "MSHID=3;ellipsoid-grid"
+    assert lines[1] == "NDIMS=2"
+
+    nlon = int(lines[2].split(";")[1])
+    nlat = int(lines[3 + nlon].split(";")[1])
+    assert nlon == 2 * nlat                    # create_hfun.py's shape
+    assert npts == nlon * nlat
+
+    lons = np.array([float(v) for v in lines[3:3 + nlon]])
+    lats = np.array([float(v) for v in lines[4 + nlon:4 + nlon + nlat]])
+    assert lons[0] == pytest.approx(-np.pi)
+    assert lons[-1] == pytest.approx(np.pi)
+    assert lats[0] == pytest.approx(-0.5 * np.pi)
+    assert lats[-1] == pytest.approx(0.5 * np.pi)
+
+    head = lines[4 + nlon + nlat]
+    assert head.startswith(f"VALUE={npts};")
+
+    values = np.array([float(v) for v in lines[5 + nlon + nlat:]])
+    assert values.size == npts
+
+    # the same call the script makes, compared elementwise
+    latgrid, longrid = np.meshgrid(lats, lons)
+    assert values == pytest.approx(hfun.sample_radians(longrid, latgrid).ravel())
+
+
+def test_msh_counts_are_read_without_the_body(tmp_path):
+    p = tmp_path / "MESH.msh"
+    p.write_text("# comment\nMSHID=3;EUCLIDEAN-MESH\nNDIMS=3\n"
+                 "POINT=5\n1;2;3;0\n" * 1 + "TRIA3=6\n1;2;3;0\n")
+    assert read_msh_counts(p) == (5, 6)
+
+
+# ----------------------------------------------------------------- the guard
+
+
+def test_a_steep_transition_stops_the_run_before_jigsaw(tmp_path):
+    """Generation costs minutes; the check costs a second."""
+    steep = write_hfun_py(tmp_path / "steep" / "hfun.py",
+                          h_max=400.0, t_end=2400.0)
+    with pytest.raises(GenerateError) as exc:
+        generate(steep, out_dir=tmp_path / "out", jigsaw="/bin/echo")
+
+    msg = str(exc.value)
+    assert "gradient" in msg
+    assert "--allow-steep" in msg
+    assert not (tmp_path / "out" / "HFUN.msh").exists()   # nothing was spent
+
+
+def test_the_executable_is_found_before_the_function_is_read(tmp_path, monkeypatch):
+    """A missing jigsaw must not be reported only after a slow sampling pass.
+
+    The hfun file here is invalid too, so whichever check runs first decides
+    the error -- which is exactly what this pins down.
+    """
+    monkeypatch.delenv("JIGSAWDIR", raising=False)
+    monkeypatch.setattr(shutil, "which", lambda _n: None)
+
+    monkey = tmp_path / "hfun.py"
+    monkey.write_text("hfun_min = 12.0\n")
+    with pytest.raises(GenerateError, match="dengwirda"):
+        generate(monkey, out_dir=tmp_path / "out", jigsaw=None)
+
+
+# ------------------------------------------------------------------ real runs
+
+
+@jigsaw_available
+def test_jigsaw_produces_a_sphere_triangulation(tmp_path):
+    """A closed triangulation of a sphere has exactly 2V - 4 triangles.
+
+    That is Euler's formula, and it holds for any valid result whatever the
+    resolution, so it checks the run really produced a mesh rather than a file.
+    """
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    result = generate(hfun, out_dir=tmp_path / "out", quiet=True)
+
+    assert result.points > 100
+    assert result.triangles == 2 * result.points - 4
+    assert result.mesh_msh.exists()
+    assert not result.reused
+
+
+@jigsaw_available
+def test_a_second_run_reuses_the_mesh_unless_forced(tmp_path):
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    out = tmp_path / "out"
+
+    first = generate(hfun, out_dir=out, quiet=True)
+    again = generate(hfun, out_dir=out, quiet=True)
+    assert again.reused
+    assert again.points == first.points
+    assert again.seconds == 0.0
+
+    forced = generate(hfun, out_dir=out, quiet=True, force=True)
+    assert not forced.reused
+
+
+def test_a_failing_jigsaw_is_reported_in_its_own_words(tmp_path):
+    """A stub, so this runs everywhere: what matters is that a non-zero exit
+    becomes a GenerateError carrying the tool's last lines, not a silent
+    success or a bare CalledProcessError."""
+    stub = tmp_path / "jigsaw"
+    stub.write_text("#!/bin/sh\necho '**parse error: no such file'\nexit 3\n")
+    stub.chmod(0o755)
+
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    with pytest.raises(GenerateError) as exc:
+        generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True)
+
+    msg = str(exc.value)
+    assert "exit 3" in msg
+    assert "parse error" in msg               # jigsaw's own words, not ours
+
+
+def test_a_jigsaw_that_exits_cleanly_without_a_mesh_still_fails(tmp_path):
+    """Exit 0 is not proof: the file has to be there."""
+    stub = tmp_path / "jigsaw"
+    stub.write_text("#!/bin/sh\nexit 0\n")
+    stub.chmod(0o755)
+
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    with pytest.raises(GenerateError, match="exit 0"):
+        generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True)


### PR DESCRIPTION
The first half of the mesh-generation workflow, in the same shape as `remap`.
Partially addresses #15.

```bash
export JIGSAWDIR=/path/to/jigsaw/build/src
gmpas prep generate hfun.py -o mesh/
```

```
  hfun.py: 12 to 60 km, max gradient 0.0300
  sampling hfun onto 3336 x 1668 (5.6M points)
  wrote GEOM.msh, HFUN.msh (32 MB) and MESH.jig
  running jigsaw — this is the slow part
  MESH.msh: 361,317 generating points, 722,630 triangles in 295.5 s
```

## Same division of labour as remapping

gmpas does not generate the mesh any more than it computes conservative
weights. It prepares every input JIGSAW needs, shells out, and reads the result
back. What it adds is everything around the call — finding the executable,
checking the distance function before spending the time, reusing work already
done, and turning a non-zero exit into a sentence with the tool's own last
lines in it.

## The one mistake that would not announce itself

`HFUN.msh` is written the way `create_hfun.py` writes it: the same grid, the
same `meshgrid(lats, lons)` argument order, and therefore the same
**longitude-major** value ordering. Transposing that would refine the wrong
part of the planet and JIGSAW would succeed anyway — no error, just a wrong
mesh. So there is a test that reads the file back, reconstructs the grid from
its own `COORD=1`/`COORD=2` blocks, and compares the values against the
function elementwise.

## Checked before anything is spent

Generation takes minutes; measuring the gradient takes a second. A transition
steeper than the 0.03 guideline stops the run rather than producing a mesh you
would throw away, and `--allow-steep` overrides it. The executable is located
*before* the function is read, so a missing jigsaw is not reported only after a
slow sampling pass — there is a test pinning that ordering, using an input that
is invalid in both ways at once.

## A real bug in the gradient this depends on

Writing the guard exposed a defect in `diagnose()`. `np.gradient` used a
one-sided difference at the ends of the longitude axis — but longitude is
periodic, and the grid runs −π to +π inclusive, so its first and last columns
are *the same meridian*. That difference is first order where the interior is
second, and the error appeared as a spurious maximum sitting exactly on the
antimeridian:

| | measured max gradient | located at |
|---|---|---|
| before | **0.0301** | `lon = −180.00` — the array edge |
| after | **0.0300** | inside the transition, where it belongs |

A function with an analytic slope of exactly 0.03 was therefore *refused* by
the new guard. Both my test function and the concentric-rings example are
designed at exactly 0.03, as is the tutorial's own, so this was not a corner
case.

## Finding JIGSAW

`--jigsaw`, then `$JIGSAWDIR`, then `PATH` — in that order. PATH is last on
purpose: JIGSAW installs wherever `CMAKE_INSTALL_PREFIX` pointed and its build
tree leaves the binary in `build/src/`, so on most machines it is not on PATH
at all. `$JIGSAWDIR` accepts either the binary or the directory holding it,
since both are things people reasonably put in a variable named that way.

## Verification

- **259 passed**, 22 new. The tests needing a real JIGSAW skip when it is
  absent, exactly as the remapping tests treat ESMF; everything up to the call
  is unconditional, because that is the part gmpas is responsible for. Failure
  handling is tested with stub executables, so it runs everywhere — including
  the case of exit 0 with no mesh file, which is not proof of success.
- End to end against the tutorial's own `hfun.py`: **361,317 generating points,
  722,630 triangles, 295.5 s**. Euler holds exactly — a closed sphere
  triangulation has `2V − 4` faces — and the deck quotes ~346,000 cells for its
  variant of the same example, the difference being its 960 km transition
  against the repo file's 1600 km.

## Not included

`convert_jigsaw.py`, `create_density.py` and `mkgrid`, so this stops at
`MESH.msh` rather than `grid.nc`. The first two are small and pure Python;
`mkgrid` needs MPI and PnetCDF and is the real obstacle. The command prints the
remaining steps when it finishes rather than leaving you to guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
