### PR TITLE
environment.yml: also stop installing nco, same reasoning as ESMF

### DIFF
--- a/docs/REMAPPING.md
+++ b/docs/REMAPPING.md
@@ -9,15 +9,17 @@ remapper computes the weights.
 Both are executables rather than Python packages, so they cannot come from pip
 and are not declared in `pyproject.toml`.
 
-**gmpas does not install ESMF itself, on purpose.** `environment.yml` only
-brings in `nco`. On an HPC site, load the site's own ESMF build instead —
-`module load esmf` — rather than adding a conda-forge copy to this
-environment: the site build is tuned for the local MPI/interconnect, and a
-second copy here would compete with it on `PATH`/`LD_LIBRARY_PATH` rather than
-help (see [issue 34](https://github.com/nmathewa/gmpas-lib/issues/34)). On a
-machine with no module system, `conda install -c conda-forge esmf` into a
-separate environment works fine — just don't add it to the one gmpas itself
-runs in. A `command not found: ESMF_RegridWeightGen` means neither is loaded.
+**gmpas does not install either itself, on purpose.** `environment.yml` brings
+in only gmpas's own Python dependencies. On an HPC site, load the site's own
+builds instead — `module load esmf`, `module load nco` — rather than adding
+conda-forge copies to this environment: a site build is tuned for the local
+MPI/interconnect, and a second copy here would compete with it on
+`PATH`/`LD_LIBRARY_PATH` rather than help, whether gmpas shells out to it
+(ESMF) or you run it yourself (`ncremap`) — see
+[issue 34](https://github.com/nmathewa/gmpas-lib/issues/34). On a machine with
+no module system, `conda install -c conda-forge esmf nco` into a separate
+environment works fine — just don't add it to the one gmpas itself runs in. A
+`command not found: ESMF_RegridWeightGen` means neither is loaded.
 
 ![conservative remapping workflow](remapping-workflow.svg)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,19 +20,15 @@ pip install -e ".[dev]" --no-deps
 ```
 
 Conservative remapping additionally needs `ESMF_RegridWeightGen`, and
-optionally NCO for `ncremap`. **gmpas does not install ESMF itself** — on an
-HPC site, load whatever build the site provides (`module load esmf`) rather
-than pulling one from conda-forge into this environment: a site build is
-tuned for the local MPI/interconnect, and a second copy in this environment
-would only compete with it on `PATH`/`LD_LIBRARY_PATH` (see
-docs/REMAPPING.md and [issue 34](https://github.com/nmathewa/gmpas-lib/issues/34)).
-On a laptop with no site module to load, `conda install -c conda-forge esmf`
-into a *separate* environment (not this one) works fine. NCO is lower-risk
-and can go straight into this environment if you want it:
-
-```bash
-conda install -c conda-forge nco
-```
+optionally NCO for `ncremap`. **gmpas does not install either itself** — on an
+HPC site, load whatever build the site provides (`module load esmf`, `module
+load nco`) rather than pulling a copy from conda-forge into this environment:
+a site build is tuned for the local MPI/interconnect, and a second copy in
+this environment would only compete with it on `PATH`/`LD_LIBRARY_PATH`,
+whether gmpas shells out to it (ESMF) or you run it yourself (`ncremap`) —
+see docs/REMAPPING.md and [issue 34](https://github.com/nmathewa/gmpas-lib/issues/34).
+On a laptop with no site module to load, `conda install -c conda-forge esmf
+nco` into a *separate* environment (not this one) works fine.
 
 These are programs rather than Python packages, so pip cannot provide them and
 they are not in `pyproject.toml`. Skip them if you only plot and view.

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,18 @@
 #   pip install -e . --no-deps
 #
 # The scientific stack comes from conda-forge because cartopy and netCDF4 are
-# much easier to install that way than from pip. The remapping tools are not
-# Python packages at all -- ESMF_RegridWeightGen and ncremap are executables
-# gmpas shells out to -- so they can only come from conda, not from pyproject.
+# much easier to install that way than from pip. All of it below is a Python
+# library imported straight into the gmpas process -- gmpas's own code has a
+# real version dependency on it (numpy>=1.24, etc.), and there is no separate
+# binary for a shell to resolve, so bundling it here is the right call.
+#
+# Deliberately NOT here: ESMF_RegridWeightGen and ncremap. Both are standalone
+# executables an HPC site typically ships as a module, tuned for the local
+# MPI/interconnect -- a conda-forge copy sitting in *this* environment would
+# compete with the site's on PATH/LD_LIBRARY_PATH rather than help, whether
+# gmpas shells out to it (ESMF) or you run it yourself in the same shell
+# (ncremap). Load whichever your work needs from your system; see
+# docs/REMAPPING.md and issue 34.
 name: gmpas
 channels:
   - conda-forge
@@ -23,15 +32,6 @@ dependencies:
   - matplotlib >=3.7
   - cartopy >=0.22
   - pillow                # palette PNG encoding for the viewer
-
-  # conservative remapping needs ESMF_RegridWeightGen on PATH, but gmpas does
-  # not install it here. HPC sites provide their own build tuned for the
-  # local MPI/interconnect (`module load esmf`), and a conda-forge copy
-  # sitting in this same environment competes with it on PATH/LD_LIBRARY_PATH
-  # rather than helping -- see docs/REMAPPING.md and issue 34. Load your
-  # system's ESMF before running `gmpas remap`; this environment only needs
-  # to provide gmpas itself.
-  - nco                   # provides ncremap
 
   # development
   - pytest >=7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ gmpas = "gmpas.cli:main"
 # in a headless pipeline that never draws anything.
 plot = ["matplotlib>=3.7", "cartopy>=0.22", "pillow>=9.0"]
 # Conservative remapping needs ESMF_RegridWeightGen on PATH and optionally
-# ncremap (conda-forge `nco`). Both are executables, not Python packages, so
-# pip cannot install them. ESMF deliberately is not brought in here or by
-# environment.yml -- load your system's build instead; see docs/REMAPPING.md.
+# ncremap. Both are executables, not Python packages, so pip cannot install
+# them, and neither is brought in by environment.yml either -- load your
+# system's builds instead; see docs/REMAPPING.md.
 test = ["pytest>=7.0"]
 dev = ["gmpas[plot,test]", "ruff>=0.4"]
 


### PR DESCRIPTION
## Summary
Follow-up to #35. `nco`/`ncremap` is the same shape of risk as ESMF was: an
HPC site typically ships it as a module tuned for the local build, and a
conda-forge copy sitting in gmpas's own environment competes with it on
`PATH`/`LD_LIBRARY_PATH` rather than helping — whether gmpas is the one
shelling out (it isn't, for `ncremap`; grepped, zero `subprocess` calls
reference it anywhere) or a user runs it themselves in the same activated
shell (they would be).

`environment.yml` now carries only Python libraries gmpas actually imports
into its own process — each has a real version dependency gmpas's code
relies on, and there's no separate binary for a shell to resolve. That's the
dividing line, not "is it used for remapping." JIGSAW/mkgrid already followed
it from the start (explicit `--flag`/env var, never in `environment.yml`);
ESMF and now `nco` catch up.

Docs (`docs/REMAPPING.md`, `docs/installation.md`) and the `pyproject.toml`
comment updated to match.

## Test plan
- [x] `pytest` — 271 passed, 5 skipped, no change from before (nco/ncremap
      was never exercised by any test)