### PR TITLE
docs: a diagram per subroutine, in each one's section

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -13,6 +13,15 @@ gmpas prep generate hfun.py -o mesh/
 
 `info` summarises the mesh and lists variables grouped by the element they
 live on. `plot` renders one field. `view` opens the interactive browser.
+
+![how gmpas view works](viewer.svg)
+
+A run is opened as a `Series` across however many files it spans, scanned in
+the background so the page appears immediately. The mesh beside it goes through
+the same cached geometry and KD-tree as `prep view`. Each request names a
+variable, timestep, level and view box; only the file holding that step is
+opened, and the values are gathered through the view index straight into a
+palette PNG.
 `scrip` and `target` prepare the two grid files a conservative remapper needs
 — see [Conservative remapping](./remapping.md).
 

--- a/docs/hfun-viewer.svg
+++ b/docs/hfun-viewer.svg
@@ -1,0 +1,51 @@
+<svg width="680" viewBox="0 0 680 470" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>How gmpas prep hfun works</title>
+<desc>A user's hfun.py is imported by path. Once at startup it is sampled over the whole sphere on the same lat-lon grid create_hfun.py would write, giving the colour limits and the maximum cell size gradient. For each view box the browser asks for, get_hfun is called exactly once over that view's pixel centres and the result is colour-mapped to a PNG. It is never called per pixel.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; }
+  .ts { font-size: 12px; font-weight: 400; }
+  .tn { font-size: 11px; font-weight: 400; fill: #5F5E5A; font-style: italic; }
+  .arr { stroke: #888780; stroke-width: 1.5; fill: none; }
+  .dash { stroke: #888780; stroke-width: 1.3; fill: none; stroke-dasharray: 4 3; }
+  .teal rect { fill: #E1F5EE; stroke: #0F6E56; }
+  .teal .th { fill: #085041; } .teal .ts { fill: #0F6E56; }
+  .purple rect { fill: #EEEDFE; stroke: #534AB7; }
+  .purple .th { fill: #3C3489; } .purple .ts { fill: #534AB7; }
+  .coral rect { fill: #FAECE7; stroke: #993C1D; }
+  .coral .th { fill: #712B13; } .coral .ts { fill: #993C1D; }
+  .gray rect { fill: #F1EFE8; stroke: #5F5E5A; }
+  .gray .th { fill: #444441; } .gray .ts { fill: #5F5E5A; }
+  @media (prefers-color-scheme: dark) {
+    .arr { stroke: #B4B2A9; } .dash { stroke: #B4B2A9; } .tn { fill: #B4B2A9; }
+    .teal rect { fill: #085041; stroke: #9FE1CB; }
+    .teal .th { fill: #9FE1CB; } .teal .ts { fill: #5DCAA5; }
+    .purple rect { fill: #3C3489; stroke: #CECBF6; }
+    .purple .th { fill: #CECBF6; } .purple .ts { fill: #AFA9EC; }
+    .coral rect { fill: #712B13; stroke: #F5C4B3; }
+    .coral .th { fill: #F5C4B3; } .coral .ts { fill: #F0997B; }
+    .gray rect { fill: #444441; stroke: #D3D1C7; }
+    .gray .th { fill: #D3D1C7; } .gray .ts { fill: #B4B2A9; }
+  }
+</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+
+<g class="teal"><rect x="245" y="30" width="190" height="52" rx="4"/><text class="th" x="340" y="51" text-anchor="middle">hfun.py</text><text class="ts" x="340" y="68" text-anchor="middle">hfun_min &#183; get_hfun(lon, lat)</text></g>
+<line class="arr" x1="340" y1="82" x2="340" y2="118" marker-end="url(#arrow)"/>
+<text class="tn" x="356" y="105" text-anchor="start">imported by path, under a private module name</text>
+<g class="gray"><rect x="245" y="120" width="190" height="52" rx="4"/><text class="th" x="340" y="141" text-anchor="middle">Hfun</text><text class="ts" x="340" y="158" text-anchor="middle">validated on 4 probe points</text></g>
+<line class="arr" x1="280" y1="172" x2="175" y2="208" marker-end="url(#arrow)"/>
+<line class="arr" x1="400" y1="172" x2="505" y2="208" marker-end="url(#arrow)"/>
+<text class="tn" x="150" y="196" text-anchor="middle">once, at startup</text>
+<text class="tn" x="540" y="196" text-anchor="middle">once per view box</text>
+<g class="purple"><rect x="40" y="210" width="270" height="52" rx="4"/><text class="th" x="175" y="231" text-anchor="middle">whole-sphere sample</text><text class="ts" x="175" y="248" text-anchor="middle">the grid create_hfun.py writes</text></g>
+<g class="coral"><rect x="370" y="210" width="270" height="52" rx="4"/><text class="th" x="505" y="231" text-anchor="middle">view pixel centres</text><text class="ts" x="505" y="248" text-anchor="middle">one get_hfun call, whole array</text></g>
+<line class="arr" x1="175" y1="262" x2="175" y2="298" marker-end="url(#arrow)"/>
+<line class="arr" x1="505" y1="262" x2="505" y2="298" marker-end="url(#arrow)"/>
+<g class="purple"><rect x="40" y="300" width="270" height="52" rx="4"/><text class="th" x="175" y="321" text-anchor="middle">diagnose</text><text class="ts" x="175" y="338" text-anchor="middle">max |grad h| vs 0.03</text></g>
+<g class="coral"><rect x="370" y="300" width="270" height="52" rx="4"/><text class="th" x="505" y="321" text-anchor="middle">colour-map</text><text class="ts" x="505" y="338" text-anchor="middle">palette PNG to the browser</text></g>
+<path class="dash" d="M310 326 L340 326 L340 372 L505 372" marker-end="url(#arrow)"/>
+<text class="tn" x="340" y="392" text-anchor="middle">the colour scale is fixed from the whole-sphere pass,</text>
+<text class="tn" x="340" y="407" text-anchor="middle">so a refinement band keeps its colour while you pan</text>
+<text class="tn" x="340" y="440" text-anchor="middle">no mesh exists yet &#8212; nothing here reads a grid file</text>
+</svg>

--- a/docs/mesh-generation.svg
+++ b/docs/mesh-generation.svg
@@ -1,0 +1,51 @@
+<svg width="680" viewBox="0 0 680 620" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>How gmpas prep generate works</title>
+<desc>An hfun.py is measured before anything is spent: a transition steeper than the 0.03 guideline stops the run. It is then sampled onto the lat-lon grid JIGSAW reads, JIGSAW turns that into generating points and a triangulation, those are converted into the four files mkgrid reads, and mkgrid writes the MPAS grid.nc and graph.info. JIGSAW and mkgrid are external executables named by JIGSAWDIR and MKGRIDFILE.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; }
+  .ts { font-size: 12px; font-weight: 400; }
+  .tn { font-size: 11px; font-weight: 400; fill: #5F5E5A; font-style: italic; }
+  .arr { stroke: #888780; stroke-width: 1.5; fill: none; }
+  .dash { stroke: #888780; stroke-width: 1.3; fill: none; stroke-dasharray: 4 3; }
+  .teal rect { fill: #E1F5EE; stroke: #0F6E56; }
+  .teal .th { fill: #085041; } .teal .ts { fill: #0F6E56; }
+  .purple rect { fill: #EEEDFE; stroke: #534AB7; }
+  .purple .th { fill: #3C3489; } .purple .ts { fill: #534AB7; }
+  .coral rect { fill: #FAECE7; stroke: #993C1D; }
+  .coral .th { fill: #712B13; } .coral .ts { fill: #993C1D; }
+  .gray rect { fill: #F1EFE8; stroke: #5F5E5A; }
+  .gray .th { fill: #444441; } .gray .ts { fill: #5F5E5A; }
+  @media (prefers-color-scheme: dark) {
+    .arr { stroke: #B4B2A9; } .dash { stroke: #B4B2A9; } .tn { fill: #B4B2A9; }
+    .teal rect { fill: #085041; stroke: #9FE1CB; }
+    .teal .th { fill: #9FE1CB; } .teal .ts { fill: #5DCAA5; }
+    .purple rect { fill: #3C3489; stroke: #CECBF6; }
+    .purple .th { fill: #CECBF6; } .purple .ts { fill: #AFA9EC; }
+    .coral rect { fill: #712B13; stroke: #F5C4B3; }
+    .coral .th { fill: #F5C4B3; } .coral .ts { fill: #F0997B; }
+    .gray rect { fill: #444441; stroke: #D3D1C7; }
+    .gray .th { fill: #D3D1C7; } .gray .ts { fill: #B4B2A9; }
+  }
+</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+
+<g class="teal"><rect x="245" y="26" width="190" height="52" rx="4"/><text class="th" x="340" y="47" text-anchor="middle">hfun.py</text><text class="ts" x="340" y="64" text-anchor="middle">the whole mesh definition</text></g>
+<line class="arr" x1="340" y1="78" x2="340" y2="110" marker-end="url(#arrow)"/>
+<g class="purple"><rect x="210" y="112" width="260" height="52" rx="4"/><text class="th" x="340" y="133" text-anchor="middle">gradient check</text><text class="ts" x="340" y="150" text-anchor="middle">stops the run above 0.03</text></g>
+<text class="tn" x="600" y="142" text-anchor="end">seconds, not minutes</text>
+<line class="arr" x1="340" y1="164" x2="340" y2="196" marker-end="url(#arrow)"/>
+<g class="gray"><rect x="40" y="198" width="190" height="52" rx="4"/><text class="th" x="135" y="219" text-anchor="middle">HFUN.msh</text><text class="ts" x="135" y="236" text-anchor="middle">the sampled distance function</text></g>
+<g class="gray"><rect x="245" y="198" width="190" height="52" rx="4"/><text class="th" x="340" y="219" text-anchor="middle">GEOM.msh</text><text class="ts" x="340" y="236" text-anchor="middle">the sphere</text></g>
+<g class="gray"><rect x="450" y="198" width="190" height="52" rx="4"/><text class="th" x="545" y="219" text-anchor="middle">MESH.jig</text><text class="ts" x="545" y="236" text-anchor="middle">config</text></g>
+<line class="arr" x1="135" y1="250" x2="300" y2="286" marker-end="url(#arrow)"/>
+<line class="arr" x1="340" y1="250" x2="340" y2="286" marker-end="url(#arrow)"/>
+<line class="arr" x1="545" y1="250" x2="380" y2="286" marker-end="url(#arrow)"/>
+<g class="coral"><rect x="200" y="288" width="280" height="54" rx="4"/><text class="th" x="340" y="309" text-anchor="middle">jigsaw</text><text class="ts" x="340" y="326" text-anchor="middle">$JIGSAWDIR &#183; external</text></g>
+<line class="arr" x1="340" y1="342" x2="340" y2="374" marker-end="url(#arrow)"/>
+<g class="teal"><rect x="220" y="376" width="240" height="52" rx="4"/><text class="th" x="340" y="397" text-anchor="middle">MESH.msh</text><text class="ts" x="340" y="414" text-anchor="middle">generating points + triangles</text></g>
+<line class="arr" x1="340" y1="428" x2="340" y2="460" marker-end="url(#arrow)"/>
+<g class="gray"><rect x="60" y="462" width="560" height="52" rx="4"/><text class="th" x="340" y="483" text-anchor="middle">SaveVertices &#183; SaveTriangles &#183; SaveDensity &#183; SaveCode</text><text class="ts" x="340" y="500" text-anchor="middle">byte-identical to the tutorial's own scripts</text></g>
+<line class="arr" x1="340" y1="514" x2="340" y2="546" marker-end="url(#arrow)"/>
+<g class="coral"><rect x="130" y="548" width="420" height="54" rx="4"/><text class="th" x="340" y="569" text-anchor="middle">mkgrid  nominalMinDc = hfun_min &#215; 1000</text><text class="ts" x="340" y="586" text-anchor="middle">$MKGRIDFILE &#183; external &#183; writes grid.nc and graph.info</text></g>
+</svg>

--- a/docs/mesh-viewer.svg
+++ b/docs/mesh-viewer.svg
@@ -1,0 +1,48 @@
+<svg width="680" viewBox="0 0 680 500" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>How gmpas prep view works</title>
+<desc>An MPAS mesh file is turned into cached geometry once: a directory of .npy arrays plus a meta.json holding the derived scalars. Later runs memory-map that cache instead of rebuilding it. A KD-tree over the cell centres turns each view box into a pixel-to-cell index, which is built once per extent and reused for every field and every frame; drawing a field is then just a gather.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; }
+  .ts { font-size: 12px; font-weight: 400; }
+  .tn { font-size: 11px; font-weight: 400; fill: #5F5E5A; font-style: italic; }
+  .arr { stroke: #888780; stroke-width: 1.5; fill: none; }
+  .dash { stroke: #888780; stroke-width: 1.3; fill: none; stroke-dasharray: 4 3; }
+  .teal rect { fill: #E1F5EE; stroke: #0F6E56; }
+  .teal .th { fill: #085041; } .teal .ts { fill: #0F6E56; }
+  .purple rect { fill: #EEEDFE; stroke: #534AB7; }
+  .purple .th { fill: #3C3489; } .purple .ts { fill: #534AB7; }
+  .coral rect { fill: #FAECE7; stroke: #993C1D; }
+  .coral .th { fill: #712B13; } .coral .ts { fill: #993C1D; }
+  .gray rect { fill: #F1EFE8; stroke: #5F5E5A; }
+  .gray .th { fill: #444441; } .gray .ts { fill: #5F5E5A; }
+  @media (prefers-color-scheme: dark) {
+    .arr { stroke: #B4B2A9; } .dash { stroke: #B4B2A9; } .tn { fill: #B4B2A9; }
+    .teal rect { fill: #085041; stroke: #9FE1CB; }
+    .teal .th { fill: #9FE1CB; } .teal .ts { fill: #5DCAA5; }
+    .purple rect { fill: #3C3489; stroke: #CECBF6; }
+    .purple .th { fill: #CECBF6; } .purple .ts { fill: #AFA9EC; }
+    .coral rect { fill: #712B13; stroke: #F5C4B3; }
+    .coral .th { fill: #F5C4B3; } .coral .ts { fill: #F0997B; }
+    .gray rect { fill: #444441; stroke: #D3D1C7; }
+    .gray .th { fill: #D3D1C7; } .gray .ts { fill: #B4B2A9; }
+  }
+</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+
+<g class="teal"><rect x="245" y="30" width="190" height="52" rx="4"/><text class="th" x="340" y="51" text-anchor="middle">mesh.nc</text><text class="ts" x="340" y="68" text-anchor="middle">verticesOnCell, areaCell, &#8230;</text></g>
+<line class="arr" x1="340" y1="82" x2="340" y2="118" marker-end="url(#arrow)"/>
+<g class="gray"><rect x="190" y="120" width="300" height="52" rx="4"/><text class="th" x="340" y="141" text-anchor="middle">build geometry once</text><text class="ts" x="340" y="158" text-anchor="middle">vectorized, chunked, streamed to disk</text></g>
+<line class="arr" x1="340" y1="172" x2="340" y2="208" marker-end="url(#arrow)"/>
+<g class="purple"><rect x="130" y="210" width="420" height="52" rx="4"/><text class="th" x="340" y="231" text-anchor="middle">cache: a directory of .npy</text><text class="ts" x="340" y="248" text-anchor="middle">cell_verts, edge_segs, xyz_cell, area_cell &#8230;</text></g>
+<text class="tn" x="340" y="280" text-anchor="middle">memory-mapped on every later load &#8212; pages arrive only for what is touched</text>
+<line class="arr" x1="230" y1="288" x2="175" y2="308" marker-end="url(#arrow)"/>
+<line class="arr" x1="450" y1="288" x2="505" y2="308" marker-end="url(#arrow)"/>
+<g class="gray"><rect x="40" y="310" width="270" height="52" rx="4"/><text class="th" x="175" y="331" text-anchor="middle">meta.json</text><text class="ts" x="175" y="348" text-anchor="middle">extent, coverage, n_cells</text></g>
+<g class="coral"><rect x="370" y="310" width="270" height="52" rx="4"/><text class="th" x="505" y="331" text-anchor="middle">KD-tree</text><text class="ts" x="505" y="348" text-anchor="middle">over cell centres</text></g>
+<text class="tn" x="175" y="380" text-anchor="middle">derived scalars, so reading them</text>
+<text class="tn" x="175" y="395" text-anchor="middle">never touches the big arrays</text>
+<line class="arr" x1="505" y1="362" x2="505" y2="398" marker-end="url(#arrow)"/>
+<g class="coral"><rect x="370" y="400" width="270" height="52" rx="4"/><text class="th" x="505" y="421" text-anchor="middle">ViewIndex</text><text class="ts" x="505" y="438" text-anchor="middle">pixel &#8594; cell, per view box</text></g>
+<text class="tn" x="505" y="478" text-anchor="middle">built once per extent, reused for every field</text>
+</svg>

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -15,6 +15,15 @@ coloured by width, so where the mesh refines is visible at a glance.
 listening on 127.0.0.1:8765 — this machine only
 ```
 
+![how gmpas prep view works](mesh-viewer.svg)
+
+The geometry is built once and cached as a directory of `.npy`, then
+memory-mapped on every later load, so pages arrive only for the arrays
+something actually touches. `meta.json` carries the derived scalars — extent,
+coverage, cell count — so reading them never pulls in the largest array. The
+KD-tree turns each view box into a pixel-to-cell index once, and every field
+and every frame at that extent is then a gather.
+
 Same flags as `view` for tunnelling and size: `-p/--port`, `--host`,
 `--width`, `--height`, `--no-browser`. On a compute node use `--host 0.0.0.0`
 and tunnel, exactly as for `view`.
@@ -78,6 +87,8 @@ export JIGSAWDIR=/path/to/jigsaw/build/src            # or .../bin
 export MKGRIDFILE=/path/to/mpas_jigsaw_tutorial/mkgrid
 gmpas prep generate hfun.py -o mesh/
 ```
+
+![how gmpas prep generate works](mesh-generation.svg)
 
 One command from a distance function to an MPAS `grid.nc`:
 
@@ -208,10 +219,16 @@ max cell size gradient 0.0300 at 75.64, -95.05 (within the 0.03 guideline)
 measured on the 3336 x 1668 lat-lon grid create_hfun.py would write (12 km spacing)
 ```
 
+![how gmpas prep hfun works](hfun-viewer.svg)
+
 The contract is the mini-tutorial's: a module-level `hfun_min` in km, and
 `get_hfun(lon, lat)` taking **radians** and returning **km**. That function is
 called once with whole arrays and may do expensive setup — a real one might
 interpolate a raster — so it is called once per view here, never per pixel.
+
+The whole-sphere pass at startup does double duty: it produces the gradient
+measured against the guideline, and it fixes the colour limits, which is why a
+refinement band keeps its colour while you pan.
 
 **The gradient is the number worth having.** The tutorial's guidance is to keep
 cell size changing by no more than a few percent per km of distance, with 0.03

--- a/docs/viewer.svg
+++ b/docs/viewer.svg
@@ -1,0 +1,50 @@
+<svg width="680" viewBox="0 0 680 530" role="img" xmlns="http://www.w3.org/2000/svg">
+<title>How gmpas view works</title>
+<desc>A run is opened as a Series across however many files it spans, scanned in the background so the page appears immediately. The mesh beside it goes through the same cached geometry and KD-tree as the mesh viewer. Each browser request names a variable, timestep, level and view box; only the file holding that step is opened, the values are gathered through the view index, and the result is encoded straight to a palette PNG.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .th { font-size: 14px; font-weight: 500; }
+  .ts { font-size: 12px; font-weight: 400; }
+  .tn { font-size: 11px; font-weight: 400; fill: #5F5E5A; font-style: italic; }
+  .arr { stroke: #888780; stroke-width: 1.5; fill: none; }
+  .dash { stroke: #888780; stroke-width: 1.3; fill: none; stroke-dasharray: 4 3; }
+  .teal rect { fill: #E1F5EE; stroke: #0F6E56; }
+  .teal .th { fill: #085041; } .teal .ts { fill: #0F6E56; }
+  .purple rect { fill: #EEEDFE; stroke: #534AB7; }
+  .purple .th { fill: #3C3489; } .purple .ts { fill: #534AB7; }
+  .coral rect { fill: #FAECE7; stroke: #993C1D; }
+  .coral .th { fill: #712B13; } .coral .ts { fill: #993C1D; }
+  .gray rect { fill: #F1EFE8; stroke: #5F5E5A; }
+  .gray .th { fill: #444441; } .gray .ts { fill: #5F5E5A; }
+  @media (prefers-color-scheme: dark) {
+    .arr { stroke: #B4B2A9; } .dash { stroke: #B4B2A9; } .tn { fill: #B4B2A9; }
+    .teal rect { fill: #085041; stroke: #9FE1CB; }
+    .teal .th { fill: #9FE1CB; } .teal .ts { fill: #5DCAA5; }
+    .purple rect { fill: #3C3489; stroke: #CECBF6; }
+    .purple .th { fill: #CECBF6; } .purple .ts { fill: #AFA9EC; }
+    .coral rect { fill: #712B13; stroke: #F5C4B3; }
+    .coral .th { fill: #F5C4B3; } .coral .ts { fill: #F0997B; }
+    .gray rect { fill: #444441; stroke: #D3D1C7; }
+    .gray .th { fill: #D3D1C7; } .gray .ts { fill: #B4B2A9; }
+  }
+</style>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+
+<g class="teal"><rect x="40" y="30" width="270" height="52" rx="4"/><text class="th" x="175" y="51" text-anchor="middle">run directory or glob</text><text class="ts" x="175" y="68" text-anchor="middle">history.*.nc, one file per interval</text></g>
+<g class="teal"><rect x="370" y="30" width="270" height="52" rx="4"/><text class="th" x="505" y="51" text-anchor="middle">mesh beside it</text><text class="ts" x="505" y="68" text-anchor="middle">or the run's own mesh variables</text></g>
+<line class="arr" x1="175" y1="82" x2="175" y2="118" marker-end="url(#arrow)"/>
+<line class="arr" x1="505" y1="82" x2="505" y2="118" marker-end="url(#arrow)"/>
+<g class="purple"><rect x="40" y="120" width="270" height="52" rx="4"/><text class="th" x="175" y="141" text-anchor="middle">Series</text><text class="ts" x="175" y="158" text-anchor="middle">time axis across files</text></g>
+<g class="gray"><rect x="370" y="120" width="270" height="52" rx="4"/><text class="th" x="505" y="141" text-anchor="middle">cached geometry</text><text class="ts" x="505" y="158" text-anchor="middle">memory-mapped .npy</text></g>
+<text class="tn" x="175" y="192" text-anchor="middle">scanned in the background,</text>
+<text class="tn" x="175" y="207" text-anchor="middle">so the page appears at once</text>
+<line class="arr" x1="505" y1="172" x2="505" y2="208" marker-end="url(#arrow)"/>
+<g class="coral"><rect x="370" y="210" width="270" height="52" rx="4"/><text class="th" x="505" y="231" text-anchor="middle">KD-tree &#8594; ViewIndex</text><text class="ts" x="505" y="248" text-anchor="middle">pixel &#8594; cell, per view box</text></g>
+<line class="arr" x1="175" y1="222" x2="175" y2="288" marker-end="url(#arrow)"/>
+<line class="arr" x1="505" y1="262" x2="505" y2="288" marker-end="url(#arrow)"/>
+<g class="gray"><rect x="130" y="290" width="420" height="54" rx="4"/><text class="th" x="340" y="311" text-anchor="middle">frame(var, time, level, extent)</text><text class="ts" x="340" y="328" text-anchor="middle">opens only the file that step needs</text></g>
+<line class="arr" x1="340" y1="344" x2="340" y2="380" marker-end="url(#arrow)"/>
+<g class="coral"><rect x="210" y="382" width="260" height="52" rx="4"/><text class="th" x="340" y="403" text-anchor="middle">palette PNG</text><text class="ts" x="340" y="420" text-anchor="middle">256 colours, one byte a pixel</text></g>
+<text class="tn" x="340" y="462" text-anchor="middle">the same index also serves the probe and the figure,</text>
+<text class="tn" x="340" y="477" text-anchor="middle">GIF and netCDF exports</text>
+</svg>


### PR DESCRIPTION
Four SVGs showing roughly what happens in the background, one per workflow.

| diagram | subroutine | lives in |
|---|---|---|
| `hfun-viewer.svg` | `prep hfun` | docs/preprocessing.md |
| `mesh-viewer.svg` | `prep view` | docs/preprocessing.md |
| `mesh-generation.svg` | `prep generate` | docs/preprocessing.md |
| `viewer.svg` | `view` | docs/command-line.md |

Remapping was the fifth you listed, and `docs/remapping-workflow.svg` already covers it accurately — so it is left alone rather than duplicated.

## Style

Same visual language the existing remapping diagram set: the same four-colour palette, the same `prefers-color-scheme: dark` overrides so they read correctly in GitHub's dark theme, the same arrow marker, and a `<title>` and `<desc>` on each so they are not opaque to a screen reader.

## What each one says

They carry the thing that is actually non-obvious about that path, not just the boxes:

- **prep hfun** — `get_hfun` is called once per view and *never* per pixel, and the same whole-sphere pass produces both the gradient and the fixed colour limits.
- **prep view** — the cache is memory-mapped, and `meta.json` exists so reading a scalar never touches the largest array. The ViewIndex is built once per extent and reused for every field.
- **prep generate** — the gradient gate comes before any work; jigsaw and mkgrid are external and named by environment variables; the metres/km conversion sits on the mkgrid box.
- **view** — a `Series` opens only the file a given step needs.

## Verification

Generated from a script so the four stay consistent, then **rendered in a browser and looked at**, which caught two overlaps invisible in the source: a caption sitting on top of its own arrow, and another rendering inside the box above it. Both fixed and re-checked.

All relative links and images across README, docs/ and examples/ resolve. 275 tests still pass; this touches no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)