### PR TITLE
docs: split the README into docs/, and add examples/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # gmpas
 
-Fast plotting of MPAS output **on its own native mesh** — no regridding, so
-variable resolution is preserved exactly as the model carries it.
+[![tests](https://github.com/nmathewa/gmpas-lib/actions/workflows/tests.yml/badge.svg)](https://github.com/nmathewa/gmpas-lib/actions/workflows/tests.yml)
+[![version](https://img.shields.io/badge/version-0.3.0-blue)](docs/status.md)
+[![python](https://img.shields.io/badge/python-3.10%2B-blue)](docs/installation.md)
+[![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-This is the installable-library form of the
-[gmpas MCP server](../gmpas): the same geometry, caching and rendering code,
-packaged so it can be `pip install`ed and imported from anywhere.
+Fast plotting of MPAS output **on its own native mesh** — no regridding, so
+variable resolution is preserved exactly as the model carries it. Plus the
+other end of the pipeline: designing a mesh, building it with JIGSAW, and
+looking at either before or after it exists.
 
 ```python
 import gmpas
@@ -14,87 +17,28 @@ ds = gmpas.open_mpas("diag.2019-09-01_00.00.00.nc", mesh="maritime.region.nc")
 
 ds.mpas.plot("mslp")        # cell field, filled Voronoi polygons
 ds.mpas.plot("u")           # edge field, drawn on the cell faces themselves
-ds.mpas.plot("mslp", time=3)
 ds.mpas.plot_mesh()         # where the mesh actually refines, in km
-ds.mpas.quiver("uzonal_850hPa", "umeridional_850hPa", background="mslp")
 ```
 
 `mesh=` may be omitted when the file carries its own mesh information, or when
 a mesh file with a matching cell count sits beside it.
 
-## Why
-
-MPAS is unstructured: a variable-resolution spherical Voronoi tessellation,
-with scalars at cell centres and normal velocity on cell edges. That is why
-ordinary lat-lon tooling does not apply, and why the usual workarounds each
-cost something:
-
-| approach | fast? | conserves? | edge variables? |
-|---|---|---|---|
-| `uxarray` | rebuilds grid topology on every call | n/a | yes |
-| `convert_mpas` → lat-lon | yes | **no** — barycentric sampling | via remap |
-| cell polygons in a `.gpkg` | yes | n/a | **no** — centres only |
-
-gmpas keeps the good idea behind the `.gpkg` approach — mesh geometry is static
-for a whole simulation, so build it once — and generalises it. The cache is an
-`.npz` holding cell polygons, edge segments and unit-sphere coordinates, so
-edge-based fields work too, and no GIS dependency is needed.
-
-## Why it is fast
-
-1. **Cached geometry.** Building cell polygons from `verticesOnCell` is
-   vectorized (no Python loop) and then cached to `.npz`. On a small regional
-   mesh that is ~63 ms to build and ~1 ms to reload; the saving grows with mesh
-   size, and it persists across sessions.
-2. **Rasterizing instead of drawing polygons.** Polygon rendering costs
-   O(nCells) and stalls on million-cell meshes. An MPAS mesh *is* the Voronoi
-   tessellation of its cell centres, so the cell containing a point is exactly
-   the nearest cell centre — one KD-tree query, no clipping, no interpolation.
-   That makes rendering O(pixels), independent of mesh size.
-
-`method="auto"` uses polygons below ~150k cells and rasterizes above.
-
-## Install anywhere
-
-Nothing here needs an MCP server, Claude Desktop, or any of the surrounding
-tooling — it is an ordinary Python package. Copy the directory (or clone it)
-onto the target machine and install it.
-
-Everything in one go:
+## Installation
 
 ```bash
 conda env create -f environment.yml && conda activate gmpas && pip install -e . --no-deps
 ```
 
-Or by hand — the scientific stack is much easier from conda-forge than from
-pip:
-
-```bash
-conda create -n gmpas -c conda-forge python=3.12 numpy scipy xarray netcdf4 matplotlib cartopy pillow -y
-conda activate gmpas
-pip install -e ".[dev]" --no-deps
-```
-
-Conservative remapping additionally needs ESMF, which ships the
-`ESMF_RegridWeightGen` executable, and optionally NCO for `ncremap`:
-
-```bash
-conda install -c conda-forge esmf nco
-```
-
-These are programs rather than Python packages, so pip cannot provide them and
-they are not in `pyproject.toml`. Skip them if you only plot and view.
-
-Pure pip works too, if wheels are available for your platform:
+Pure pip works too where wheels exist:
 
 ```bash
 pip install -e ".[dev]"
 ```
 
-Extras: `plot` pulls in matplotlib and cartopy, `test` pulls in pytest, `dev`
-is both plus ruff. The core install has no plotting dependency at all —
-geometry, caching and rasterizing are usable headless, and `plot.py` imports
-matplotlib lazily so `import gmpas` never pays for it.
+Two workflows need external programs, which pip cannot provide. Conservative
+remapping needs ESMF (`conda install -c conda-forge esmf nco`); mesh generation
+needs [JIGSAW](https://github.com/dengwirda/jigsaw) and, for the final step,
+MPI and PnetCDF. Skip both if you only plot and view.
 
 Check it landed:
 
@@ -102,555 +46,43 @@ Check it landed:
 gmpas --version && pytest -q
 ```
 
-## Command line
+Full detail, including the extras and what each one pulls in:
+[docs/installation.md](docs/installation.md).
+
+## Usage
 
 ```bash
-gmpas info       history.2012-02-25_12.00.00.nc
-gmpas plot       history.2012-02-25_12.00.00.nc precipw -o pw.png
-gmpas view       /path/to/run/
-gmpas scrip      history.2012-02-25_12.00.00.nc -o src.scrip.nc
-gmpas target     -o dst.scrip.nc
-gmpas prep view  mesh.nc
-gmpas prep hfun  hfun.py
+gmpas info          history.2012-02-25_12.00.00.nc
+gmpas plot          history.2012-02-25_12.00.00.nc precipw -o pw.png
+gmpas view          /path/to/run/
+gmpas remap         history.*.nc -o out/
+gmpas prep view     mesh.nc
+gmpas prep hfun     hfun.py --check
 gmpas prep generate hfun.py -o mesh/
 ```
 
-`info` summarises the mesh and lists variables grouped by the element they
-live on. `plot` renders one field. `view` opens the interactive browser.
-`scrip` and `target` prepare the two grid files a conservative remapper needs
-— see [Conservative remapping](#conservative-remapping).
-
-Everything above except `prep` is **postprocessing**: it opens a run and
-renders, remaps or exports it. `prep` is the other end of the pipeline, for
-work that happens before there is any output — see
-[Preprocessing](#preprocessing).
-
-Running `gmpas` with no arguments prints the whole list with examples.
-
-Every command takes a file, a directory, or a glob. A directory or glob is
-read as one time series across files, which is how MPAS actually writes
-output — one `history.YYYY-MM-DD_HH.MM.SS.nc` per interval:
-
-```bash
-gmpas plot '/path/to/run/history.*.nc' precipw --all-steps -o 'frames/pw_{step:04d}.png' -j 8
-```
-
-`--all-steps` needs `{step}` in the output pattern; `-j` sets the worker count
-(default: every core). Useful flags on `plot`: `-t/--time`, `-l/--level`,
-`--cmap`, `--extent`, `--symmetric` for anomalies, `--method poly|raster|auto`,
-`--style paper|poster|notebook|mesh`.
-
-## In a notebook
-
-```python
-import gmpas
-
-ds = gmpas.open_mpas("history.2012-02-25_12.00.00.nc")
-ds.mpas                       # <MPAS 413,788 cells / 1,243,651 edges — ...>
-
-ds.mpas.plot("precipw")       # returns (fig, ax); renders inline
-ds.mpas.plot("theta", level=20)
-ds.mpas.plot("u")             # edge field, drawn on the cell faces
-ds.mpas.plot_mesh()           # where the mesh refines, in km
-ds.mpas.quiver("uReconstructZonal", "uReconstructMeridional",
-               background="precipw")
-```
-
-Pass `mesh=` when the file carries no mesh of its own (a `diag.*.nc` usually
-does not) and no mesh file sits beside it.
-
-The pieces are usable directly when you want the array rather than the figure:
-
-```python
-mesh = ds.mpas.mesh
-mesh.n_cells, mesh.extent, mesh.is_global, mesh.coverage
-
-values = gmpas.select(ds["precipw"], time=0)
-img, lon, lat = gmpas.rasterize(mesh, values)      # regular lat-lon array
-gmpas.save_figure(fig, "out.png")
-```
-
-For many files as one time axis:
-
-```python
-from gmpas.series import Series
-
-run = Series("/path/to/run/")            # or a glob, or a list of paths
-len(run), run.n_files, run.labels[:3]
-values = run.values("precipw", step=7)   # opens only the file that step needs
-```
-
-For time means, composites and anomalies across a run, use
-`xarray.open_mfdataset` with dask instead — that is what it is good at, and
-`Series` deliberately does not try to replace it.
-
-## On a cluster
-
-The viewer serves on `127.0.0.1`, so forward the port rather than exporting a
-display — this is the case where ncview's X11 forwarding hurts most:
-
-```bash
-ssh -L 8765:localhost:8765 user@cluster
-```
-
-then on the node, inside your interactive job:
-
-```bash
-gmpas view /scratch/run/ --no-browser --port 8765
-```
-
-and open `http://localhost:8765` in your own browser.
-
-Two environment variables matter on a shared machine:
-
-- `GMPAS_CACHE_DIR` — where cached mesh geometry goes. Defaults to
-  `~/.cache/gmpas/mesh`; point it at scratch if your home quota is small.
-  The cache is memory-mapped, so several processes reading the same mesh share
-  one copy through the page cache.
-- `GMPAS_DATA_DIR` — tried first when resolving relative paths.
-
-Batch rendering scales with `-j`, but two things limit it: worker startup
-(cheap under `fork` on Linux, expensive under `spawn` on macOS), and the
-KD-tree query inside each worker still requesting every core, which
-oversubscribes when many workers run at once. Measured on 12 steps: 10.2 s at
-`-j 1`, 5.7 s at `-j 4`, 6.2 s at `-j 10`. Until the query's worker count is
-plumbed through, `-j` around half your cores is the sweet spot.
-
-## Configuration
-
-Two environment variables, both optional:
-
-- `GMPAS_CACHE_DIR` — where cached `.npz` mesh geometry goes.
-  Defaults to `~/.cache/gmpas/mesh`. Safe to delete; it rebuilds.
-- `GMPAS_DATA_DIR` — tried first when resolving a relative path, before the
-  working directory.
-
-## Tests
-
-```bash
-pytest
-```
-
-Tests build synthetic MPAS mesh files in `tmp_path`, so no model output is
-needed and the real cache directory is never touched. They pin down the parts
-a reader cannot eyeball: the ragged 1-based `verticesOnCell` fill, the
-antimeridian unwrap, the `sphere_radius = 1` redimensionalisation, cache
-identity, and the factor-of-two bias in the edge-normal wind reconstruction.
-Rendering tests skip themselves when the `plot` extra is absent.
-
-## Layout
-
-- `src/gmpas/mesh.py` — `MpasMesh`, geometry build, `.npz` cache, wind reconstruction
-- `src/gmpas/raster.py` — KD-tree Voronoi rasterizer
-- `src/gmpas/plot.py` — cell / edge / vector / mesh-structure rendering
-- `src/gmpas/data.py` — opening output, pairing with a mesh, time/level selection
-- `src/gmpas/style.py` — `Style` presets, colormaps, named extents, `save_figure`
-- `src/gmpas/accessor.py` — the `ds.mpas` xarray accessor
-- `src/gmpas/paths.py` — cache and data directory resolution
-- `src/gmpas/prep/` — preprocessing: the `gmpas prep` commands and their layout
-
-## Preprocessing
-
-The rest of gmpas opens a run. `gmpas prep` covers what happens before one
-exists — building a mesh and looking at it on its own.
-
-```bash
-gmpas prep view mesh.nc
-```
-
-A browser view of a mesh file with no output data anywhere near it: cells
-coloured by width, so where the mesh refines is visible at a glance.
-
-```
-8,228 cells, 24,987 edges, regional — cell width 43 to 68.1 km
-listening on 127.0.0.1:8765 — this machine only
-```
-
-Same flags as `view` for tunnelling and size: `-p/--port`, `--host`,
-`--width`, `--height`, `--no-browser`. On a compute node use `--host 0.0.0.0`
-and tunnel, exactly as for `view`.
-
-Two fields are offered, both derived from geometry the mesh cache already
-holds, so neither costs a rebuild: `cell_width_km` (the default) and
-`cell_area_km2`.
-
-**The colour scale is fixed**, taken once from the whole mesh rather than
-autoscaled to the current view. There is no vmin/vmax control to put it back,
-and that is the point: a scale that restretched as you panned would make the
-same refinement band change colour while you moved across it, which misreads a
-variable-resolution mesh badly.
-
-The layout is the `view` page reduced to what a preprocessing step uses. The
-timestep and level sliders, the colormap picker, the colour-range boxes, the
-animation panel, the exports and the probe all belong to a model run, so they
-are absent rather than disabled. Pan, zoom, graticule, scale bar and the
-extent box stay — the last because reading a domain off a mesh is how one
-picks a region.
-
-`prep.layout.page(title, panel=..., script=...)` is that layout as a reusable
-shell, with slots for a step's own controls. The sidebar's facts block is
-data-driven — a step sends `subtitle` and `stats`, so one with no cells or
-edges reuses the shell rather than forking it. `prep hfun` is the second user;
-mesh generation is meant to be the third
-([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)); like the
-remapping tools, JIGSAW would be an external executable gmpas shells out to,
-not a Python dependency.
-
-### One server, one port
-
-A run, the mesh it is on, and the distance function behind that mesh are the
-three things one wants side by side, and they used to be three processes on
-three ports — three SSH tunnels from a compute node. They are now one:
-
-```bash
-gmpas view /path/to/run/ --hfun hfun.py     # data + mesh + hfun
-gmpas prep view mesh.nc --hfun hfun.py      # mesh + hfun
-gmpas prep hfun hfun.py --mesh mesh.nc      # hfun + mesh
-```
-
-```
-2 sources on one port:
-  /mesh  mesh — maritime.region.nc · 8,228 cells
-  /hfun  hfun — hfun.py · 12 to 60 km · gradient 0.0300
-```
-
-`/` lists what is available and each page carries a switcher, so one tunnel
-reaches all of them. Opening a run gives the mesh page for free — a run always
-brings its mesh with it. Every source is constructed before the server binds,
-so a bad path is an error at the prompt rather than a 500 in a browser tab.
-
-A single source is unchanged: it is served at the root, with no index and no
-switcher, on exactly the paths it always used.
-
-### Generating a mesh with JIGSAW
-
-```bash
-export JIGSAWDIR=/path/to/jigsaw/build/src     # or wherever it installed
-gmpas prep generate hfun.py -o mesh/
-```
-
-Same division of labour as the remapping side: gmpas does not generate the mesh
-itself, it prepares every input JIGSAW needs, shells out, and reads the result
-back. What it adds is everything around the call.
-
-```
-  hfun.py: 12 to 60 km, max gradient 0.0300
-  sampling hfun onto 3336 x 1668 (5.6M points)
-  wrote GEOM.msh, HFUN.msh (32 MB) and MESH.jig
-  running jigsaw — this is the slow part
-  MESH.msh: 9,734 generating points, 19,464 triangles in 8.7 s
-```
-
-`HFUN.msh` is written the way `create_hfun.py` writes it — the same grid, the
-same `meshgrid(lats, lons)` argument order, and therefore the same
-longitude-major value ordering. Getting that order wrong would transpose the
-distance function and refine the wrong part of the planet *without failing*, so
-there is a test comparing the file back against the function elementwise.
-
-**The distance function is checked before any time is spent.** Generation takes
-minutes; measuring the gradient takes a second. A transition steeper than the
-0.03 guideline stops the run rather than producing a mesh you would throw away:
-
-```
-gmpas: hfun.py has a maximum cell size gradient of 0.0501 at 41.2, -95.0,
-above the 0.03 guideline. A mesh built from it will change cell size too
-quickly to be well behaved.
-  Widen the transition region, or raise hfun_min.
-  Pass --allow-steep to generate it anyway.
-```
-
-JIGSAW is found by `--jigsaw`, then `$JIGSAWDIR`, then `PATH` — in that order.
-PATH is last because JIGSAW installs wherever `CMAKE_INSTALL_PREFIX` pointed
-and its build tree leaves the binary in `build/src/`, so on most machines it is
-not on PATH at all. `$JIGSAWDIR` accepts either the binary or the directory
-holding it.
-
-`MESH.msh` is reused if it is already there, unless `--force`. `--init` passes
-an initial point set through to `INIT_FILE`, which is what gives a
-quasi-uniform mesh icosahedral structure — a constant `HFUN` alone produces
-7-sided cells.
-
-After JIGSAW, the run continues into the two conversion steps, so the output
-directory ends up holding everything `mkgrid` reads:
-
-```
-  SaveVertices   9,734 generating points
-  SaveTriangles  19,464 triangles
-  SaveDensity    the mesh density at each point
-  SaveCode       a copy of the hfun.py that produced them
-```
-
-`SaveVertices` and `SaveTriangles` carry the file's own tokens rather than
-floats reformatted by us, so JIGSAW's precision survives the trip, and the
-triangle indices are left exactly as JIGSAW wrote them — 0-based, which is what
-`mkgrid` expects. `SaveDensity` is MPAS's `meshDensity`:
-
-```
-rho(x) = (h_fine / h(x)) ** 4
-```
-
-one value per generating point, 1.0 where the mesh is finest.
-
-Two details are worth knowing. A real `MESH.msh` has a `POWER` block between
-`POINT` and `TRIA3` — the per-point weights for a power diagram — which
-`convert_jigsaw.py` skips only as a side effect of its counter staying at the
-limit across those lines; gmpas dispatches on section headers instead, so an
-unfamiliar block is ignored because it is unfamiliar rather than by luck. And
-`create_density` reuses the coordinates already parsed out of `MESH.msh`
-instead of reading back the `SaveVertices` it just wrote with `np.loadtxt`.
-
-All three files were checked **byte for byte** against the tutorial's own
-scripts run on the same mesh with the same interpreter.
-
-**The one step gmpas does not take is `mkgrid`**, which needs MPI and PnetCDF:
-
-```bash
-cd mesh/ && mkgrid 12000
-```
-
-That argument is `nominalMinDc` in **metres** while `hfun.py` works in km
-throughout — the one unit seam in this workflow, and an easy factor of a
-thousand to get wrong — so the command computes it for you and prints the line
-to run.
-
-### Looking at a mesh before it exists
-
-```bash
-gmpas prep hfun hfun.py            # browse it
-gmpas prep hfun hfun.py --check    # just the numbers, no server
-```
-
-In the JIGSAW workflow for MPAS-Atmosphere, a variable-resolution mesh is
-defined entirely by a small Python file. `create_hfun.py` samples it onto a
-lat-lon grid to write `HFUN.msh`, JIGSAW turns that into generating points, and
-`mkgrid` turns those into `grid.nc`. Every design decision lives in that one
-file, so this reads it on its own — no JIGSAW, no mesh, no generation time:
-
-```
-hfun.py: hfun_min 12 km, grid distance 12 to 60 km
-max cell size gradient 0.0300 at 75.64, -95.05 (within the 0.03 guideline)
-measured on the 3336 x 1668 lat-lon grid create_hfun.py would write (12 km spacing)
-```
-
-The contract is the mini-tutorial's: a module-level `hfun_min` in km, and
-`get_hfun(lon, lat)` taking **radians** and returning **km**. That function is
-called once with whole arrays and may do expensive setup — a real one might
-interpolate a raster — so it is called once per view here, never per pixel.
-
-**The gradient is the number worth having.** The tutorial's guidance is to keep
-cell size changing by no more than a few percent per km of distance, with 0.03
-generally safe, and `mesh_quality.py` reports exactly that from a finished
-`grid.nc`:
-
-```python
-nominalDx = r_earth * nominalMinDc * (1.0 / meshDensity) ** 0.25
-gradient  = abs(nominalDx[c0] - nominalDx[c1]) / dcEdge / r_earth
-```
-
-Since `meshDensity` is `(hfun_min / h) ** 4` and `nominalMinDc` is `hfun_min`,
-that is the change in grid distance between neighbouring cells over the
-distance between them. Its continuous limit is `|grad h|` with respect to arc
-length, which is what is computed here — on the same lat-lon grid
-`create_hfun.py` would write, so the number is comparable both to the 0.03
-guideline and to what `mesh_quality.py` will say once the mesh exists. The two
-polar rows are excluded: every longitude at a pole is the same point, so the
-zonal derivative there is 0/0 rather than a gradient.
-
-Two fields are offered, neither invented here: `cell_width_km` is `get_hfun`
-straight out, and `mesh_density` is `(hfun_min / h) ** 4` — MPAS's own
-`meshDensity`, 1.0 where the mesh is finest.
-
-Nothing in `prep/` modifies the postprocessing path. It imports the viewer's
-rasterizing, PNG encoding, coastline overlay and port binding, and changes
-none of them.
-
-## Differences from the MCP server
-
-### Two behaviour fixes
-
-Both change output, and neither has been ported back to the MCP server yet.
-
-**The out-of-mesh mask now uses the mesh's own sphere radius.** It converts a
-cell's radius in metres to an angle, and the server divides by a hardcoded
-6 371 000 m. On a reduced-radius ("small planet", X-factor) run — a real MPAS
-configuration — that understates every cell's angular size by the radius
-ratio. On a 1/120-radius mesh it blanks *every* pixel: the figure comes back
-empty. `MpasMesh` now carries `sphere_radius`, and `rasterize` divides by that.
-
-**The geometry cache can no longer return a different mesh's polygons.** The
-server keys its cache on `path | size | mtime`. netCDF4's padded layout means
-two meshes with different cell counts can occupy identical byte sizes (a
-1-cell and a 3-cell file here are both 18436 bytes), and `st_mtime` truncates
-to whole seconds — so regenerating a mesh in place could silently reuse the
-previous geometry. The key is now
-`path | size | st_mtime_ns | nCells | nEdges`, with the counts read from the
-netCDF header (no data I/O). Costs a roughly constant ~2 ms per load.
-
-A unit-sphere mesh (`sphere_radius = 1`, straight from JIGSAW/MPAS-Tools) is
-still assumed to be Earth-sized, matching MPAS's own default — but that is now
-a stated assumption in the code, not a buried constant. Nothing in such a file
-distinguishes an Earth mesh from a small-planet one.
-
-### Packaging
-
-The server writes into its own repo (`data/`, `research/plots/`,
-`research/mesh_cache/`). A library cannot: it is installed somewhere the user
-never looks. So:
-
-- the cache moved to `~/.cache/gmpas/mesh`, overridable by `GMPAS_CACHE_DIR`
-- `save_figure(fig, path)` writes where the caller says, instead of into a
-  fixed `research/plots/`
-- relative paths resolve against `GMPAS_DATA_DIR` then the working directory,
-  instead of a project-local `data/`
-- `mesh.cell_width_km` replaces the hexagon-width formula that was repeated at
-  three call sites (identical numerics)
-- an unknown extent name or render method now raises instead of silently
-  falling back, so a typo cannot quietly produce the wrong map
-
-### Known, unfixed
-
-- `is_global` is true as soon as any cell straddles the antimeridian, so a
-  regional Pacific domain gets the whole-sphere extent and plots the entire
-  globe. Documented by a test; not changed.
-- The edge-normal wind reconstruction carries a systematic factor-of-two low
-  bias, not just noise: for uniform flow across normals evenly spread over
-  [0, π) the unweighted average returns exactly half the true speed. Direction
-  is right. Pinned by a test; prefer `uReconstructZonal` /
-  `umeridional_*` when the diagnostics file has them.
-
-## Conservative remapping
-
-gmpas writes the grid files a real remapper needs and checks the answer; ESMF,
-TempestRemap or ncremap compute the weights. It does **not** compute them
-itself — spherical polygon intersection is hard to get right and those tools
-already do it. See [docs/REMAPPING.md](docs/REMAPPING.md) for the reasoning,
-the conservation check, and two MPAS traps that crash or are rejected by the
-standard tooling.
-
-### Running it from a terminal
-
-The whole conversion is one command:
-
-```bash
-gmpas remap 'history.*.nc' -o out/ -j 64
-```
-
-It reads the configuration below from the working directory, generates the
-weights once, and writes one remapped file per input file, converting them in
-parallel.
-
-**Pass `-j` explicitly.** Left out, the worker count is detected from the
-scheduler — `SLURM_CPUS_PER_TASK`, `PBS_NCPUS` and friends, then the process
-affinity mask — but detection is only as good as what the site sets. `NCPUS=1`
-in a login profile, which several sites use, will pin a 256-core job to a
-single worker:
-
-```
-  1 worker(s) (of 1 from NCPUS)
-```
-
-If the run looks slower than it should, that line is the first thing to read.
-`-j` always wins:
-
-```
-  64 worker(s) (asked for 64; 1 available from NCPUS)
-``` See
-[docs/REMAPPING.md](docs/REMAPPING.md) for the output it prints and the
-individual steps.
-
-Put a `target_domain` file next to the run. `startlat`/`endlat` are the domain
-edges and `nlat` counts cells across them:
-
-```
-nlat     = 267
-nlon     = 534
-startlat = -20.0
-endlat   =  20.0
-startlon =  80.0
-endlon   = 160.0
-```
-
-Optionally add `mesh_file` — one line naming the mesh, for when the output
-stream does not carry `verticesOnCell` — and `include_fields` and/or
-`exclude_fields`, one variable name per line. Blank lines, `#` comments and trailing spaces are fine. A name in both
-files is contradictory: **include wins**, with a warning naming the fields.
-
-```
-u10
-v10
-theta
-precipw
-```
-
-Then, from that directory — the files are found without being named:
-
-```bash
-gmpas target                       # what was found, and the grid it describes
-gmpas target history.*.nc          # and which fields would be remapped
-```
-
-```bash
-gmpas target -o dst.scrip.nc       # write the destination grid
-gmpas scrip  history.2012-02-25_12.00.00.nc -o src.scrip.nc
-```
-
-Generate the weights once for the pair — they are reusable for every variable,
-level and timestep of the run. `ESMF_RegridWeightGen` comes from
-`conda install -c conda-forge esmf`; a `command not found` means that
-environment is not active:
-
-```bash
-ESMF_RegridWeightGen -s src.scrip.nc -d dst.scrip.nc -w map.nc -m conserve --src_regional --dst_regional --ignore_unmapped
-```
-
-```bash
-ncremap -m map.nc history.2012-02-25_12.00.00.nc remapped.nc
-```
-
-`-m conserve` is first-order; `-m conserve2nd` is second-order and less
-diffusive. `ncremap -a aave` is the equivalent E3SM route.
-
-### Checking that it conserved
-
-Worth never skipping — every failure mode here gives a plausible-looking wrong
-answer rather than an error:
-
-```python
-import numpy as np, xarray as xr
-
-w = xr.open_dataset("map.nc")
-dst = np.zeros(w.sizes["n_b"])
-np.add.at(dst, w.row.values - 1, w.S.values * src[w.col.values - 1])
-
-I_src = (src * w.area_a.values * w.frac_a.values).sum()
-I_dst = (dst * w.area_b.values).sum()          # NOT * frac_b
-assert abs(I_dst - I_src) / abs(I_src) < 1e-12
-```
-
-Measured on a 413,788-cell mesh to a 0.25° grid: `1.1e-16` for a constant
-field and exactly `0.0` for real fields, against `2.1e-05` for
-nearest-neighbour sampling.
-
-The extent need not be exact — target cells outside the source mesh come back
-unmapped and a narrow target simply crops, both expected. `gmpas target`
-prints the covered extent beside the requested one so any shift is visible.
-
-Applying weights from the command line is not built yet
-([issue 2](https://github.com/nmathewa/gmpas-lib/issues/2)); the snippet above
-is what it would do, and `ncremap -m` does it today.
-
-## Status
-
-Plotting is implemented. Conservative remapping (`convert`) is next: the same
-KD-tree gives area weights by supersampling a target cell and counting which
-source cells the samples land in, which — unlike barycentric sampling —
-actually conserves cell integrals.
-
-Preprocessing now covers `prep view`, `prep hfun` and `prep generate` — looking
-at a mesh after it exists, looking at one before it exists, and running JIGSAW
-to get from the second to the first.
-
-What is still missing is `mkgrid`, the last leg from JIGSAW's output to an
-MPAS `grid.nc` ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)).
-It needs MPI and PnetCDF, so it cannot simply be vendored; everything feeding
-it is now produced by `gmpas prep generate`.
+Any path may be a file, a directory, or a glob; a directory or glob is read as
+one time series across files, which is how MPAS writes output. Running `gmpas`
+with no arguments prints the whole list with examples.
+
+Everything except `prep` is **postprocessing** — it opens a run and renders,
+remaps or exports it. `prep` is the other end, for work that happens before
+there is any output.
+
+## Documentation
+
+| | |
+|---|---|
+| [Why gmpas exists](docs/why.md) | the problem with lat-lon tooling, and why this is fast |
+| [Installation](docs/installation.md) | conda, pip, extras, and the external programs |
+| [Command line](docs/command-line.md) | every command and its flags |
+| [In a notebook](docs/notebook.md) | the accessor, and using the pieces directly |
+| [Preprocessing](docs/preprocessing.md) | `prep view`, `prep hfun`, `prep generate` — mesh design and JIGSAW |
+| [Conservative remapping](docs/REMAPPING.md) | the whole terminal workflow, and two MPAS traps |
+| [On a cluster](docs/cluster.md) | port forwarding, and the two variables that matter |
+| [Configuration](docs/configuration.md) | `GMPAS_CACHE_DIR` and `GMPAS_DATA_DIR` |
+| [Examples](examples/) | ready-to-edit `hfun.py` templates |
+| [Tests](docs/testing.md) | what the suite covers |
+| [Layout](docs/layout.md) | what lives in which module |
+| [Differences from the MCP server](docs/mcp-server.md) | what changed on the way to a package |
+| [Status](docs/status.md) | what is implemented and what is not |

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -1,0 +1,31 @@
+# On a cluster
+
+The viewer serves on `127.0.0.1`, so forward the port rather than exporting a
+display — this is the case where ncview's X11 forwarding hurts most:
+
+```bash
+ssh -L 8765:localhost:8765 user@cluster
+```
+
+then on the node, inside your interactive job:
+
+```bash
+gmpas view /scratch/run/ --no-browser --port 8765
+```
+
+and open `http://localhost:8765` in your own browser.
+
+Two environment variables matter on a shared machine:
+
+- `GMPAS_CACHE_DIR` — where cached mesh geometry goes. Defaults to
+  `~/.cache/gmpas/mesh`; point it at scratch if your home quota is small.
+  The cache is memory-mapped, so several processes reading the same mesh share
+  one copy through the page cache.
+- `GMPAS_DATA_DIR` — tried first when resolving relative paths.
+
+Batch rendering scales with `-j`, but two things limit it: worker startup
+(cheap under `fork` on Linux, expensive under `spawn` on macOS), and the
+KD-tree query inside each worker still requesting every core, which
+oversubscribes when many workers run at once. Measured on 12 steps: 10.2 s at
+`-j 1`, 5.7 s at `-j 4`, 6.2 s at `-j 10`. Until the query's worker count is
+plumbed through, `-j` around half your cores is the sweet spot.

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -1,0 +1,37 @@
+# Command line
+
+```bash
+gmpas info       history.2012-02-25_12.00.00.nc
+gmpas plot       history.2012-02-25_12.00.00.nc precipw -o pw.png
+gmpas view       /path/to/run/
+gmpas scrip      history.2012-02-25_12.00.00.nc -o src.scrip.nc
+gmpas target     -o dst.scrip.nc
+gmpas prep view  mesh.nc
+gmpas prep hfun  hfun.py
+gmpas prep generate hfun.py -o mesh/
+```
+
+`info` summarises the mesh and lists variables grouped by the element they
+live on. `plot` renders one field. `view` opens the interactive browser.
+`scrip` and `target` prepare the two grid files a conservative remapper needs
+— see [Conservative remapping](./remapping.md).
+
+Everything above except `prep` is **postprocessing**: it opens a run and
+renders, remaps or exports it. `prep` is the other end of the pipeline, for
+work that happens before there is any output — see
+[Preprocessing](./preprocessing.md).
+
+Running `gmpas` with no arguments prints the whole list with examples.
+
+Every command takes a file, a directory, or a glob. A directory or glob is
+read as one time series across files, which is how MPAS actually writes
+output — one `history.YYYY-MM-DD_HH.MM.SS.nc` per interval:
+
+```bash
+gmpas plot '/path/to/run/history.*.nc' precipw --all-steps -o 'frames/pw_{step:04d}.png' -j 8
+```
+
+`--all-steps` needs `{step}` in the output pattern; `-j` sets the worker count
+(default: every core). Useful flags on `plot`: `-t/--time`, `-l/--level`,
+`--cmap`, `--extent`, `--symmetric` for anomalies, `--method poly|raster|auto`,
+`--style paper|poster|notebook|mesh`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,8 @@
+# Configuration
+
+Two environment variables, both optional:
+
+- `GMPAS_CACHE_DIR` — where cached `.npz` mesh geometry goes.
+  Defaults to `~/.cache/gmpas/mesh`. Safe to delete; it rebuilds.
+- `GMPAS_DATA_DIR` — tried first when resolving a relative path, before the
+  working directory.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,47 @@
+# Installation
+
+Nothing here needs an MCP server, Claude Desktop, or any of the surrounding
+tooling — it is an ordinary Python package. Copy the directory (or clone it)
+onto the target machine and install it.
+
+Everything in one go:
+
+```bash
+conda env create -f environment.yml && conda activate gmpas && pip install -e . --no-deps
+```
+
+Or by hand — the scientific stack is much easier from conda-forge than from
+pip:
+
+```bash
+conda create -n gmpas -c conda-forge python=3.12 numpy scipy xarray netcdf4 matplotlib cartopy pillow -y
+conda activate gmpas
+pip install -e ".[dev]" --no-deps
+```
+
+Conservative remapping additionally needs ESMF, which ships the
+`ESMF_RegridWeightGen` executable, and optionally NCO for `ncremap`:
+
+```bash
+conda install -c conda-forge esmf nco
+```
+
+These are programs rather than Python packages, so pip cannot provide them and
+they are not in `pyproject.toml`. Skip them if you only plot and view.
+
+Pure pip works too, if wheels are available for your platform:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Extras: `plot` pulls in matplotlib and cartopy, `test` pulls in pytest, `dev`
+is both plus ruff. The core install has no plotting dependency at all —
+geometry, caching and rasterizing are usable headless, and `plot.py` imports
+matplotlib lazily so `import gmpas` never pays for it.
+
+Check it landed:
+
+```bash
+gmpas --version && pytest -q
+```

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,0 +1,10 @@
+# Layout
+
+- `src/gmpas/mesh.py` — `MpasMesh`, geometry build, `.npz` cache, wind reconstruction
+- `src/gmpas/raster.py` — KD-tree Voronoi rasterizer
+- `src/gmpas/plot.py` — cell / edge / vector / mesh-structure rendering
+- `src/gmpas/data.py` — opening output, pairing with a mesh, time/level selection
+- `src/gmpas/style.py` — `Style` presets, colormaps, named extents, `save_figure`
+- `src/gmpas/accessor.py` — the `ds.mpas` xarray accessor
+- `src/gmpas/paths.py` — cache and data directory resolution
+- `src/gmpas/prep/` — preprocessing: the `gmpas prep` commands and their layout

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,53 @@
+# Differences from the MCP server
+
+### Two behaviour fixes
+
+Both change output, and neither has been ported back to the MCP server yet.
+
+**The out-of-mesh mask now uses the mesh's own sphere radius.** It converts a
+cell's radius in metres to an angle, and the server divides by a hardcoded
+6 371 000 m. On a reduced-radius ("small planet", X-factor) run — a real MPAS
+configuration — that understates every cell's angular size by the radius
+ratio. On a 1/120-radius mesh it blanks *every* pixel: the figure comes back
+empty. `MpasMesh` now carries `sphere_radius`, and `rasterize` divides by that.
+
+**The geometry cache can no longer return a different mesh's polygons.** The
+server keys its cache on `path | size | mtime`. netCDF4's padded layout means
+two meshes with different cell counts can occupy identical byte sizes (a
+1-cell and a 3-cell file here are both 18436 bytes), and `st_mtime` truncates
+to whole seconds — so regenerating a mesh in place could silently reuse the
+previous geometry. The key is now
+`path | size | st_mtime_ns | nCells | nEdges`, with the counts read from the
+netCDF header (no data I/O). Costs a roughly constant ~2 ms per load.
+
+A unit-sphere mesh (`sphere_radius = 1`, straight from JIGSAW/MPAS-Tools) is
+still assumed to be Earth-sized, matching MPAS's own default — but that is now
+a stated assumption in the code, not a buried constant. Nothing in such a file
+distinguishes an Earth mesh from a small-planet one.
+
+### Packaging
+
+The server writes into its own repo (`data/`, `research/plots/`,
+`research/mesh_cache/`). A library cannot: it is installed somewhere the user
+never looks. So:
+
+- the cache moved to `~/.cache/gmpas/mesh`, overridable by `GMPAS_CACHE_DIR`
+- `save_figure(fig, path)` writes where the caller says, instead of into a
+  fixed `research/plots/`
+- relative paths resolve against `GMPAS_DATA_DIR` then the working directory,
+  instead of a project-local `data/`
+- `mesh.cell_width_km` replaces the hexagon-width formula that was repeated at
+  three call sites (identical numerics)
+- an unknown extent name or render method now raises instead of silently
+  falling back, so a typo cannot quietly produce the wrong map
+
+### Known, unfixed
+
+- `is_global` is true as soon as any cell straddles the antimeridian, so a
+  regional Pacific domain gets the whole-sphere extent and plots the entire
+  globe. Documented by a test; not changed.
+- The edge-normal wind reconstruction carries a systematic factor-of-two low
+  bias, not just noise: for uniform flow across normals evenly spread over
+  [0, π) the unweighted average returns exactly half the true speed. Direction
+  is right. Pinned by a test; prefer `uReconstructZonal` /
+  `umeridional_*` when the diagnostics file has them.

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -1,0 +1,43 @@
+# In a notebook
+
+```python
+import gmpas
+
+ds = gmpas.open_mpas("history.2012-02-25_12.00.00.nc")
+ds.mpas                       # <MPAS 413,788 cells / 1,243,651 edges — ...>
+
+ds.mpas.plot("precipw")       # returns (fig, ax); renders inline
+ds.mpas.plot("theta", level=20)
+ds.mpas.plot("u")             # edge field, drawn on the cell faces
+ds.mpas.plot_mesh()           # where the mesh refines, in km
+ds.mpas.quiver("uReconstructZonal", "uReconstructMeridional",
+               background="precipw")
+```
+
+Pass `mesh=` when the file carries no mesh of its own (a `diag.*.nc` usually
+does not) and no mesh file sits beside it.
+
+The pieces are usable directly when you want the array rather than the figure:
+
+```python
+mesh = ds.mpas.mesh
+mesh.n_cells, mesh.extent, mesh.is_global, mesh.coverage
+
+values = gmpas.select(ds["precipw"], time=0)
+img, lon, lat = gmpas.rasterize(mesh, values)      # regular lat-lon array
+gmpas.save_figure(fig, "out.png")
+```
+
+For many files as one time axis:
+
+```python
+from gmpas.series import Series
+
+run = Series("/path/to/run/")            # or a glob, or a list of paths
+len(run), run.n_files, run.labels[:3]
+values = run.values("precipw", step=7)   # opens only the file that step needs
+```
+
+For time means, composites and anomalies across a run, use
+`xarray.open_mfdataset` with dask instead — that is what it is good at, and
+`Series` deliberately does not try to replace it.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -1,0 +1,214 @@
+# Preprocessing
+
+The rest of gmpas opens a run. `gmpas prep` covers what happens before one
+exists — building a mesh and looking at it on its own.
+
+```bash
+gmpas prep view mesh.nc
+```
+
+A browser view of a mesh file with no output data anywhere near it: cells
+coloured by width, so where the mesh refines is visible at a glance.
+
+```
+8,228 cells, 24,987 edges, regional — cell width 43 to 68.1 km
+listening on 127.0.0.1:8765 — this machine only
+```
+
+Same flags as `view` for tunnelling and size: `-p/--port`, `--host`,
+`--width`, `--height`, `--no-browser`. On a compute node use `--host 0.0.0.0`
+and tunnel, exactly as for `view`.
+
+Two fields are offered, both derived from geometry the mesh cache already
+holds, so neither costs a rebuild: `cell_width_km` (the default) and
+`cell_area_km2`.
+
+**The colour scale is fixed**, taken once from the whole mesh rather than
+autoscaled to the current view. There is no vmin/vmax control to put it back,
+and that is the point: a scale that restretched as you panned would make the
+same refinement band change colour while you moved across it, which misreads a
+variable-resolution mesh badly.
+
+The layout is the `view` page reduced to what a preprocessing step uses. The
+timestep and level sliders, the colormap picker, the colour-range boxes, the
+animation panel, the exports and the probe all belong to a model run, so they
+are absent rather than disabled. Pan, zoom, graticule, scale bar and the
+extent box stay — the last because reading a domain off a mesh is how one
+picks a region.
+
+`prep.layout.page(title, panel=..., script=...)` is that layout as a reusable
+shell, with slots for a step's own controls. The sidebar's facts block is
+data-driven — a step sends `subtitle` and `stats`, so one with no cells or
+edges reuses the shell rather than forking it. `prep hfun` is the second user;
+mesh generation is meant to be the third
+([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)); like the
+remapping tools, JIGSAW would be an external executable gmpas shells out to,
+not a Python dependency.
+
+### One server, one port
+
+A run, the mesh it is on, and the distance function behind that mesh are the
+three things one wants side by side, and they used to be three processes on
+three ports — three SSH tunnels from a compute node. They are now one:
+
+```bash
+gmpas view /path/to/run/ --hfun hfun.py     # data + mesh + hfun
+gmpas prep view mesh.nc --hfun hfun.py      # mesh + hfun
+gmpas prep hfun hfun.py --mesh mesh.nc      # hfun + mesh
+```
+
+```
+2 sources on one port:
+  /mesh  mesh — maritime.region.nc · 8,228 cells
+  /hfun  hfun — hfun.py · 12 to 60 km · gradient 0.0300
+```
+
+`/` lists what is available and each page carries a switcher, so one tunnel
+reaches all of them. Opening a run gives the mesh page for free — a run always
+brings its mesh with it. Every source is constructed before the server binds,
+so a bad path is an error at the prompt rather than a 500 in a browser tab.
+
+A single source is unchanged: it is served at the root, with no index and no
+switcher, on exactly the paths it always used.
+
+### Generating a mesh with JIGSAW
+
+```bash
+export JIGSAWDIR=/path/to/jigsaw/build/src     # or wherever it installed
+gmpas prep generate hfun.py -o mesh/
+```
+
+Same division of labour as the remapping side: gmpas does not generate the mesh
+itself, it prepares every input JIGSAW needs, shells out, and reads the result
+back. What it adds is everything around the call.
+
+```
+  hfun.py: 12 to 60 km, max gradient 0.0300
+  sampling hfun onto 3336 x 1668 (5.6M points)
+  wrote GEOM.msh, HFUN.msh (32 MB) and MESH.jig
+  running jigsaw — this is the slow part
+  MESH.msh: 9,734 generating points, 19,464 triangles in 8.7 s
+```
+
+`HFUN.msh` is written the way `create_hfun.py` writes it — the same grid, the
+same `meshgrid(lats, lons)` argument order, and therefore the same
+longitude-major value ordering. Getting that order wrong would transpose the
+distance function and refine the wrong part of the planet *without failing*, so
+there is a test comparing the file back against the function elementwise.
+
+**The distance function is checked before any time is spent.** Generation takes
+minutes; measuring the gradient takes a second. A transition steeper than the
+0.03 guideline stops the run rather than producing a mesh you would throw away:
+
+```
+gmpas: hfun.py has a maximum cell size gradient of 0.0501 at 41.2, -95.0,
+above the 0.03 guideline. A mesh built from it will change cell size too
+quickly to be well behaved.
+  Widen the transition region, or raise hfun_min.
+  Pass --allow-steep to generate it anyway.
+```
+
+JIGSAW is found by `--jigsaw`, then `$JIGSAWDIR`, then `PATH` — in that order.
+PATH is last because JIGSAW installs wherever `CMAKE_INSTALL_PREFIX` pointed
+and its build tree leaves the binary in `build/src/`, so on most machines it is
+not on PATH at all. `$JIGSAWDIR` accepts either the binary or the directory
+holding it.
+
+`MESH.msh` is reused if it is already there, unless `--force`. `--init` passes
+an initial point set through to `INIT_FILE`, which is what gives a
+quasi-uniform mesh icosahedral structure — a constant `HFUN` alone produces
+7-sided cells.
+
+After JIGSAW, the run continues into the two conversion steps, so the output
+directory ends up holding everything `mkgrid` reads:
+
+```
+  SaveVertices   9,734 generating points
+  SaveTriangles  19,464 triangles
+  SaveDensity    the mesh density at each point
+  SaveCode       a copy of the hfun.py that produced them
+```
+
+`SaveVertices` and `SaveTriangles` carry the file's own tokens rather than
+floats reformatted by us, so JIGSAW's precision survives the trip, and the
+triangle indices are left exactly as JIGSAW wrote them — 0-based, which is what
+`mkgrid` expects. `SaveDensity` is MPAS's `meshDensity`:
+
+```
+rho(x) = (h_fine / h(x)) ** 4
+```
+
+one value per generating point, 1.0 where the mesh is finest.
+
+Two details are worth knowing. A real `MESH.msh` has a `POWER` block between
+`POINT` and `TRIA3` — the per-point weights for a power diagram — which
+`convert_jigsaw.py` skips only as a side effect of its counter staying at the
+limit across those lines; gmpas dispatches on section headers instead, so an
+unfamiliar block is ignored because it is unfamiliar rather than by luck. And
+`create_density` reuses the coordinates already parsed out of `MESH.msh`
+instead of reading back the `SaveVertices` it just wrote with `np.loadtxt`.
+
+All three files were checked **byte for byte** against the tutorial's own
+scripts run on the same mesh with the same interpreter.
+
+**The one step gmpas does not take is `mkgrid`**, which needs MPI and PnetCDF:
+
+```bash
+cd mesh/ && mkgrid 12000
+```
+
+That argument is `nominalMinDc` in **metres** while `hfun.py` works in km
+throughout — the one unit seam in this workflow, and an easy factor of a
+thousand to get wrong — so the command computes it for you and prints the line
+to run.
+
+### Looking at a mesh before it exists
+
+```bash
+gmpas prep hfun hfun.py            # browse it
+gmpas prep hfun hfun.py --check    # just the numbers, no server
+```
+
+In the JIGSAW workflow for MPAS-Atmosphere, a variable-resolution mesh is
+defined entirely by a small Python file. `create_hfun.py` samples it onto a
+lat-lon grid to write `HFUN.msh`, JIGSAW turns that into generating points, and
+`mkgrid` turns those into `grid.nc`. Every design decision lives in that one
+file, so this reads it on its own — no JIGSAW, no mesh, no generation time:
+
+```
+hfun.py: hfun_min 12 km, grid distance 12 to 60 km
+max cell size gradient 0.0300 at 75.64, -95.05 (within the 0.03 guideline)
+measured on the 3336 x 1668 lat-lon grid create_hfun.py would write (12 km spacing)
+```
+
+The contract is the mini-tutorial's: a module-level `hfun_min` in km, and
+`get_hfun(lon, lat)` taking **radians** and returning **km**. That function is
+called once with whole arrays and may do expensive setup — a real one might
+interpolate a raster — so it is called once per view here, never per pixel.
+
+**The gradient is the number worth having.** The tutorial's guidance is to keep
+cell size changing by no more than a few percent per km of distance, with 0.03
+generally safe, and `mesh_quality.py` reports exactly that from a finished
+`grid.nc`:
+
+```python
+nominalDx = r_earth * nominalMinDc * (1.0 / meshDensity) ** 0.25
+gradient  = abs(nominalDx[c0] - nominalDx[c1]) / dcEdge / r_earth
+```
+
+Since `meshDensity` is `(hfun_min / h) ** 4` and `nominalMinDc` is `hfun_min`,
+that is the change in grid distance between neighbouring cells over the
+distance between them. Its continuous limit is `|grad h|` with respect to arc
+length, which is what is computed here — on the same lat-lon grid
+`create_hfun.py` would write, so the number is comparable both to the 0.03
+guideline and to what `mesh_quality.py` will say once the mesh exists. The two
+polar rows are excluded: every longitude at a pole is the same point, so the
+zonal derivative there is 0/0 rather than a gradient.
+
+Two fields are offered, neither invented here: `cell_width_km` is `get_hfun`
+straight out, and `mesh_density` is `(hfun_min / h) ** 4` — MPAS's own
+`meshDensity`, 1.0 where the mesh is finest.
+
+Nothing in `prep/` modifies the postprocessing path. It imports the viewer's
+rasterizing, PNG encoding, coastline overlay and port binding, and changes
+none of them.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,15 @@
+# Status
+
+Plotting is implemented. Conservative remapping (`convert`) is next: the same
+KD-tree gives area weights by supersampling a target cell and counting which
+source cells the samples land in, which — unlike barycentric sampling —
+actually conserves cell integrals.
+
+Preprocessing now covers `prep view`, `prep hfun` and `prep generate` — looking
+at a mesh after it exists, looking at one before it exists, and running JIGSAW
+to get from the second to the first.
+
+What is still missing is `mkgrid`, the last leg from JIGSAW's output to an
+MPAS `grid.nc` ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)).
+It needs MPI and PnetCDF, so it cannot simply be vendored; everything feeding
+it is now produced by `gmpas prep generate`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,12 @@
+# Tests
+
+```bash
+pytest
+```
+
+Tests build synthetic MPAS mesh files in `tmp_path`, so no model output is
+needed and the real cache directory is never touched. They pin down the parts
+a reader cannot eyeball: the ragged 1-based `verticesOnCell` fill, the
+antimeridian unwrap, the `sphere_radius = 1` redimensionalisation, cache
+identity, and the factor-of-two bias in the edge-normal wind reconstruction.
+Rendering tests skip themselves when the `plot` extra is absent.

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,33 @@
+# Why gmpas exists
+
+## Why
+
+MPAS is unstructured: a variable-resolution spherical Voronoi tessellation,
+with scalars at cell centres and normal velocity on cell edges. That is why
+ordinary lat-lon tooling does not apply, and why the usual workarounds each
+cost something:
+
+| approach | fast? | conserves? | edge variables? |
+|---|---|---|---|
+| `uxarray` | rebuilds grid topology on every call | n/a | yes |
+| `convert_mpas` → lat-lon | yes | **no** — barycentric sampling | via remap |
+| cell polygons in a `.gpkg` | yes | n/a | **no** — centres only |
+
+gmpas keeps the good idea behind the `.gpkg` approach — mesh geometry is static
+for a whole simulation, so build it once — and generalises it. The cache is an
+`.npz` holding cell polygons, edge segments and unit-sphere coordinates, so
+edge-based fields work too, and no GIS dependency is needed.
+
+## Why it is fast
+
+1. **Cached geometry.** Building cell polygons from `verticesOnCell` is
+   vectorized (no Python loop) and then cached to `.npz`. On a small regional
+   mesh that is ~63 ms to build and ~1 ms to reload; the saving grows with mesh
+   size, and it persists across sessions.
+2. **Rasterizing instead of drawing polygons.** Polygon rendering costs
+   O(nCells) and stalls on million-cell meshes. An MPAS mesh *is* the Voronoi
+   tessellation of its cell centres, so the cell containing a point is exactly
+   the nearest cell centre — one KD-tree query, no clipping, no interpolation.
+   That makes rendering O(pixels), independent of mesh size.
+
+`method="auto"` uses polygons below ~150k cells and rasterizes above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,63 @@
+# Examples
+
+Ready-to-edit `hfun.py` templates. An `hfun.py` is the whole definition of a
+variable-resolution MPAS mesh — everything after it is mechanical — so this is
+where the design decisions live.
+
+| file | what it builds |
+|---|---|
+| [hfun_concentric.py](hfun_concentric.py) | any number of nested refinement rings about one centre |
+| [hfun_uniform.py](hfun_uniform.py) | a quasi-uniform mesh at one resolution |
+
+## Using one
+
+```bash
+cp examples/hfun_concentric.py my_mesh/hfun.py
+$EDITOR my_mesh/hfun.py                       # edit CENTER and RINGS
+
+gmpas prep hfun     my_mesh/hfun.py --check   # the numbers, before spending time
+gmpas prep hfun     my_mesh/hfun.py           # look at it in a browser
+gmpas prep generate my_mesh/hfun.py -o mesh/  # build it with JIGSAW
+```
+
+`python hfun_concentric.py` on its own prints the resolution profile it
+describes, which is the quickest way to see the effect of an edit:
+
+```
+hfun_min = 3 km, centre 38.0, -95.0
+        0 -     600 km     3.0 km
+      600 -     900 km     3.0 ->  12.0 km   slope 0.0300
+      900 -    1400 km    12.0 km
+     1400 -    2000 km    12.0 ->  30.0 km   slope 0.0300
+     2000 -    3200 km    30.0 km
+     3200 -    4200 km    30.0 ->  60.0 km   slope 0.0300
+```
+
+## The contract
+
+Both files satisfy the mini-tutorial's contract, and so will anything you write
+from scratch:
+
+- `hfun_min` — a module-level float, the minimum grid distance in **km**
+- `get_hfun(lon, lat)` — takes **radians**, returns **km**
+
+`get_hfun` is called once with whole arrays, so it may do expensive setup —
+loading a raster and building an interpolator, for instance. Nothing in gmpas
+calls it per pixel.
+
+## What to watch
+
+The one number that decides whether a mesh is well behaved is the **cell size
+gradient**: km of cell size per km of distance. The guidance is a few percent
+at most, with 0.03 generally safe. `gmpas prep hfun --check` measures it from
+the distance function alone, before any mesh exists, and `gmpas prep generate`
+refuses to run above it unless you pass `--allow-steep`.
+
+`hfun_concentric.py` derives its transition widths from a single `SLOPE`
+constant, so every transition is equally gentle by construction and a larger
+jump in resolution automatically gets the distance it needs.
+
+Two other things it checks, both failures the tutorial names: transition
+regions that overlap because the rings are too close (this raises), and
+refinement regions that are only a few tens of cells across when they want to
+be several hundred (this warns).

--- a/examples/hfun_concentric.py
+++ b/examples/hfun_concentric.py
@@ -1,0 +1,161 @@
+"""Concentric refinement rings for JIGSAW — a template to copy and edit.
+
+Any number of rings about one centre. To change the mesh, edit CENTER and RINGS
+below and nothing else; the transition widths, hfun_min, and the checks all
+follow from them.
+
+    gmpas prep hfun     hfun_concentric.py --check     # the numbers, no server
+    gmpas prep hfun     hfun_concentric.py             # look at it
+    gmpas prep generate hfun_concentric.py -o mesh/    # build it
+
+The contract this satisfies is the mini-tutorial's (Duda, MPAS/WRF Users
+Workshop 2026): a module-level `hfun_min` in km, and `get_hfun(lon, lat)`
+taking RADIANS and returning KM.
+
+Rings about *different* centres are a different problem — see the note at the
+bottom of this file.
+"""
+
+import numpy as np
+
+# ============================================================== EDIT FROM HERE
+
+#: centre of every ring, in degrees
+CENTER_LON, CENTER_LAT = -95.0, 38.0
+
+#: The rings, finest first. Each is (radius_km, spacing_km): hold `spacing_km`
+#: out to `radius_km`, then transition to the next entry. The last entry is the
+#: background everywhere beyond, and has no radius.
+#:
+#: Add a ring by adding a line. Change a resolution or a radius by editing one.
+#: You do NOT set the transition widths -- they follow from SLOPE below, so a
+#: bigger jump in resolution automatically gets the distance it needs.
+RINGS = [
+    (600.0,  3.0),      # 3 km out to 600 km from the centre
+    (1400.0, 12.0),     # 12 km out to 1400 km
+    (3200.0, 30.0),     # 30 km out to 3200 km
+    (None,   60.0),     # 60 km everywhere beyond
+]
+
+#: km of cell size per km of distance, in every transition. The tutorial's
+#: guidance is a few percent at most, with 0.03 generally safe. Giving every
+#: transition the same slope is deliberate: it is the steepest one that limits
+#: mesh quality, so there is nothing to gain by making the others gentler.
+SLOPE = 0.03
+
+# ================================================================ EDIT TO HERE
+
+#: MPAS-Atmosphere's Earth radius (km)
+R_EARTH = 6371.229
+
+#: the contract's minimum grid distance: whatever the finest ring asks for
+hfun_min = RINGS[0][1]
+
+
+def _knots():
+    """Turn RINGS into the breakpoints of a piecewise-linear h(r).
+
+    A flat band, then a ramp, repeated. Between them the radii strictly
+    increase, which is all `np.interp` needs, and beyond the last one it clamps
+    -- which is exactly "h_max everywhere outside".
+    """
+    r, h = [0.0], [RINGS[0][1]]
+    for (radius, spacing), (_, next_spacing) in zip(RINGS, RINGS[1:]):
+        width = abs(next_spacing - spacing) / SLOPE      # implied by the slope
+        r += [radius, radius + width]
+        h += [spacing, next_spacing]
+
+    _check(r)
+    return np.array(r), np.array(h)
+
+
+def _check(r):
+    """Refuse the two mistakes the tutorial calls out by name.
+
+    The cell-count figure is a rough reading of "ideally several hundred cells
+    in diameter" as 2*radius/spacing, not a rule from the tutorial. Treat it as
+    a prompt to think rather than a verdict.
+    """
+    # The breakpoints must march outwards. Anywhere they go backwards, a
+    # transition has overrun the ring meant to follow it -- the "transition
+    # regions begin to overlap" failure. Checked as plain monotonicity rather
+    # than by indexing the pairs, because getting that indexing subtly wrong is
+    # how a check silently passes a mesh it should have refused.
+    for i in range(1, len(r)):
+        if r[i] < r[i - 1]:
+            raise ValueError(
+                f"ring {(i - 1) // 2} begins at {r[i]:.0f} km, but the "
+                f"transition before it does not finish until {r[i - 1]:.0f} km "
+                f"-- they overlap. Move the rings apart, or make the jump in "
+                f"resolution between them smaller."
+            )
+
+    for i, (radius, spacing) in enumerate(RINGS[:-1]):
+        cells = 2.0 * radius / spacing
+        if cells < 200:
+            print(f"note: ring {i} is ~{cells:.0f} cells across at "
+                  f"{spacing:g} km; the guidance is several hundred")
+
+
+#: built once at import. `get_hfun` may be handed millions of points, and the
+#: checks above should speak once rather than on every frame.
+R_KNOTS, H_KNOTS = _knots()
+
+
+def get_hfun(lon, lat):
+    """Grid distance (km) at each (lon, lat), both in RADIANS.
+
+    Called once with whole arrays, so it is allowed to be expensive.
+    """
+    r = _radius_km(lon, lat)
+
+    # a piecewise-linear h(r) is exactly an interpolation over the breakpoints,
+    # so any number of rings costs one call and no extra code
+    return np.interp(r, R_KNOTS, H_KNOTS).reshape(np.shape(lon))
+
+
+def _radius_km(lon, lat):
+    """Great-circle distance (km) from the centre to each point."""
+    lam, phi = np.radians(CENTER_LON), np.radians(CENTER_LAT)
+    centre = np.array([np.cos(lam) * np.cos(phi),
+                       np.sin(lam) * np.cos(phi),
+                       np.sin(phi)])
+
+    lon, lat = np.asarray(lon), np.asarray(lat)
+    p = np.column_stack([(np.cos(lon) * np.cos(lat)).ravel(),
+                         (np.sin(lon) * np.cos(lat)).ravel(),
+                         np.sin(lat).ravel()])
+
+    # clip because round-off can push the dot product just past +-1, where
+    # arccos returns nan rather than 0 or pi
+    return R_EARTH * np.arccos(np.clip(p @ centre, -1.0, 1.0))
+
+
+if __name__ == "__main__":
+    # `python hfun_concentric.py` prints the profile it describes
+    print(f"hfun_min = {hfun_min:g} km, centre {CENTER_LAT}, {CENTER_LON}")
+    for i in range(len(R_KNOTS) - 1):
+        if H_KNOTS[i + 1] != H_KNOTS[i]:
+            span = R_KNOTS[i + 1] - R_KNOTS[i]
+            slope = (H_KNOTS[i + 1] - H_KNOTS[i]) / span
+            print(f"  {R_KNOTS[i]:7.0f} - {R_KNOTS[i + 1]:7.0f} km   "
+                  f"{H_KNOTS[i]:5.1f} -> {H_KNOTS[i + 1]:5.1f} km   "
+                  f"slope {slope:.4f}")
+        else:
+            print(f"  {R_KNOTS[i]:7.0f} - {R_KNOTS[i + 1]:7.0f} km   "
+                  f"{H_KNOTS[i]:5.1f} km")
+
+
+# --------------------------------------------------------------------- notes
+#
+# Rings about DIFFERENT centres cannot be written as one h(r). Compute a full
+# field for each and take the pointwise minimum:
+#
+#     def get_hfun(lon, lat):
+#         return np.minimum(_ring_field(lon, lat, centre_a, ...),
+#                           _ring_field(lon, lat, centre_b, ...))
+#
+# For a nested pair the child must return np.inf beyond its own transition, so
+# the minimum falls back to the parent; the child and its transition must sit
+# entirely inside the parent, and the two must agree on the resolution where
+# they meet.

--- a/examples/hfun_uniform.py
+++ b/examples/hfun_uniform.py
@@ -1,0 +1,27 @@
+"""A quasi-uniform mesh — the simplest hfun.py there is.
+
+    gmpas prep hfun     hfun_uniform.py --check
+    gmpas prep generate hfun_uniform.py -o mesh/
+
+A constant distance function is not quite enough on its own. JIGSAW will
+produce a mesh at the right resolution, but with 7-sided cells and less
+desirable shapes, because nothing imposes icosahedral structure on it. To get
+that structure, hand JIGSAW an initial point set:
+
+    sphtri_subdiv ICOS.msh 120KM.msh 63        # from islas/mesh_tools
+    gmpas prep generate hfun_uniform.py --init 120KM.msh -o mesh/
+
+`ICOS.msh` ships with the mini-tutorial repository. The divisor sets the
+resolution: with R = 6371.229 km the base icosahedron has dx = 7053.898 km, so
+a divisor of n gives roughly dx/n.
+"""
+
+import numpy as np
+
+#: the grid distance everywhere, in km
+hfun_min = 120.0
+
+
+def get_hfun(lon, lat):
+    """Grid distance (km) at each (lon, lat), both in RADIANS."""
+    return np.full(np.shape(lon), hfun_min)


### PR DESCRIPTION
README goes from **656 lines to 89** — introduction, installation, usage, and an
index — with each section its own file under `docs/`. Stacks on #27.

Nothing was rewritten in the move except the introduction. Sections were cut out
programmatically rather than retyped, and the old same-page anchors
(`#conservative-remapping` etc.) were rewritten to point at the files those
sections now live in. All relative links verified to resolve.

| | |
|---|---|
| `docs/why.md` | Why + Why it is fast |
| `docs/installation.md` | Install anywhere |
| `docs/command-line.md` | Command line |
| `docs/notebook.md` | In a notebook |
| `docs/preprocessing.md` | Preprocessing |
| `docs/cluster.md` | On a cluster |
| `docs/configuration.md` | Configuration |
| `docs/testing.md` | Tests |
| `docs/layout.md` | Layout |
| `docs/mcp-server.md` | Differences from the MCP server |
| `docs/status.md` | Status |

## Two things worth flagging

**`docs/REMAPPING.md` already existed** and is the fuller document — 348 lines
against the README section's 121, which was a summary that already linked to it.
So the index points at the existing file and the summary is gone rather than
duplicated. Before dropping it I checked every command, code block and
substantive claim against `REMAPPING.md`: `startlat`, `mesh_file`,
`include_fields`/`exclude_fields`, "include wins", the conservation figures
`1.1e-16` and `2.1e-05`, `area_b`, `ncremap -a aave`, `SLURM_CPUS_PER_TASK`, the
`-j` guidance and issue 2 are all already there.

**That check mattered, because on the way to it I overwrote `REMAPPING.md`.**
macOS is case-insensitive, so writing `docs/remapping.md` landed on
`docs/REMAPPING.md` and cut it from 348 lines to 60. Restored from git, and the
generated file dropped in favour of the existing one. Worth knowing before
anyone adds a `docs/Installation.md` beside `docs/installation.md`.

## examples/

New, and the thing most likely to be used directly:

- **`hfun_concentric.py`** — any number of nested refinement rings about one
  centre. You edit `CENTER` and `RINGS`; you do *not* set transition widths,
  which are derived from a single `SLOPE` constant so every transition is
  equally gentle by construction and a larger jump in resolution automatically
  gets the distance it needs. Guards against the two failures the tutorial
  names: overlapping transitions raise, undersized rings warn.
- **`hfun_uniform.py`** — the simplest hfun there is, plus a note on why a
  constant distance function alone gives 7-sided cells and how `INIT_FILE` fixes
  it.

Running either as a script prints the profile it describes:

```
hfun_min = 3 km, centre 38.0, -95.0
        0 -     600 km     3.0 km
      600 -     900 km     3.0 ->  12.0 km   slope 0.0300
      900 -    1400 km    12.0 km
     1400 -    2000 km    12.0 ->  30.0 km   slope 0.0300
     2000 -    3200 km    30.0 km
     3200 -    4200 km    30.0 ->  60.0 km   slope 0.0300
```

Both verified under `gmpas prep hfun --check` at exactly 0.0300.

## Badges

The tests workflow, plus static version, python and licence badges. The Actions
badge 404s for anonymous requests because the repository is private — it renders
for anyone who can see the repository at all, which is the only audience it has.
The three shields.io badges return 200.

268 tests still pass; this touches no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
