### PR TITLE
xarray: pin engine="netcdf4" everywhere, skip backend auto-detection

### DIFF
--- a/src/gmpas/accessor.py
+++ b/src/gmpas/accessor.py
@@ -36,6 +36,7 @@ def open_mpas(data_path: str, mesh: str = "", **kwargs) -> xr.Dataset:
     when a mesh file with a matching cell count sits in the same directory.
     """
     kwargs.setdefault("decode_timedelta", False)
+    kwargs.setdefault("engine", "netcdf4")
     path = resolve_path(data_path)
     ds = xr.open_dataset(path, **kwargs)
 

--- a/src/gmpas/data.py
+++ b/src/gmpas/data.py
@@ -29,7 +29,7 @@ def open_data(data_path: str | Path,
     dpath = resolve_path(data_path)
     if not dpath.exists():
         raise FileNotFoundError(f"No such data file: {dpath}")
-    ds = xr.open_dataset(dpath, decode_timedelta=False)
+    ds = xr.open_dataset(dpath, decode_timedelta=False, engine="netcdf4")
 
     if mesh_path:
         return ds, MpasMesh.load(resolve_path(mesh_path))
@@ -52,7 +52,7 @@ def find_mesh_beside(dpath: Path, n_cells: int) -> Path | None:
         if cand == dpath:
             continue
         try:
-            with xr.open_dataset(cand, decode_timedelta=False) as c:
+            with xr.open_dataset(cand, decode_timedelta=False, engine="netcdf4") as c:
                 if has_mesh(c) and int(c.sizes.get("nCells", -1)) == n_cells:
                     return cand
         except Exception:

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -263,7 +263,7 @@ class MpasMesh:
 
     @classmethod
     def _build(cls, path: Path) -> "MpasMesh":
-        ds = xr.open_dataset(path, decode_timedelta=False)
+        ds = xr.open_dataset(path, decode_timedelta=False, engine="netcdf4")
         if not has_mesh(ds):
             missing = [v for v in MESH_VARS if v not in ds.variables]
             ds.close()
@@ -683,7 +683,7 @@ def reconstruct_cell_winds(mesh: MpasMesh,
     Reads `edgesOnCell` from the mesh file, which the cached geometry does not
     carry.
     """
-    with xr.open_dataset(mesh.path, decode_timedelta=False) as ds:
+    with xr.open_dataset(mesh.path, decode_timedelta=False, engine="netcdf4") as ds:
         eoc = ds.edgesOnCell.values.astype(np.int64) - 1
         nedges = ds.nEdgesOnCell.values.astype(np.int64)
 

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -54,7 +54,7 @@ class Weights:
     @classmethod
     def load(cls, path: str | Path) -> "Weights":
         p = Path(path)
-        with xr.open_dataset(p) as w:
+        with xr.open_dataset(p, engine="netcdf4") as w:
             return cls(
                 row=w.row.values - 1,        # SCRIP indices are 1-based
                 col=w.col.values - 1,
@@ -318,7 +318,7 @@ def remap_file(path, weights: Weights, domain: TargetDomain, fields,
     slabs = 0
     worst = 0.0
 
-    with xr.open_dataset(path, decode_timedelta=False) as ds:
+    with xr.open_dataset(path, decode_timedelta=False, engine="netcdf4") as ds:
         keep, skip = remappable(ds, fields)
         n_time = int(ds.sizes.get("Time", 1))
 

--- a/src/gmpas/scrip.py
+++ b/src/gmpas/scrip.py
@@ -64,7 +64,7 @@ def write_scrip(mesh_path: str | Path, out_path: str | Path,
     if not src.exists():
         raise FileNotFoundError(f"No such mesh file: {src}")
 
-    with xr.open_dataset(src, decode_timedelta=False) as ds:
+    with xr.open_dataset(src, decode_timedelta=False, engine="netcdf4") as ds:
         missing = [v for v in (*MESH_VARS, *SCRIP_SOURCE_VARS)
                    if v not in ds.variables]
         if missing:
@@ -156,5 +156,5 @@ def coverage_of(scrip_path: str | Path) -> float:
     1.0, and a regional one at its real fraction. Anything wildly off means the
     areas or the sphere radius went in wrong.
     """
-    with xr.open_dataset(resolve_path(scrip_path)) as ds:
+    with xr.open_dataset(resolve_path(scrip_path), engine="netcdf4") as ds:
         return float(ds.grid_area.values.sum() / (4.0 * np.pi))

--- a/src/gmpas/series.py
+++ b/src/gmpas/series.py
@@ -201,7 +201,7 @@ class Series:
             self._open.move_to_end(path)
             return self._open[path]
 
-        ds = xr.open_dataset(path, decode_timedelta=False)
+        ds = xr.open_dataset(path, decode_timedelta=False, engine="netcdf4")
         self._open[path] = ds
         while len(self._open) > LRU_SIZE:
             _, old = self._open.popitem(last=False)


### PR DESCRIPTION
## Summary
- `xr.open_dataset()` with no `engine=` makes xarray enumerate and import every installed `xarray.backends` plugin to guess which one applies to the file.
- In this environment that includes MetPy's GEMPAK backend, whose import chain drags in all of `metpy.calc`/`metpy.io` — profiled at ~1s of the ~1.5s `open_dataset` cost, paid once per process on the first file opened. This showed up as the `gmpas remap` CLI appearing to stall before weight generation ever started.
- gmpas only ever reads its own netCDF4 files (MPAS output, meshes, SCRIP grids, ESMF weight files), so there's nothing to detect. Pinned `engine="netcdf4"` at all 9 internal call sites, and defaulted it via `setdefault` in the public `open_mpas()` API so callers can still override.
- Fresh-process `Series()` init on the maritime test file: ~1.07s → ~0.45s.

## Test plan
- [x] `pytest` — 271 passed, 4 pre-existing skips, no new failures
- [x] Profiled `xr.open_dataset()` before/after with `cProfile` to confirm the MetPy import chain is skipped
- [x] Timed a fresh-process `Series()` construction before/after