### PR TITLE
prep: carry the run on to everything mkgrid reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,11 +370,48 @@ an initial point set through to `INIT_FILE`, which is what gives a
 quasi-uniform mesh icosahedral structure — a constant `HFUN` alone produces
 7-sided cells.
 
-**This is the first half of the workflow.** Turning `MESH.msh` into an MPAS
-`grid.nc` still needs `convert_jigsaw.py`, `create_density.py` and then
-`mkgrid`, and gmpas does not run those yet — `mkgrid` needs MPI and PnetCDF,
-which is a separate problem from running JIGSAW. The command says so when it
-finishes.
+After JIGSAW, the run continues into the two conversion steps, so the output
+directory ends up holding everything `mkgrid` reads:
+
+```
+  SaveVertices   9,734 generating points
+  SaveTriangles  19,464 triangles
+  SaveDensity    the mesh density at each point
+  SaveCode       a copy of the hfun.py that produced them
+```
+
+`SaveVertices` and `SaveTriangles` carry the file's own tokens rather than
+floats reformatted by us, so JIGSAW's precision survives the trip, and the
+triangle indices are left exactly as JIGSAW wrote them — 0-based, which is what
+`mkgrid` expects. `SaveDensity` is MPAS's `meshDensity`:
+
+```
+rho(x) = (h_fine / h(x)) ** 4
+```
+
+one value per generating point, 1.0 where the mesh is finest.
+
+Two details are worth knowing. A real `MESH.msh` has a `POWER` block between
+`POINT` and `TRIA3` — the per-point weights for a power diagram — which
+`convert_jigsaw.py` skips only as a side effect of its counter staying at the
+limit across those lines; gmpas dispatches on section headers instead, so an
+unfamiliar block is ignored because it is unfamiliar rather than by luck. And
+`create_density` reuses the coordinates already parsed out of `MESH.msh`
+instead of reading back the `SaveVertices` it just wrote with `np.loadtxt`.
+
+All three files were checked **byte for byte** against the tutorial's own
+scripts run on the same mesh with the same interpreter.
+
+**The one step gmpas does not take is `mkgrid`**, which needs MPI and PnetCDF:
+
+```bash
+cd mesh/ && mkgrid 12000
+```
+
+That argument is `nominalMinDc` in **metres** while `hfun.py` works in km
+throughout — the one unit seam in this workflow, and an easy factor of a
+thousand to get wrong — so the command computes it for you and prints the line
+to run.
 
 ### Looking at a mesh before it exists
 
@@ -613,8 +650,7 @@ Preprocessing now covers `prep view`, `prep hfun` and `prep generate` — lookin
 at a mesh after it exists, looking at one before it exists, and running JIGSAW
 to get from the second to the first.
 
-What is still missing is the last leg, from JIGSAW's `MESH.msh` to an MPAS
-`grid.nc` ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)).
-`convert_jigsaw.py` and `create_density.py` are small and pure Python;
-`mkgrid` is the real obstacle, since it needs MPI and PnetCDF and so cannot
-simply be vendored.
+What is still missing is `mkgrid`, the last leg from JIGSAW's output to an
+MPAS `grid.nc` ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)).
+It needs MPI and PnetCDF, so it cannot simply be vendored; everything feeding
+it is now produced by `gmpas prep generate`.

--- a/src/gmpas/prep/generate.py
+++ b/src/gmpas/prep/generate.py
@@ -66,6 +66,18 @@ class Generated:
     triangles: int
     seconds: float
     reused: bool
+    out_dir: Path = Path(".")
+    hfun_min_km: float = 0.0
+
+    @property
+    def nominal_min_dc(self) -> float:
+        """`mkgrid`'s one argument: the finest grid distance, in METRES.
+
+        hfun.py works in km throughout and mkgrid wants metres, which is the
+        one unit seam in this workflow and an easy factor of a thousand to get
+        wrong by hand.
+        """
+        return self.hfun_min_km * 1000.0
 
 
 # ------------------------------------------------------------- the executable
