### PR TITLE
prep generate: one command from hfun.py to grid.nc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gmpas
 
 [![tests](https://github.com/nmathewa/gmpas-lib/actions/workflows/tests.yml/badge.svg)](https://github.com/nmathewa/gmpas-lib/actions/workflows/tests.yml)
-[![version](https://img.shields.io/badge/version-0.4.0-blue)](docs/status.md)
+[![version](https://img.shields.io/badge/version-0.4.1-blue)](docs/status.md)
 [![python](https://img.shields.io/badge/python-3.10%2B-blue)](docs/installation.md)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -58,7 +58,7 @@ gmpas view          /path/to/run/
 gmpas remap         history.*.nc -o out/
 gmpas prep view     mesh.nc
 gmpas prep hfun     hfun.py --check
-gmpas prep generate hfun.py -o mesh/
+gmpas prep generate hfun.py -o mesh/     # needs $JIGSAWDIR and $MKGRIDFILE
 ```
 
 Any path may be a file, a directory, or a glob; a directory or glob is read as

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -74,21 +74,65 @@ switcher, on exactly the paths it always used.
 ### Generating a mesh with JIGSAW
 
 ```bash
-export JIGSAWDIR=/path/to/jigsaw/build/src     # or wherever it installed
+export JIGSAWDIR=/path/to/jigsaw/build/src            # or .../bin
+export MKGRIDFILE=/path/to/mpas_jigsaw_tutorial/mkgrid
 gmpas prep generate hfun.py -o mesh/
 ```
 
-Same division of labour as the remapping side: gmpas does not generate the mesh
-itself, it prepares every input JIGSAW needs, shells out, and reads the result
-back. What it adds is everything around the call.
+One command from a distance function to an MPAS `grid.nc`:
 
 ```
-  hfun.py: 12 to 60 km, max gradient 0.0300
-  sampling hfun onto 3336 x 1668 (5.6M points)
-  wrote GEOM.msh, HFUN.msh (32 MB) and MESH.jig
+  hfun_uniform.py: 120 to 120 km, max gradient 0.0000
+  sampling hfun onto 334 x 167 (0.1M points)
+  wrote GEOM.msh, HFUN.msh (0 MB) and MESH.jig
   running jigsaw — this is the slow part
-  MESH.msh: 9,734 generating points, 19,464 triangles in 8.7 s
+  MESH.msh: 41,225 generating points, 82,446 triangles in 37.4 s
+  SaveVertices (41,225) and SaveTriangles (82,446)
+  SaveDensity (1 to 1)
+  running mkgrid 120000 (nominalMinDc in metres = hfun_min * 1000)
+  grid.nc: 41,225 cells (49 MB) in 0.4 s
 ```
+
+Same division of labour as the remapping side: gmpas does not generate the mesh
+itself, it prepares every input the external tools need, shells out, and reads
+the result back.
+
+#### Both executables are prerequisites
+
+`$JIGSAWDIR` and `$MKGRIDFILE` must be set, or the run stops before it starts.
+Either variable takes the executable itself or the directory holding it, and
+`--jigsaw` / `--mkgrid` override them.
+
+**There is deliberately no `PATH` fallback.** Both tools are built by hand into
+a location of the builder's choosing — JIGSAW wherever `CMAKE_INSTALL_PREFIX`
+pointed, `mkgrid` wherever the tutorial repository was cloned — so `PATH` is the
+exception rather than the rule, and silently picking up some other binary of the
+same name is a worse outcome than a sentence naming the variable to set.
+
+Both are resolved **before any work**, because discovering that `mkgrid` is
+missing after JIGSAW has run for five minutes helps nobody:
+
+```
+gmpas: $MKGRIDFILE is not set, so mkgrid cannot be run.
+  It is mkgrid.c in the mini-tutorial repository, and has to be built:
+    git clone https://github.com/mgduda/mpas_jigsaw_tutorial.git
+    cd mpas_jigsaw_tutorial
+    export PNETCDF=$(brew --prefix pnetcdf)   # or your PnetCDF prefix
+    make                                      # needs mpicc
+  then:
+    export MKGRIDFILE=<path>/mpas_jigsaw_tutorial/mkgrid
+  or pass --mkgrid.
+```
+
+`mkgrid` is not released anywhere on its own — it is `mkgrid.c` in the
+[mini-tutorial repository](https://github.com/mgduda/mpas_jigsaw_tutorial),
+built against MPI and PnetCDF. JIGSAW is also on conda-forge
+(`conda install -c conda-forge jigsaw`) if you would rather not build it.
+
+Use `--skip-mkgrid` to stop after the `Save*` files; `$MKGRIDFILE` is then not
+needed.
+
+#### What it writes
 
 `HFUN.msh` is written the way `create_hfun.py` writes it — the same grid, the
 same `meshgrid(lats, lons)` argument order, and therefore the same
@@ -96,9 +140,24 @@ longitude-major value ordering. Getting that order wrong would transpose the
 distance function and refine the wrong part of the planet *without failing*, so
 there is a test comparing the file back against the function elementwise.
 
-**The distance function is checked before any time is spent.** Generation takes
-minutes; measuring the gradient takes a second. A transition steeper than the
-0.03 guideline stops the run rather than producing a mesh you would throw away:
+`SaveVertices` and `SaveTriangles` carry the file's own tokens rather than
+floats reformatted by us, so JIGSAW's precision survives and the triangle
+indices stay exactly as written — 0-based, which is what `mkgrid` expects.
+`SaveDensity` is MPAS's `meshDensity`, `(h_fine / h(x)) ** 4`, one value per
+generating point. All three were checked **byte for byte** against the
+tutorial's own scripts.
+
+A real `MESH.msh` has a `POWER` block between `POINT` and `TRIA3` — per-point
+weights for a power diagram — which `convert_jigsaw.py` skips only as a side
+effect of its counter staying at the limit across those lines. gmpas dispatches
+on section headers instead, so an unfamiliar block is ignored because it is
+unfamiliar rather than by luck.
+
+#### Checked before any time is spent
+
+Generation takes minutes; measuring the gradient takes a second. A transition
+steeper than the 0.03 guideline stops the run rather than producing a mesh you
+would throw away:
 
 ```
 gmpas: hfun.py has a maximum cell size gradient of 0.0501 at 41.2, -95.0,
@@ -108,59 +167,27 @@ quickly to be well behaved.
   Pass --allow-steep to generate it anyway.
 ```
 
-JIGSAW is found by `--jigsaw`, then `$JIGSAWDIR`, then `PATH` — in that order.
-PATH is last because JIGSAW installs wherever `CMAKE_INSTALL_PREFIX` pointed
-and its build tree leaves the binary in `build/src/`, so on most machines it is
-not on PATH at all. `$JIGSAWDIR` accepts either the binary or the directory
-holding it.
+`MESH.msh` and `grid.nc` are reused if already present, unless `--force`.
+`--init` passes an initial point set through to `INIT_FILE`, which is what
+gives a quasi-uniform mesh icosahedral structure — a constant `HFUN` alone
+produces 7-sided cells.
 
-`MESH.msh` is reused if it is already there, unless `--force`. `--init` passes
-an initial point set through to `INIT_FILE`, which is what gives a
-quasi-uniform mesh icosahedral structure — a constant `HFUN` alone produces
-7-sided cells.
+#### A trap worth knowing
 
-After JIGSAW, the run continues into the two conversion steps, so the output
-directory ends up holding everything `mkgrid` reads:
+`MESH.jig` names `GEOM.msh` and `HFUN.msh` **relatively**, and JIGSAW resolves
+those against its *working directory* — not the `.jig` file's directory, and not
+the executable's. Measured:
 
-```
-  SaveVertices   9,734 generating points
-  SaveTriangles  19,464 triangles
-  SaveDensity    the mesh density at each point
-  SaveCode       a copy of the hfun.py that produced them
-```
+| setup | result |
+|---|---|
+| cwd = the files' directory, binary called by absolute path | works |
+| cwd elsewhere, `.jig` passed by absolute path | fails |
+| cwd elsewhere, binary symlinked into cwd | fails |
+| cwd elsewhere, absolute paths written inside `MESH.jig` | works |
 
-`SaveVertices` and `SaveTriangles` carry the file's own tokens rather than
-floats reformatted by us, so JIGSAW's precision survives the trip, and the
-triangle indices are left exactly as JIGSAW wrote them — 0-based, which is what
-`mkgrid` expects. `SaveDensity` is MPAS's `meshDensity`:
-
-```
-rho(x) = (h_fine / h(x)) ** 4
-```
-
-one value per generating point, 1.0 where the mesh is finest.
-
-Two details are worth knowing. A real `MESH.msh` has a `POWER` block between
-`POINT` and `TRIA3` — the per-point weights for a power diagram — which
-`convert_jigsaw.py` skips only as a side effect of its counter staying at the
-limit across those lines; gmpas dispatches on section headers instead, so an
-unfamiliar block is ignored because it is unfamiliar rather than by luck. And
-`create_density` reuses the coordinates already parsed out of `MESH.msh`
-instead of reading back the `SaveVertices` it just wrote with `np.loadtxt`.
-
-All three files were checked **byte for byte** against the tutorial's own
-scripts run on the same mesh with the same interpreter.
-
-**The one step gmpas does not take is `mkgrid`**, which needs MPI and PnetCDF:
-
-```bash
-cd mesh/ && mkgrid 12000
-```
-
-That argument is `nominalMinDc` in **metres** while `hfun.py` works in km
-throughout — the one unit seam in this workflow, and an easy factor of a
-thousand to get wrong — so the command computes it for you and prints the line
-to run.
+gmpas always runs it in the output directory, so this cannot bite here. It is
+recorded because it does bite when running JIGSAW by hand: it prints
+`**parse error: file not found!` and exits 2.
 
 ### Looking at a mesh before it exists
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -14,11 +14,10 @@ everything `mkgrid` reads.
 
 ## Not implemented
 
-- **`mkgrid`**, the last leg from JIGSAW's output to an MPAS `grid.nc`
-  ([issue 15](https://github.com/nmathewa/gmpas-lib/issues/15)). It needs MPI
-  and PnetCDF, so it cannot simply be vendored. Everything feeding it is
-  produced by `gmpas prep generate`, and the command prints the exact
-  `mkgrid` line to run, with `nominalMinDc` already converted to metres.
+- **Bundling JIGSAW or mkgrid.** Both are external executables gmpas shells
+  out to, named by `$JIGSAWDIR` and `$MKGRIDFILE`. `gmpas prep generate` runs
+  the whole chain through to `grid.nc`, but only if you have built them
+  ([issue 30](https://github.com/nmathewa/gmpas-lib/issues/30)).
 - **Applying weights from the command line**
   ([issue 2](https://github.com/nmathewa/gmpas-lib/issues/2)). `ncremap -m`
   does it today.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.0"
+version = "0.4.1"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = [
     # entry points

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -123,8 +123,9 @@ one time series across files, which is how MPAS writes output.
 environment:
   GMPAS_CACHE_DIR   where cached mesh geometry goes (default ~/.cache/gmpas/mesh)
   GMPAS_DATA_DIR    tried first when resolving relative paths
-  JIGSAWDIR         the jigsaw executable, or the directory holding it,
-                    for `gmpas prep generate`
+  JIGSAWDIR         the jigsaw executable, or the directory holding it
+  MKGRIDFILE        the mkgrid executable, or the directory holding it
+                    both required by `gmpas prep generate`
 """
 
 
@@ -566,7 +567,8 @@ def _prep_generate(args) -> int:
     print(f"generating a mesh from {args.hfun_file}")
     result = generate(args.hfun_file, out_dir=args.out, jigsaw=args.jigsaw,
                       qlim=args.qlim, init=args.init, force=args.force,
-                      allow_steep=args.allow_steep)
+                      allow_steep=args.allow_steep, mkgrid=args.mkgrid,
+                      skip_mkgrid=args.skip_mkgrid)
     print(next_steps(result, args.out))
     return 0
 
@@ -729,9 +731,15 @@ def build_parser() -> argparse.ArgumentParser:
                          "get_hfun(lon, lat)")
     pg.add_argument("-o", "--out", default="mesh",
                    help="directory for the JIGSAW files (default: mesh/)")
-    pg.add_argument("--jigsaw", help="path to the jigsaw executable, or the "
-                                     "directory holding it. Defaults to "
-                                     "$JIGSAWDIR, then PATH")
+    pg.add_argument("--jigsaw", help="the jigsaw executable, or the directory "
+                                     "holding it. Overrides $JIGSAWDIR, which "
+                                     "is otherwise required")
+    pg.add_argument("--mkgrid", help="the mkgrid executable, or the directory "
+                                     "holding it. Overrides $MKGRIDFILE, which "
+                                     "is otherwise required")
+    pg.add_argument("--skip-mkgrid", action="store_true",
+                    help="stop after the Save* files, without building "
+                         "grid.nc (then $MKGRIDFILE is not needed)")
     pg.add_argument("--init", help="a JIGSAW mesh file of initial points, for "
                                    "a quasi-uniform mesh with icosahedral "
                                    "structure (INIT_FILE)")

--- a/src/gmpas/prep/generate.py
+++ b/src/gmpas/prep/generate.py
@@ -35,6 +35,11 @@ from .hfun import GRADIENT_GUIDELINE, R_EARTH_KM, Hfun, analysis_grid, diagnose
 #: said. Either the executable itself or the directory holding it.
 JIGSAW_ENV = "JIGSAWDIR"
 
+#: environment variable pointing at mkgrid. mkgrid is not released anywhere on
+#: its own -- it is mkgrid.c in the mini-tutorial repository, built against MPI
+#: and PnetCDF -- so there is no package to depend on and no PATH convention.
+MKGRID_ENV = "MKGRIDFILE"
+
 #: what `MESH.jig` says. Straight from the tutorial; MESH_FILE and the two
 #: input files are filled in per run.
 JIG_TEMPLATE = """# written by gmpas prep generate
@@ -68,6 +73,10 @@ class Generated:
     reused: bool
     out_dir: Path = Path(".")
     hfun_min_km: float = 0.0
+    grid_nc: Path | None = None      # set once mkgrid has run
+    graph_info: Path | None = None
+    cells: int = 0
+    mkgrid_seconds: float = 0.0
 
     @property
     def nominal_min_dc(self) -> float:
@@ -83,47 +92,73 @@ class Generated:
 # ------------------------------------------------------------- the executable
 
 
-def find_jigsaw(explicit: str | Path | None = None) -> Path:
-    """Locate the JIGSAW executable: `--jigsaw`, then `$JIGSAWDIR`, then PATH.
+def _resolve_tool(explicit, env_var: str, name: str, how: str) -> Path:
+    """An external executable, from `--flag` or from the environment.
 
-    PATH last, not first. JIGSAW installs wherever `CMAKE_INSTALL_PREFIX`
-    pointed and its build tree leaves the binary in `build/src/`, so on most
-    machines it is not on PATH at all and `$JIGSAWDIR` is how you say where it
-    went. Either form works — the directory holding it, or the binary itself —
-    because both are things people reasonably put in that variable.
+    Deliberately no PATH fallback. Both of these are built by hand into a
+    location of the builder's choosing -- JIGSAW wherever CMAKE_INSTALL_PREFIX
+    pointed, mkgrid wherever the tutorial repository was cloned -- so PATH is
+    the exception rather than the rule, and silently picking up some other
+    binary of the same name is a worse outcome than a sentence saying which
+    variable to set. Naming the tool is a prerequisite, like a compiler.
     """
-    if explicit:
-        p = Path(explicit).expanduser()
-        if p.is_dir():                       # a build directory, not the binary
-            p = p / "jigsaw"
-        if not p.exists():
-            raise GenerateError(
-                f"no jigsaw executable at {p}. Point --jigsaw or "
-                f"${JIGSAW_ENV} at the binary, or at the directory holding it."
-            )
-        if not os.access(p, os.X_OK):
-            raise GenerateError(f"{p} is not executable")
-        return p.resolve()
+    if not explicit:
+        explicit = os.environ.get(env_var)
+    if not explicit:
+        raise GenerateError(
+            f"${env_var} is not set, so {name} cannot be run.\n{how}"
+        )
 
-    env = os.environ.get(JIGSAW_ENV)
-    if env:
-        return find_jigsaw(env)
+    p = Path(explicit).expanduser()
+    if p.is_dir():                    # the directory holding it, not the binary
+        p = p / name
+    if not p.exists():
+        raise GenerateError(
+            f"no {name} executable at {p}\n"
+            f"  Point ${env_var} at the binary, or at the directory holding it."
+        )
+    if not os.access(p, os.X_OK):
+        raise GenerateError(
+            f"{p} is not executable\n"
+            f"  chmod +x it, or point ${env_var} somewhere else."
+        )
+    return p.resolve()
 
-    found = shutil.which("jigsaw")
-    if found:
-        return Path(found).resolve()
 
-    raise GenerateError(
-        f"jigsaw is not on your PATH and ${JIGSAW_ENV} is not set, so the "
-        f"mesh cannot be generated. Build it with:\n"
-        f"    git clone https://github.com/dengwirda/jigsaw.git\n"
-        f"    cd jigsaw && mkdir build && cd build\n"
-        f"    cmake .. -DCMAKE_BUILD_TYPE=Release "
-        f"-DCMAKE_INSTALL_PREFIX=<where>\n"
-        f"    make -j 4 install\n"
-        f"then point gmpas at it:\n"
-        f"    export {JIGSAW_ENV}=<where>/bin          # or .../build/src\n"
-        f"or pass --jigsaw. gmpas deliberately does not generate meshes itself."
+def find_jigsaw(explicit: str | Path | None = None) -> Path:
+    """The JIGSAW executable, from `--jigsaw` or `$JIGSAWDIR`."""
+    return _resolve_tool(
+        explicit, JIGSAW_ENV, "jigsaw",
+        "  Build it:\n"
+        "    git clone https://github.com/dengwirda/jigsaw.git\n"
+        "    cd jigsaw && mkdir build && cd build\n"
+        "    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<where>\n"
+        "    make -j 4 install\n"
+        "  then:\n"
+        f"    export {JIGSAW_ENV}=<where>/bin        # or .../jigsaw/build/src\n"
+        "  or pass --jigsaw. It is also on conda-forge: conda install -c "
+        "conda-forge jigsaw",
+    )
+
+
+def find_mkgrid(explicit: str | Path | None = None) -> Path:
+    """The mkgrid executable, from `--mkgrid` or `$MKGRIDFILE`.
+
+    mkgrid is not released anywhere on its own -- it is `mkgrid.c` in the
+    MPAS/WRF mini-tutorial repository, built against MPI and PnetCDF -- so
+    there is nowhere for gmpas to fetch it from and nothing to fall back on.
+    """
+    return _resolve_tool(
+        explicit, MKGRID_ENV, "mkgrid",
+        "  It is mkgrid.c in the mini-tutorial repository, and has to be "
+        "built:\n"
+        "    git clone https://github.com/mgduda/mpas_jigsaw_tutorial.git\n"
+        "    cd mpas_jigsaw_tutorial\n"
+        "    export PNETCDF=$(brew --prefix pnetcdf)   # or your PnetCDF prefix\n"
+        "    make                                      # needs mpicc\n"
+        "  then:\n"
+        f"    export {MKGRID_ENV}=<path>/mpas_jigsaw_tutorial/mkgrid\n"
+        "  or pass --mkgrid.",
     )
 
 
@@ -302,15 +337,19 @@ def read_msh_counts(path: Path) -> tuple[int, int]:
 def generate(hfun_path, out_dir="mesh", jigsaw: str | Path | None = None,
              qlim: float = DEFAULT_QLIM, init: str | None = None,
              force: bool = False, quiet: bool = False,
-             allow_steep: bool = False) -> Generated:
-    """Take an `hfun.py` all the way to a JIGSAW `MESH.msh`.
+             allow_steep: bool = False, mkgrid: str | Path | None = None,
+             skip_mkgrid: bool = False) -> Generated:
+    """Take an `hfun.py` all the way to an MPAS `grid.nc`.
 
-    Everything is checked before anything is spent: the executable is located,
-    the distance function is loaded and measured, and a transition steeper than
-    the guideline stops the run rather than producing a mesh that has to be
-    thrown away. Generation takes minutes and the check takes a second.
+    Everything is checked before anything is spent: BOTH executables are
+    located, the distance function is loaded and measured, and a transition
+    steeper than the guideline stops the run rather than producing a mesh that
+    has to be thrown away. Generation takes minutes; the checks take a second,
+    and finding out that mkgrid is missing after JIGSAW has run for five
+    minutes helps nobody.
     """
     tool = find_jigsaw(jigsaw)
+    mkgrid_tool = None if skip_mkgrid else find_mkgrid(mkgrid)
     hfun = Hfun.load(hfun_path)
 
     out = Path(out_dir)
@@ -324,6 +363,7 @@ def generate(hfun_path, out_dir="mesh", jigsaw: str | Path | None = None,
         result = Generated(mesh_msh, points, triangles, 0.0, reused=True,
                            out_dir=out, hfun_min_km=hfun.hfun_min)
         _mkgrid_inputs(hfun, result, out, quiet=quiet)
+        run_mkgrid(mkgrid_tool, result, out, force=force, quiet=quiet)
         return result
 
     d = diagnose(hfun)
@@ -369,6 +409,7 @@ def generate(hfun_path, out_dir="mesh", jigsaw: str | Path | None = None,
     result = Generated(mesh_msh, points, triangles, seconds, reused=False,
                        out_dir=out, hfun_min_km=hfun.hfun_min)
     _mkgrid_inputs(hfun, result, out, quiet=quiet)
+    run_mkgrid(mkgrid_tool, result, out, force=force, quiet=quiet)
     return result
 
 
@@ -380,23 +421,90 @@ def _mkgrid_inputs(hfun: Hfun, result: Generated, out: Path,
     save_code(hfun, out)
 
 
-def next_steps(result: Generated, out_dir=None) -> str:
-    """The one step gmpas cannot take for you, spelled out.
+def run_mkgrid(tool: Path | None, result: Generated, out: Path,
+               force: bool = False, quiet: bool = False) -> None:
+    """The last leg: generating points and their triangulation -> grid.nc.
 
-    The argument mkgrid wants is in metres while hfun.py is in km throughout,
-    so it is computed here rather than left as an exercise.
+    mkgrid takes one argument, `nominalMinDc` in METRES, while hfun.py works in
+    km throughout. That factor of a thousand is the only unit seam in the
+    workflow, so it is computed rather than typed.
+
+    Like jigsaw, it insists on running where its inputs are: the Save* names it
+    opens are relative to the working directory.
     """
+    if tool is None:
+        return
+
+    grid = out / "grid.nc"
+    graph = out / "graph.info"
+    if grid.exists() and not force:
+        if not quiet:
+            print(f"  reusing {grid}")
+    else:
+        nominal = result.nominal_min_dc
+        if not quiet:
+            print(f"  running {tool.name} {nominal:g} "
+                  f"(nominalMinDc in metres = hfun_min * 1000)")
+        grid.unlink(missing_ok=True)
+
+        t0 = time.perf_counter()
+        done = subprocess.run([str(tool), f"{nominal:g}"], cwd=out,
+                              capture_output=True, text=True)
+        result.mkgrid_seconds = time.perf_counter() - t0
+
+        if done.returncode != 0 or not grid.exists():
+            tail = (done.stdout or done.stderr or "").strip().splitlines()[-8:]
+            raise GenerateError(
+                f"mkgrid failed (exit {done.returncode}) after "
+                f"{result.mkgrid_seconds:.1f} s.\n"
+                + "\n".join(f"    {line}" for line in tail)
+            )
+
+    result.grid_nc = grid
+    result.graph_info = graph if graph.exists() else None
+    result.cells = _cell_count(grid)
+    if not quiet:
+        size = grid.stat().st_size / 1e6
+        print(f"  grid.nc: {result.cells:,} cells ({size:.0f} MB)"
+              + (f" in {result.mkgrid_seconds:.1f} s"
+                 if result.mkgrid_seconds else ""))
+
+
+def _cell_count(grid: Path) -> int:
+    """nCells straight from the netCDF header -- no data is read."""
+    try:
+        import netCDF4
+
+        with netCDF4.Dataset(grid) as nc:
+            return len(nc.dimensions.get("nCells", ()))
+    except Exception:
+        return 0
+
+
+def next_steps(result: Generated, out_dir=None) -> str:
+    """What was produced, and what to do with it."""
     out = Path(out_dir) if out_dir is not None else result.out_dir
+
+    if result.grid_nc is None:
+        # --skip-mkgrid: say exactly what is left, with the units already done
+        return (
+            f"\n{out}/ holds everything mkgrid reads:\n"
+            f"    SaveVertices   {result.points:,} generating points\n"
+            f"    SaveTriangles  {result.triangles:,} triangles\n"
+            f"    SaveDensity    the mesh density at each point\n"
+            f"    SaveCode       a copy of the hfun.py that produced them\n"
+            f"\nmkgrid was skipped. To finish by hand:\n"
+            f"    cd {out} && mkgrid {result.nominal_min_dc:g}\n"
+            f"That argument is nominalMinDc in METRES; hfun.py works in km, "
+            f"so it is hfun_min * 1000."
+        )
+
+    graph = (f"    {result.graph_info}   METIS input: "
+             f"gpmetis graph.info <nparts>\n" if result.graph_info else "")
     return (
-        f"\n{out}/ now holds everything mkgrid reads:\n"
-        f"    SaveVertices   {result.points:,} generating points\n"
-        f"    SaveTriangles  {result.triangles:,} triangles\n"
-        f"    SaveDensity    the mesh density at each point\n"
-        f"    SaveCode       a copy of the hfun.py that produced them\n"
-        f"\nThe last step is mkgrid, which gmpas does not run — it needs MPI "
-        f"and PnetCDF:\n"
-        f"    cd {out} && mkgrid {result.nominal_min_dc:g}\n"
-        f"That argument is nominalMinDc in METRES; hfun.py works in km, so it "
-        f"is hfun_min * 1000.\nIt writes grid.nc and graph.info, and "
-        f"`gmpas prep view {out}/grid.nc` will open the result."
+        f"\n{result.grid_nc}   {result.cells:,} cells\n"
+        f"{graph}"
+        f"\nLook at it:\n"
+        f"    gmpas info      {result.grid_nc} --mesh-only\n"
+        f"    gmpas prep view {result.grid_nc}"
     )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -53,8 +53,13 @@ def write_hfun_py(path, h_min=COARSE, h_max=400.0, t_end=20000.0):
 
 
 jigsaw_available = pytest.mark.skipif(
-    shutil.which("jigsaw") is None and not os.environ.get("JIGSAWDIR"),
-    reason="jigsaw is not installed (set JIGSAWDIR or put it on PATH)",
+    not os.environ.get("JIGSAWDIR"),
+    reason="jigsaw is not available (set JIGSAWDIR)",
+)
+
+mkgrid_available = pytest.mark.skipif(
+    not os.environ.get("MKGRIDFILE"),
+    reason="mkgrid is not available (set MKGRIDFILE)",
 )
 
 
@@ -195,7 +200,8 @@ def test_a_steep_transition_stops_the_run_before_jigsaw(tmp_path):
     steep = write_hfun_py(tmp_path / "steep" / "hfun.py",
                           h_max=400.0, t_end=2400.0)
     with pytest.raises(GenerateError) as exc:
-        generate(steep, out_dir=tmp_path / "out", jigsaw="/bin/echo")
+        generate(steep, out_dir=tmp_path / "out", jigsaw="/bin/echo",
+                 skip_mkgrid=True)
 
     msg = str(exc.value)
     assert "gradient" in msg
@@ -215,7 +221,8 @@ def test_the_executable_is_found_before_the_function_is_read(tmp_path, monkeypat
     monkey = tmp_path / "hfun.py"
     monkey.write_text("hfun_min = 12.0\n")
     with pytest.raises(GenerateError, match="dengwirda"):
-        generate(monkey, out_dir=tmp_path / "out", jigsaw=None)
+        generate(monkey, out_dir=tmp_path / "out", jigsaw=None,
+                 skip_mkgrid=True)
 
 
 # ------------------------------------------------------------------ real runs
@@ -229,7 +236,8 @@ def test_jigsaw_produces_a_sphere_triangulation(tmp_path):
     resolution, so it checks the run really produced a mesh rather than a file.
     """
     hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
-    result = generate(hfun, out_dir=tmp_path / "out", quiet=True)
+    result = generate(hfun, out_dir=tmp_path / "out", quiet=True,
+                      skip_mkgrid=True)
 
     assert result.points > 100
     assert result.triangles == 2 * result.points - 4
@@ -242,13 +250,14 @@ def test_a_second_run_reuses_the_mesh_unless_forced(tmp_path):
     hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
     out = tmp_path / "out"
 
-    first = generate(hfun, out_dir=out, quiet=True)
-    again = generate(hfun, out_dir=out, quiet=True)
+    first = generate(hfun, out_dir=out, quiet=True, skip_mkgrid=True)
+    again = generate(hfun, out_dir=out, quiet=True, skip_mkgrid=True)
     assert again.reused
     assert again.points == first.points
     assert again.seconds == 0.0
 
-    forced = generate(hfun, out_dir=out, quiet=True, force=True)
+    forced = generate(hfun, out_dir=out, quiet=True, force=True,
+                      skip_mkgrid=True)
     assert not forced.reused
 
 
@@ -262,7 +271,8 @@ def test_a_failing_jigsaw_is_reported_in_its_own_words(tmp_path):
 
     hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
     with pytest.raises(GenerateError) as exc:
-        generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True)
+        generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True,
+                 skip_mkgrid=True)
 
     msg = str(exc.value)
     assert "exit 3" in msg
@@ -277,7 +287,8 @@ def test_a_jigsaw_that_exits_cleanly_without_a_mesh_still_fails(tmp_path):
 
     hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
     with pytest.raises(GenerateError, match="exit 0"):
-        generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True)
+        generate(hfun, out_dir=tmp_path / "out", jigsaw=stub, quiet=True,
+                 skip_mkgrid=True)
 
 
 # ------------------------------------------------------- what mkgrid reads
@@ -410,7 +421,7 @@ def test_the_mkgrid_argument_is_in_metres(tmp_path):
 def test_a_whole_run_leaves_everything_mkgrid_needs(tmp_path):
     hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
     out = tmp_path / "out"
-    result = generate(hfun, out_dir=out, quiet=True)
+    result = generate(hfun, out_dir=out, quiet=True, skip_mkgrid=True)
 
     for name in ("MESH.msh", "SaveVertices", "SaveTriangles", "SaveDensity",
                  "SaveCode"):
@@ -422,3 +433,122 @@ def test_a_whole_run_leaves_everything_mkgrid_needs(tmp_path):
     assert len(verts) == result.points
     assert len(tris) == result.triangles
     assert len(density) == result.points        # one per generating point
+
+
+# ------------------------------------------- the tools are prerequisites now
+
+
+def test_a_missing_jigsawdir_names_the_variable(tmp_path, monkeypatch):
+    monkeypatch.delenv("JIGSAWDIR", raising=False)
+    with pytest.raises(GenerateError) as exc:
+        find_jigsaw()
+    msg = str(exc.value)
+    assert "$JIGSAWDIR is not set" in msg
+    assert "github.com/dengwirda/jigsaw" in msg      # where to get it
+    assert "--jigsaw" in msg                         # and the override
+
+
+def test_a_missing_mkgridfile_names_the_variable(monkeypatch):
+    from gmpas.prep.generate import find_mkgrid
+
+    monkeypatch.delenv("MKGRIDFILE", raising=False)
+    with pytest.raises(GenerateError) as exc:
+        find_mkgrid()
+    msg = str(exc.value)
+    assert "$MKGRIDFILE is not set" in msg
+    # mkgrid is not released anywhere -- the message has to say where it lives
+    assert "mpas_jigsaw_tutorial" in msg
+    assert "mkgrid.c" in msg
+    assert "--mkgrid" in msg
+
+
+def test_neither_tool_falls_back_to_path(tmp_path, monkeypatch):
+    """PATH is deliberately not consulted: silently picking up some other
+    binary called `jigsaw` is worse than a sentence naming the variable."""
+    from gmpas.prep.generate import find_mkgrid
+
+    fake = tmp_path / "bin"
+    fake.mkdir()
+    for name in ("jigsaw", "mkgrid"):
+        exe = fake / name
+        exe.write_text("#!/bin/sh\n")
+        exe.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake))
+    monkeypatch.delenv("JIGSAWDIR", raising=False)
+    monkeypatch.delenv("MKGRIDFILE", raising=False)
+
+    with pytest.raises(GenerateError, match="JIGSAWDIR"):
+        find_jigsaw()
+    with pytest.raises(GenerateError, match="MKGRIDFILE"):
+        find_mkgrid()
+
+
+def test_both_tools_are_located_before_any_work(tmp_path, monkeypatch):
+    """mkgrid missing must not be discovered after JIGSAW has run for minutes,
+    so it is resolved up front -- before the output directory even exists."""
+    monkeypatch.setenv("JIGSAWDIR", str(tmp_path))
+    monkeypatch.delenv("MKGRIDFILE", raising=False)
+    exe = tmp_path / "jigsaw"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    out = tmp_path / "out"
+    with pytest.raises(GenerateError, match="MKGRIDFILE"):
+        generate(hfun, out_dir=out, quiet=True)
+    assert not out.exists()          # nothing was created
+
+
+def test_mkgridfile_may_be_the_directory_or_the_binary(tmp_path, monkeypatch):
+    from gmpas.prep.generate import find_mkgrid
+
+    exe = tmp_path / "mkgrid"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+
+    monkeypatch.setenv("MKGRIDFILE", str(tmp_path))
+    assert find_mkgrid() == exe.resolve()
+    monkeypatch.setenv("MKGRIDFILE", str(exe))
+    assert find_mkgrid() == exe.resolve()
+
+
+def test_a_failing_mkgrid_is_reported_in_its_own_words(tmp_path):
+    stub_jig = tmp_path / "jigsaw"
+    stub_jig.write_text("#!/bin/sh\ncp MESH_STUB MESH.msh\n")
+    stub_jig.chmod(0o755)
+    stub_mk = tmp_path / "mkgrid"
+    stub_mk.write_text("#!/bin/sh\necho 'mkgrid: cannot read SaveDensity'\nexit 4\n")
+    stub_mk.chmod(0o755)
+
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "MESH_STUB").write_text(MSH)
+
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    with pytest.raises(GenerateError) as exc:
+        generate(hfun, out_dir=out, jigsaw=stub_jig, mkgrid=stub_mk, quiet=True)
+
+    msg = str(exc.value)
+    assert "exit 4" in msg
+    assert "cannot read SaveDensity" in msg      # mkgrid's words, not ours
+
+
+@jigsaw_available
+@mkgrid_available
+def test_one_command_reaches_grid_nc(tmp_path):
+    """The whole point of the streamlining: hfun.py in, grid.nc out."""
+    hfun = write_hfun_py(tmp_path / "hfun.py", h_min=400.0, h_max=800.0)
+    out = tmp_path / "out"
+    result = generate(hfun, out_dir=out, quiet=True)
+
+    assert result.grid_nc is not None
+    assert result.grid_nc.exists()
+    assert result.graph_info is not None and result.graph_info.exists()
+    # mkgrid builds one cell per generating point
+    assert result.cells == result.points
+
+    # and gmpas can open what it just built
+    from gmpas import MpasMesh
+
+    mesh = MpasMesh.load(result.grid_nc)
+    assert mesh.n_cells == result.points


### PR DESCRIPTION
`gmpas prep generate` now runs `mkgrid` as part of the workflow instead of printing it as an instruction, so a distance function goes straight to `grid.nc` and `graph.info`.

```
  MESH.msh: 41,225 generating points, 82,446 triangles in 37.4 s
  SaveVertices (41,225) and SaveTriangles (82,446)
  SaveDensity (1 to 1)
  running mkgrid 120000 (nominalMinDc in metres = hfun_min * 1000)
  grid.nc: 41,225 cells (49 MB) in 0.4 s
```

## Both tools are prerequisites

`$JIGSAWDIR` and `$MKGRIDFILE` must be set. Either takes the binary or the directory holding it; `--jigsaw` / `--mkgrid` override.

**The PATH fallback for jigsaw is deliberately gone** — a behaviour change for anyone who had it on PATH. Both tools are built by hand into a location of the builder's choosing, so PATH is the exception rather than the rule, and silently picking up some other binary of the same name is worse than a sentence naming the variable to set. There is a test that plants fake `jigsaw` and `mkgrid` on PATH and asserts neither is used.

Both are resolved **before any work**, including before the output directory is created — finding out `mkgrid` is missing after JIGSAW has run for five minutes helps nobody. A test asserts the directory does not exist after that failure.

`--skip-mkgrid` stops after the `Save*` files, and then `$MKGRIDFILE` is not needed.

## Verification

- **275 passed** with both tools set; **271 passed, 4 skipped** with neither, which is how CI runs.
- End to end: `hfun_uniform.py` → 41,225 generating points → `grid.nc` with 41,225 cells, opened back with `MpasMesh.load`.
- Failure paths tested with stub executables, including `mkgrid` exiting non-zero and its message being carried through.

## Also

Version 0.4.1. Docs rewritten for the new contract, including the JIGSAW working-directory trap measured four ways. [Issue #30](https://github.com/nmathewa/gmpas-lib/issues/30) filed on packaging the two tools — JIGSAW is already on conda-forge; `mkgrid` has no release anywhere, and the options are weighed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)