### PR TITLE
release: 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gmpas
 
 [![tests](https://github.com/nmathewa/gmpas-lib/actions/workflows/tests.yml/badge.svg)](https://github.com/nmathewa/gmpas-lib/actions/workflows/tests.yml)
-[![version](https://img.shields.io/badge/version-0.3.0-blue)](docs/status.md)
+[![version](https://img.shields.io/badge/version-0.4.0-blue)](docs/status.md)
 [![python](https://img.shields.io/badge/python-3.10%2B-blue)](docs/installation.md)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,15 +1,34 @@
 # Status
 
-Plotting is implemented. Conservative remapping (`convert`) is next: the same
-KD-tree gives area weights by supersampling a target cell and counting which
-source cells the samples land in, which — unlike barycentric sampling —
-actually conserves cell integrals.
+As of 0.4.0, gmpas covers the pipeline from both ends.
 
-Preprocessing now covers `prep view`, `prep hfun` and `prep generate` — looking
-at a mesh after it exists, looking at one before it exists, and running JIGSAW
-to get from the second to the first.
+**Postprocessing** — plotting, the interactive viewer, and conservative
+remapping — is implemented. gmpas does not compute remapping weights itself;
+it writes the grid files ESMF or TempestRemap need, applies the result and
+checks that it conserved. See [REMAPPING.md](./REMAPPING.md).
 
-What is still missing is `mkgrid`, the last leg from JIGSAW's output to an
-MPAS `grid.nc` ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)).
-It needs MPI and PnetCDF, so it cannot simply be vendored; everything feeding
-it is now produced by `gmpas prep generate`.
+**Preprocessing** covers `prep view`, `prep hfun` and `prep generate`: looking
+at a mesh after it exists, looking at a distance function before any mesh
+exists, and running JIGSAW to get from the second to the first. A run leaves
+everything `mkgrid` reads.
+
+## Not implemented
+
+- **`mkgrid`**, the last leg from JIGSAW's output to an MPAS `grid.nc`
+  ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)). It needs MPI
+  and PnetCDF, so it cannot simply be vendored. Everything feeding it is
+  produced by `gmpas prep generate`, and the command prints the exact
+  `mkgrid` line to run, with `nominalMinDc` already converted to metres.
+- **Applying weights from the command line**
+  ([issue 2](https://github.com/nmathewa/gmpas-lib/issues/2)). `ncremap -m`
+  does it today.
+- **Comparing a generated mesh against the `hfun.py` that asked for it** —
+  the two are one click apart in the viewer, but nothing yet differences them.
+
+## Known rough edges
+
+- Browsing `prep hfun` is slower than it should be on some machines
+  ([issue 25](https://github.com/nmathewa/gmpas-lib/issues/25)). The
+  distance function is re-evaluated over every pixel of every new view,
+  and there is a lot of headroom to exploit — it is a function, so the
+  sampling is entirely ours to choose.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.3.0"
+version = "0.4.0"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     # entry points


### PR DESCRIPTION
Version bump to 0.4.0 and a status-doc correction, ahead of tagging the release.

Six PRs landed since v0.2.0 (#22, #23, #24, #26, #27, #28). `pyproject.toml` said 0.3.0, but that bump shipped only the hfun viewer — the dashboard, JIGSAW generation and the mkgrid inputs all came after it.

Also rewrites `docs/status.md`, which still opened with "Conservative remapping (`convert`) is next". It shipped in 0.2.0. Now states what is implemented, what is not (`mkgrid`, applying weights from the CLI, diffing a mesh against its `hfun.py`), and the known rough edge in #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)