@@ -174,6 +186,103 @@ def write_jig(path: Path, geom: str, hfun: str, mesh: str,
 # --------------------------------------------------------------- the mesh out
 
 
+def convert_jigsaw(mesh_msh: Path, out_dir: Path,
+                   quiet: bool = False) -> tuple[Path, Path, np.ndarray]:
+    """MESH.msh -> SaveVertices, SaveTriangles, and the coordinates in memory.
+
+    This is `convert_jigsaw.py`. It differs from that script in two ways, both
+    deliberate.
+
+    It dispatches on the section headers it knows rather than on a running
+    counter. A real MESH.msh has a POWER block between POINT and TRIA3 -- the
+    per-point weights for a power diagram -- which the script skips only as a
+    side effect of `i >= n` staying true across it. Reading headers means an
+    unfamiliar section is ignored because it is unfamiliar, not by luck.
+
+    And it keeps the coordinates it parsed, so `create_density` does not have to
+    read the file it just wrote back off disk with `np.loadtxt`. The written
+    columns are still the file's own tokens rather than reformatted floats, so
+    no precision is lost passing through.
+    """
+    vertices = out_dir / "SaveVertices"
+    triangles = out_dir / "SaveTriangles"
+    xyz: list[tuple[float, float, float]] = []
+    n_tri = 0
+
+    with open(mesh_msh) as msh:
+        for line in msh:
+            if line.startswith("POINT="):
+                n = int(line.split("=", 1)[1])
+                with open(vertices, "w") as out:
+                    for _ in range(n):
+                        parts = next(msh).split(";")
+                        out.write(f"{parts[0]} {parts[1]} {parts[2]}\n")
+                        xyz.append((float(parts[0]), float(parts[1]),
+                                    float(parts[2])))
+            elif line.startswith("TRIA3="):
+                n_tri = int(line.split("=", 1)[1])
+                with open(triangles, "w") as out:
+                    for _ in range(n_tri):
+                        parts = next(msh).split(";")
+                        out.write(f"{parts[0]} {parts[1]} {parts[2]}\n")
+
+    if not xyz:
+        raise GenerateError(f"{mesh_msh} carries no POINT section")
+    if not n_tri:
+        raise GenerateError(f"{mesh_msh} carries no TRIA3 section")
+
+    if not quiet:
+        print(f"  SaveVertices ({len(xyz):,}) and SaveTriangles ({n_tri:,})")
+    return vertices, triangles, np.asarray(xyz, dtype=np.float64)
+
+
+def create_density(hfun: Hfun, xyz: np.ndarray, out_dir: Path,
+                   radius_km: float = R_EARTH_KM,
+                   quiet: bool = False) -> Path:
+    """SaveDensity: the mesh density function at each generating point.
+
+    This is `create_density.py`. MPAS's meshDensity is
+
+        rho(x) = (h_fine / h(x)) ** 4
+
+    which is 1 where the mesh is finest and falls off as the fourth power --
+    the relation between cell size and density in a centroidal Voronoi
+    tessellation. `mkgrid` combines it with nominalMinDc to recover a smooth
+    nominal cell size anywhere on the mesh.
+    """
+    unit = xyz / radius_km
+    lon = np.atan2(unit[:, 1], unit[:, 0])
+    lat = np.asin(np.clip(unit[:, 2], -1.0, 1.0))
+
+    dx = hfun.sample_radians(lon, lat)
+
+    # Written the way create_density.py writes it, and not simplified to the
+    # algebraically identical (hfun_min / dx) ** 4. The two differ in the last
+    # bit or two, and matching the reference implementation exactly is worth
+    # more than the tidier expression: it lets the output be checked against
+    # the script byte for byte, which is a far stronger test than "close".
+    density = (1.0 / (dx / hfun.hfun_min)) ** 4
+
+    path = out_dir / "SaveDensity"
+    with open(path, "w") as f:
+        f.write("\n".join(map(str, density.tolist())))
+        f.write("\n")
+    if not quiet:
+        print(f"  SaveDensity ({density.min():.4g} to {density.max():.4g})")
+    return path
+
+
+def save_code(hfun: Hfun, out_dir: Path) -> Path:
+    """SaveCode: the hfun.py that produced all this, carried alongside it.
+
+    `mkgrid` wants it there, and it doubles as the record of what the mesh was
+    asked to be -- which is the one thing a grid.nc cannot tell you afterwards.
+    """
+    path = out_dir / "SaveCode"
+    shutil.copyfile(hfun.path, path)
+    return path
+
+
 def read_msh_counts(path: Path) -> tuple[int, int]:
     """POINT= and TRIA3= from a JIGSAW mesh file, without reading the body."""
     points = triangles = 0
@@ -212,7 +321,10 @@ def generate(hfun_path, out_dir="mesh", jigsaw: str | Path | None = None,
         points, triangles = read_msh_counts(mesh_msh)
         if not quiet:
             print(f"  reusing {mesh_msh} ({points:,} points)")
-        return Generated(mesh_msh, points, triangles, 0.0, reused=True)
+        result = Generated(mesh_msh, points, triangles, 0.0, reused=True,
+                           out_dir=out, hfun_min_km=hfun.hfun_min)
+        _mkgrid_inputs(hfun, result, out, quiet=quiet)
+        return result
 
     d = diagnose(hfun)
     if not quiet:
@@ -253,18 +365,38 @@ def generate(hfun_path, out_dir="mesh", jigsaw: str | Path | None = None,
     if not quiet:
         print(f"  {mesh_msh.name}: {points:,} generating points, "
               f"{triangles:,} triangles in {seconds:.1f} s")
-    return Generated(mesh_msh, points, triangles, seconds, reused=False)
+
+    result = Generated(mesh_msh, points, triangles, seconds, reused=False,
+                       out_dir=out, hfun_min_km=hfun.hfun_min)
+    _mkgrid_inputs(hfun, result, out, quiet=quiet)
+    return result
 
 
-def next_steps(result: Generated, out_dir) -> str:
-    """What still has to happen to get an MPAS `grid.nc`, and honestly why."""
+def _mkgrid_inputs(hfun: Hfun, result: Generated, out: Path,
+                   quiet: bool = False) -> None:
+    """Everything `mkgrid` reads, beside the mesh JIGSAW just produced."""
+    _, _, xyz = convert_jigsaw(result.mesh_msh, out, quiet=quiet)
+    create_density(hfun, xyz, out, quiet=quiet)
+    save_code(hfun, out)
+
+
+def next_steps(result: Generated, out_dir=None) -> str:
+    """The one step gmpas cannot take for you, spelled out.
+
+    The argument mkgrid wants is in metres while hfun.py is in km throughout,
+    so it is computed here rather than left as an exercise.
+    """
+    out = Path(out_dir) if out_dir is not None else result.out_dir
     return (
-        f"\n{result.mesh_msh} holds the generating points and their "
-        f"triangulation.\nTurning it into an MPAS grid.nc still needs the "
-        f"tutorial's remaining steps:\n"
-        f"    convert_jigsaw.py  MESH.msh -> SaveVertices, SaveTriangles\n"
-        f"    create_density.py  -> SaveDensity\n"
-        f"    cp hfun.py SaveCode\n"
-        f"    mkgrid <nominalMinDc_metres>  -> grid.nc, graph.info\n"
-        f"gmpas does not run these yet: mkgrid needs MPI and PnetCDF."
+        f"\n{out}/ now holds everything mkgrid reads:\n"
+        f"    SaveVertices   {result.points:,} generating points\n"
+        f"    SaveTriangles  {result.triangles:,} triangles\n"
+        f"    SaveDensity    the mesh density at each point\n"
+        f"    SaveCode       a copy of the hfun.py that produced them\n"
+        f"\nThe last step is mkgrid, which gmpas does not run — it needs MPI "
+        f"and PnetCDF:\n"
+        f"    cd {out} && mkgrid {result.nominal_min_dc:g}\n"
+        f"That argument is nominalMinDc in METRES; hfun.py works in km, so it "
+        f"is hfun_min * 1000.\nIt writes grid.nc and graph.info, and "
+        f"`gmpas prep view {out}/grid.nc` will open the result."
     )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -278,3 +278,147 @@ def test_a_jigsaw_that_exits_cleanly_without_a_mesh_still_fails(tmp_path):
     hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
     with pytest.raises(GenerateError, match="exit 0"):
         generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True)
+
+
+# ------------------------------------------------------- what mkgrid reads
+
+#: a MESH.msh in JIGSAW's real shape -- including the POWER block that sits
+#: between POINT and TRIA3, which is the part a naive parser walks straight
+#: into. `convert_jigsaw.py` skips it only as a side effect of its counter
+#: staying at the limit across those lines.
+MSH = """# MESH.msh; created by JIGSAW VERSION 1.1.0
+MSHID=3;EUCLIDEAN-MESH 
+NDIMS=3 
+POINT=3
+-3881.1824500587131;-4376.3194278168248;2525.2346476140142;0
+6371.229;0.0;0.0;0
+0.0;0.0;6371.229;0
+POWER=3;1
+0.5
+0.25
+0.125
+TRIA3=2
+0;1;2;0
+2;1;0;0
+"""
+
+
+@pytest.fixture
+def msh(tmp_path):
+    p = tmp_path / "MESH.msh"
+    p.write_text(MSH)
+    return p
+
+
+def test_the_power_block_is_skipped_not_read_as_points(msh, tmp_path):
+    """A real MESH.msh has POWER between POINT and TRIA3."""
+    from gmpas.prep.generate import convert_jigsaw
+
+    verts, tris, xyz = convert_jigsaw(msh, tmp_path, quiet=True)
+
+    assert xyz.shape == (3, 3)
+    assert verts.read_text().splitlines() == [
+        "-3881.1824500587131 -4376.3194278168248 2525.2346476140142",
+        "6371.229 0.0 0.0",
+        "0.0 0.0 6371.229",
+    ]
+    assert tris.read_text().splitlines() == ["0 1 2", "2 1 0"]
+    assert "0.5" not in verts.read_text()          # no POWER value leaked in
+
+
+def test_coordinates_pass_through_as_written(msh, tmp_path):
+    """The file's own tokens, not floats reformatted by us -- so JIGSAW's
+    precision survives the trip to mkgrid intact."""
+    from gmpas.prep.generate import convert_jigsaw
+
+    verts, _, _ = convert_jigsaw(msh, tmp_path, quiet=True)
+    assert "-3881.1824500587131" in verts.read_text()
+
+
+def test_triangle_indices_are_left_alone(msh, tmp_path):
+    """JIGSAW writes them 0-based and mkgrid expects what convert_jigsaw
+    hands over, so renumbering here would silently corrupt the mesh."""
+    from gmpas.prep.generate import convert_jigsaw
+
+    _, tris, _ = convert_jigsaw(msh, tmp_path, quiet=True)
+    idx = [int(v) for line in tris.read_text().split() for v in [line]]
+    assert min(idx) == 0
+    assert max(idx) == 2                            # nPoints - 1
+
+
+def test_a_mesh_without_the_sections_is_refused(tmp_path):
+    from gmpas.prep.generate import convert_jigsaw
+
+    bad = tmp_path / "MESH.msh"
+    bad.write_text("MSHID=3;EUCLIDEAN-MESH\nNDIMS=3\n")
+    with pytest.raises(GenerateError, match="no POINT section"):
+        convert_jigsaw(bad, tmp_path, quiet=True)
+
+
+def test_density_is_one_where_the_mesh_is_finest(msh, tmp_path):
+    """MPAS's meshDensity: rho(x) = (h_fine / h(x)) ** 4, so 1.0 at hfun_min."""
+    from gmpas.prep.generate import convert_jigsaw, create_density
+
+    # the refinement centre of GENTLE is (0, 0), which is the second point
+    hfun = Hfun.load(write_hfun_py(tmp_path / "hfun.py"))
+    _, _, xyz = convert_jigsaw(msh, tmp_path, quiet=True)
+    path = create_density(hfun, xyz, tmp_path, quiet=True)
+
+    density = np.array([float(v) for v in path.read_text().split()])
+    assert density.size == 3
+    assert density[1] == pytest.approx(1.0)         # at the centre, h = hfun_min
+    assert (density <= 1.0).all()
+    assert (density > 0.0).all()
+
+
+def test_density_recovers_the_distance_function(msh, tmp_path):
+    """Inverting rho = (h_min/h)**4 must give back what get_hfun said."""
+    from gmpas.prep.generate import convert_jigsaw, create_density
+
+    hfun = Hfun.load(write_hfun_py(tmp_path / "hfun.py"))
+    _, _, xyz = convert_jigsaw(msh, tmp_path, quiet=True)
+    density = np.array([float(v) for v in
+                        create_density(hfun, xyz, tmp_path,
+                                       quiet=True).read_text().split()])
+
+    unit = xyz / 6371.229
+    expected = hfun.sample_radians(np.atan2(unit[:, 1], unit[:, 0]),
+                                   np.asin(np.clip(unit[:, 2], -1, 1)))
+    assert hfun.hfun_min / density ** 0.25 == pytest.approx(expected)
+
+
+def test_save_code_is_the_hfun_that_produced_it(msh, tmp_path):
+    from gmpas.prep.generate import save_code
+
+    src = write_hfun_py(tmp_path / "hfun.py")
+    hfun = Hfun.load(src)
+    assert save_code(hfun, tmp_path).read_text() == src.read_text()
+
+
+def test_the_mkgrid_argument_is_in_metres(tmp_path):
+    """hfun.py is in km throughout and mkgrid wants metres -- the one unit
+    seam in the workflow, and a factor of a thousand to get wrong by hand."""
+    from gmpas.prep.generate import Generated, next_steps
+
+    result = Generated(tmp_path / "MESH.msh", 10, 16, 1.0, False,
+                       out_dir=tmp_path, hfun_min_km=12.0)
+    assert result.nominal_min_dc == 12000.0
+    assert "mkgrid 12000" in next_steps(result)
+
+
+@jigsaw_available
+def test_a_whole_run_leaves_everything_mkgrid_needs(tmp_path):
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    out = tmp_path / "out"
+    result = generate(hfun, out_dir=out, quiet=True)
+
+    for name in ("MESH.msh", "SaveVertices", "SaveTriangles", "SaveDensity",
+                 "SaveCode"):
+        assert (out / name).exists(), name
+
+    verts = (out / "SaveVertices").read_text().splitlines()
+    tris = (out / "SaveTriangles").read_text().splitlines()
+    density = (out / "SaveDensity").read_text().split()
+    assert len(verts) == result.points
+    assert len(tris) == result.triangles
+    assert len(density) == result.points        # one per generating point


### PR DESCRIPTION
`convert_jigsaw.py` and `create_density.py`, folded into `prep generate`. Stacks
on #26. After this, only `mkgrid` is left outside gmpas.

```
  MESH.msh: 9,734 generating points, 19,464 triangles in 9.6 s
  SaveVertices (9,734) and SaveTriangles (19,464)
  SaveDensity (0.0256 to 1)

/tmp/gen_full/ now holds everything mkgrid reads:
    SaveVertices   9,734 generating points
    SaveTriangles  19,464 triangles
    SaveDensity    the mesh density at each point
    SaveCode       a copy of the hfun.py that produced them

The last step is mkgrid, which gmpas does not run — it needs MPI and PnetCDF:
    cd /tmp/gen_full && mkgrid 120000
```

Density range `0.0256` to `1.0` is exactly `(120/300)**4` and `(120/120)**4` for
that test function.

## Verified byte for byte

All three generated files were compared against the tutorial's own scripts, run
on the same mesh with the same interpreter. Getting there turned up three
things worth recording.

**A real trap in the parsing.** A `MESH.msh` has a `POWER` block between `POINT`
and `TRIA3` — the per-point weights for a power diagram — and
`convert_jigsaw.py` skips it *only* as a side effect of `i >= n` staying true
across those lines. A parser that assumed `POINT` is followed by `TRIA3` would
read the weights as coordinates and produce a plausible, wrong mesh with no
error. This dispatches on section headers instead, so an unfamiliar block is
ignored because it is unfamiliar rather than by luck. There is a fixture with a
`POWER` block in it and a test asserting no weight leaks into `SaveVertices`.

**Density has to be written the reference way.** `(1.0 / (dx / hfun_min)) ** 4`,
not the algebraically identical `(hfun_min / dx) ** 4`. They differ in the last
bit or two, and matching exactly is worth more than the tidier expression: it
turns "close enough" into a byte comparison.

**One residual difference was neither implementation's fault.** numpy 2.4.4 and
2.5.1 differ in the last ULP for this arithmetic, so the files agree only when
both are computed by the same interpreter — 981 of 9,734 values differed at
~4e-15 purely from that. Worth knowing before someone diffs these across
machines and concludes something is broken.

## Two deliberate departures

Both avoid work rather than change results:

- The coordinates parsed out of `MESH.msh` are kept and handed to
  `create_density`, instead of reading back the `SaveVertices` just written with
  `np.loadtxt`.
- `SaveVertices` and `SaveTriangles` carry the file's own tokens rather than
  floats reformatted by us, so JIGSAW's precision survives and the triangle
  indices stay exactly as written — **0-based**, which is what `mkgrid` expects.
  Renumbering them here would silently corrupt the mesh, so there is a test.

## The unit seam

`mkgrid`'s one argument is `nominalMinDc` in **metres**, while `hfun.py` works
in km throughout — an easy factor of a thousand to get wrong by hand. It is
computed now, and the command prints the exact line to run.

## Verification

- **268 passed**, 9 new.
- Tests cover the `POWER` skip, token pass-through, index preservation, a
  missing section being refused, `rho = 1` at the finest point, inverting
  `rho = (h_min/h)**4` back to `get_hfun`, `SaveCode` being a true copy, and the
  metres conversion.
- End to end with real JIGSAW: one value in `SaveDensity` per generating point,
  and the vertex and triangle counts matching the mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
