### PR TITLE
remap: use srun/mpirun for weight generation, sized by -j

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -430,9 +430,18 @@ def _remap(args) -> int:
             raise SystemExit("gmpas: no fields selected — check include_fields")
 
         work = Path(args.out)
+
+        # One number for how much of the machine this run gets: -j if given,
+        # otherwise whatever the scheduler/affinity mask reports. It sizes
+        # both the MPI ranks ESMF_RegridWeightGen gets below and the worker
+        # pool that converts files in [3/3] -- not two separate knobs.
+        detected, source = detect_cores()
+        requested = args.jobs if args.jobs > 0 else detected
+
         print(f"\n[2/3] weights")
         weights_path, built = ensure_weights(
-            mesh_path, domain, work, method=args.method, force=args.force_weights
+            mesh_path, domain, work, method=args.method,
+            force=args.force_weights, ranks=requested,
         )
         weights = Weights.load(weights_path)
         if weights.n_a != series.mesh.n_cells:
@@ -451,9 +460,7 @@ def _remap(args) -> int:
     else:
         existing = []
 
-    detected, source = detect_cores()
-    workers = args.jobs if args.jobs > 0 else detected
-    workers = max(1, min(workers, len(todo) or 1))
+    workers = max(1, min(requested, len(todo) or 1))
 
     print(f"\n[3/3] remapping {len(todo)} file(s) -> {work}/")
     if existing:
@@ -647,8 +654,10 @@ def build_parser() -> argparse.ArgumentParser:
     r.add_argument("--overwrite", action="store_true",
                    help="rewrite output files that already exist")
     r.add_argument("-j", "--jobs", type=int, default=0,
-                   help="parallel workers (default: the cores this job was "
-                        "given, from the scheduler or the affinity mask)")
+                   help="parallel workers, and MPI ranks for weight "
+                        "generation if srun/mpirun is available (default: "
+                        "the cores this job was given, from the scheduler "
+                        "or the affinity mask)")
     r.set_defaults(func=_remap)
 
     v = sub.add_parser("view", help="browse a file interactively in a browser")

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -92,13 +92,108 @@ class Weights:
         return abs(i_dst - i_src) / abs(i_src) if i_src else 0.0
 
 
+def _esmf_supports_mpi(tool: str) -> bool | None:
+    """Whether this ESMF build can coordinate more than one rank.
+
+    Only rules out the case actually observed: a `mpiuni` build -- ESMF's
+    internal stub for "compiled with no real MPI library" -- identified from
+    ESMF's own build-info makefile fragment, `esmf.mk`. `module load esmf`
+    conventionally sets `$ESMFMKFILE` to it; failing that, it lives at
+    `<prefix>/lib/esmf.mk` next to the binary.
+
+    Measured directly, not assumed: launching a `mpiuni` ESMF_RegridWeightGen
+    (the conda-forge build) under `mpirun -np 2` did not parallelize it -- it
+    ran two uncoordinated copies that both wrote the same output files in the
+    same directory and corrupted each other, both failing with a nonsense
+    NetCDF error. A build that doesn't declare itself `mpiuni` might still be
+    unsafe to launch this way, for a different reason this check cannot see:
+    if the launcher on PATH is a different MPI implementation than the one
+    ESMF was linked against (e.g. a Homebrew/Open MPI `mpirun` in front of a
+    conda/MPICH-linked ESMF), the ranks are just as uncoordinated and fail the
+    same way. This function only answers "is it mpiuni," not "will this
+    specific launcher work with it" -- see the HPC TODO on issue 34.
+
+    Returns `None`, not `False`, when `esmf.mk` cannot be found or parsed:
+    "unknown" and "known not to work" get different messages upstream.
+    """
+    import os
+
+    candidates = []
+    mkfile = os.environ.get("ESMFMKFILE")
+    if mkfile:
+        candidates.append(Path(mkfile))
+    candidates.append(Path(tool).resolve().parent.parent / "lib" / "esmf.mk")
+
+    for mk in candidates:
+        try:
+            text = mk.read_text()
+        except OSError:
+            continue
+        for line in text.splitlines():
+            stripped = line.lstrip("#").strip()
+            if not stripped.startswith("ESMF_COMM"):
+                continue
+            _, _, value = stripped.partition("=")
+            if not value:
+                _, _, value = stripped.partition(":")
+            if value.strip():
+                return value.strip() != "mpiuni"
+    return None
+
+
+def _mpi_launch_prefix(ranks: int, tool: str) -> tuple[list[str], str | None]:
+    """How to run `ranks` copies of `tool`, or `[]` for one rank.
+
+    ESMF_RegridWeightGen's search and polygon intersection is genuinely
+    MPI-parallel, but gmpas invoking it bare only ever gave it one rank --
+    see issue 34. srun and mpirun expect different flags and suit different
+    schedulers: srun only works inside an active Slurm allocation, so it is
+    tried first only when one is actually detected (`SLURM_JOB_ID`); mpirun
+    (or mpiexec, the HPE Cray name for the same thing) is the fallback
+    everywhere else, including PBS sites like Derecho.
+
+    Returns `(prefix, note)`. `note` is set whenever `ranks > 1` was asked
+    for but declined -- silently running single-rank when more was requested
+    is exactly the confusion that started this. See `_esmf_supports_mpi` for
+    why declining is sometimes the safe choice, not just the cautious one.
+    """
+    if ranks <= 1:
+        return [], None
+
+    supports_mpi = _esmf_supports_mpi(tool)
+    if supports_mpi is False:
+        return [], ("this ESMF build has no real MPI (ESMF_COMM=mpiuni) -- "
+                    "running single-rank instead of corrupting output "
+                    "across uncoordinated ranks")
+    if supports_mpi is None:
+        return [], ("could not tell whether this ESMF build supports MPI "
+                    "(no esmf.mk found) -- running single-rank")
+
+    import os
+
+    srun = shutil.which("srun") if os.environ.get("SLURM_JOB_ID") else None
+    if srun:
+        return [srun, "-n", str(ranks)], None
+
+    launcher = shutil.which("mpirun") or shutil.which("mpiexec")
+    if launcher:
+        return [launcher, "-np", str(ranks)], None
+
+    return [], "no srun/mpirun/mpiexec on PATH -- running single-rank"
+
+
 def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
                    method: str = "conserve", force: bool = False,
-                   quiet: bool = False) -> tuple[Path, bool]:
+                   ranks: int = 1, quiet: bool = False) -> tuple[Path, bool]:
     """Return a weight file for this mesh and target, building it if needed.
 
     Weights depend only on the two grids, never on the data, so this runs once
     for a whole run. Returns the path and whether it had to be generated.
+
+    `ranks` is how many MPI ranks to ask for -- see `_mpi_launch_prefix`. It
+    is the same count `gmpas remap` uses for its own worker pool (`-j`), not
+    a separate knob: one number describes how much of the machine this run
+    gets to use.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -130,10 +225,15 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
         print(f"    normalised {wrapped:,} longitudes onto [0, 2pi)")
     domain.to_scrip(dst_scrip)
 
-    cmd = [tool, "-s", src_scrip.name, "-d", dst_scrip.name, "-w", weights.name,
-           "-m", method, "--src_regional", "--dst_regional", "--ignore_unmapped"]
+    launch, note = _mpi_launch_prefix(ranks, tool)
+    cmd = launch + [tool, "-s", src_scrip.name, "-d", dst_scrip.name,
+                    "-w", weights.name, "-m", method,
+                    "--src_regional", "--dst_regional", "--ignore_unmapped"]
     if not quiet:
-        print(f"  generating weights: {' '.join(cmd[:1])} ... -m {method}")
+        if note:
+            print(f"  {note}")
+        prefix = f"{' '.join(launch)} " if launch else ""
+        print(f"  generating weights: {prefix}{Path(tool).name} ... -m {method}")
     # ESMF 8.9.1 on macOS segfaults intermittently -- measured at roughly one
     # run in five on byte-identical inputs that succeed the other four times.
     # Weights are generated once for a whole run, so retrying is cheap; it is

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -8,7 +8,9 @@ import xarray as xr
 
 from conftest import write_mesh
 from gmpas.config import TargetDomain
-from gmpas.remap import RemapError, Weights, ensure_weights, level_dim, remappable
+from gmpas.remap import (RemapError, Weights, _esmf_supports_mpi,
+                         _mpi_launch_prefix, ensure_weights, level_dim,
+                         remappable)
 
 
 def _weight_file(path, row, col, S, area_a, area_b, frac_a, frac_b):
@@ -172,6 +174,239 @@ def test_a_crashing_esmf_is_retried_then_reported(tmp_path, monkeypatch):
     with pytest.raises(RemapError, match="segfaulted"):
         ensure_weights(tmp_path / "m.nc", domain, tmp_path / "w", quiet=True)
     assert len(calls) == remap_mod.WEIGHT_ATTEMPTS
+
+
+# -------------------------------------------------- ESMF's own MPI awareness
+
+
+def _write_esmf_mk(path, comm=None, style="comment-colon"):
+    """A minimal stand-in for ESMF's build-info makefile fragment.
+
+    Real esmf.mk files bury `-DESMF_COMM=...` inside long *COMPILECPPFLAGS
+    lines too -- `_esmf_supports_mpi` must not be fooled by those, so the
+    fixture includes one, matching the real file this was written against
+    (conda-forge esmf 8.9.1's mpiuni build).
+    """
+    lines = [
+        "ESMF_F90COMPILECPPFLAGS=-DESMF_NO_INTEGER_1_BYTE "
+        "-DESMF_COMM=not_the_real_value -DESMF_DIR=/wherever",
+    ]
+    if comm is not None:
+        line = {"comment-colon": f"# ESMF_COMM: {comm}",
+                "comment-equals": f"#  ESMF_COMM={comm}"}[style]
+        lines.append(line)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_a_mpiuni_build_is_not_mpi_capable(tmp_path, monkeypatch):
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+    tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
+    tool.parent.mkdir()
+    (tmp_path / "lib").mkdir()
+    _write_esmf_mk(tmp_path / "lib" / "esmf.mk", comm="mpiuni")
+
+    assert _esmf_supports_mpi(str(tool)) is False
+
+
+def test_a_real_mpi_build_is_detected(tmp_path, monkeypatch):
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+    tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
+    tool.parent.mkdir()
+    (tmp_path / "lib").mkdir()
+    _write_esmf_mk(tmp_path / "lib" / "esmf.mk", comm="mpich",
+                   style="comment-equals")
+
+    assert _esmf_supports_mpi(str(tool)) is True
+
+
+def test_esmfmkfile_env_var_wins_over_the_relative_path(tmp_path, monkeypatch):
+    tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
+    tool.parent.mkdir()
+    (tmp_path / "lib").mkdir()
+    _write_esmf_mk(tmp_path / "lib" / "esmf.mk", comm="mpiuni")   # would say False
+
+    elsewhere = tmp_path / "elsewhere.mk"
+    _write_esmf_mk(elsewhere, comm="openmpi")
+    monkeypatch.setenv("ESMFMKFILE", str(elsewhere))
+
+    assert _esmf_supports_mpi(str(tool)) is True
+
+
+def test_unknown_when_no_esmf_mk_can_be_found(tmp_path, monkeypatch):
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+    tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
+    tool.parent.mkdir()   # no lib/esmf.mk beside it
+
+    assert _esmf_supports_mpi(str(tool)) is None
+
+
+def test_unknown_when_esmf_mk_never_states_esmf_comm(tmp_path, monkeypatch):
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+    tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
+    tool.parent.mkdir()
+    (tmp_path / "lib").mkdir()
+    _write_esmf_mk(tmp_path / "lib" / "esmf.mk", comm=None)   # only the flags line
+
+    assert _esmf_supports_mpi(str(tool)) is None
+
+
+# --------------------------------------------------------------- MPI launcher
+
+
+def test_a_single_rank_needs_no_launcher():
+    assert _mpi_launch_prefix(1, "/fake/esmf") == ([], None)
+    assert _mpi_launch_prefix(0, "/fake/esmf") == ([], None)
+
+
+def test_mpirun_is_used_outside_a_slurm_allocation(monkeypatch):
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: "/opt/mpirun" if name == "mpirun" else None)
+
+    assert _mpi_launch_prefix(64, "/fake/esmf") == (["/opt/mpirun", "-np", "64"], None)
+
+
+def test_mpiexec_is_used_when_mpirun_is_absent(monkeypatch):
+    """mpiexec is the HPE Cray name for the same launcher."""
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: "/opt/cray/mpiexec" if name == "mpiexec" else None)
+
+    assert _mpi_launch_prefix(64, "/fake/esmf") == (["/opt/cray/mpiexec", "-np", "64"], None)
+
+
+def test_srun_is_preferred_inside_an_active_slurm_allocation(monkeypatch):
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: f"/opt/{name}")   # srun and mpirun both "exist"
+
+    assert _mpi_launch_prefix(64, "/fake/esmf") == (["/opt/srun", "-n", "64"], None)
+
+
+def test_srun_is_not_used_outside_an_allocation_even_if_installed(monkeypatch):
+    """A laptop can have Slurm client tools on PATH with no job running."""
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: f"/opt/{name}")
+
+    assert _mpi_launch_prefix(64, "/fake/esmf") == (["/opt/mpirun", "-np", "64"], None)
+
+
+def test_no_launcher_on_path_falls_back_to_a_bare_command(monkeypatch):
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setattr(remap_mod.shutil, "which", lambda name: None)
+
+    prefix, note = _mpi_launch_prefix(64, "/fake/esmf")
+    assert prefix == []
+    assert "no srun/mpirun/mpiexec" in note
+
+
+def test_a_mpiuni_build_declines_the_launcher_with_a_reason(monkeypatch):
+    """The gate that matters: don't corrupt output on a build that can't
+    coordinate ranks, and don't do it silently either."""
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: False)
+    monkeypatch.setattr(remap_mod.shutil, "which", lambda name: f"/opt/{name}")
+
+    prefix, note = _mpi_launch_prefix(64, "/fake/esmf")
+    assert prefix == []
+    assert "mpiuni" in note
+
+
+def test_an_undetectable_build_declines_the_launcher_too(monkeypatch):
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: None)
+    monkeypatch.setattr(remap_mod.shutil, "which", lambda name: f"/opt/{name}")
+
+    prefix, note = _mpi_launch_prefix(64, "/fake/esmf")
+    assert prefix == []
+    assert "could not tell" in note
+
+
+def test_ensure_weights_wraps_the_esmf_call_with_the_launcher(tmp_path, monkeypatch):
+    import gmpas.remap as remap_mod
+
+    calls = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_which(name):
+        return {"ESMF_RegridWeightGen": "/fake/esmf",
+                "mpirun": "/fake/mpirun"}.get(name)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        (tmp_path / "w" / "map_conserve.nc").write_bytes(b"weights")
+        return Result()
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setattr(remap_mod.shutil, "which", fake_which)
+    monkeypatch.setattr(remap_mod.subprocess, "run", fake_run)
+    write_mesh(tmp_path / "m.nc", [(0.0, 0.0), (5.0, 0.0)])
+    domain = TargetDomain(4, 8, -2.0, 2.0, 0.0, 8.0)
+
+    (tmp_path / "w").mkdir()
+    ensure_weights(tmp_path / "m.nc", domain, tmp_path / "w",
+                   ranks=8, quiet=True)
+
+    assert len(calls) == 1
+    assert calls[0][:3] == ["/fake/mpirun", "-np", "8"]
+    assert "/fake/esmf" in calls[0]
+
+
+def test_ensure_weights_declines_the_launcher_on_a_mpiuni_build(tmp_path, monkeypatch):
+    import gmpas.remap as remap_mod
+
+    calls = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_which(name):
+        return {"ESMF_RegridWeightGen": "/fake/esmf",
+                "mpirun": "/fake/mpirun"}.get(name)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        (tmp_path / "w" / "map_conserve.nc").write_bytes(b"weights")
+        return Result()
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: False)
+    monkeypatch.setattr(remap_mod.shutil, "which", fake_which)
+    monkeypatch.setattr(remap_mod.subprocess, "run", fake_run)
+    write_mesh(tmp_path / "m.nc", [(0.0, 0.0), (5.0, 0.0)])
+    domain = TargetDomain(4, 8, -2.0, 2.0, 0.0, 8.0)
+
+    (tmp_path / "w").mkdir()
+    ensure_weights(tmp_path / "m.nc", domain, tmp_path / "w",
+                   ranks=8, quiet=True)
+
+    assert calls[0] == ["/fake/esmf", "-s", "src.scrip.nc", "-d", "dst.scrip.nc",
+                        "-w", "map_conserve.nc", "-m", "conserve",
+                        "--src_regional", "--dst_regional", "--ignore_unmapped"]
 
 
 # ------------------------------------------------------- output construction


### PR DESCRIPTION
## Summary
- `ESMF_RegridWeightGen`'s search and polygon intersection is genuinely MPI-parallel, but gmpas has only ever invoked it bare — one rank, no matter how many cores the job had. `gmpas remap ... -j N` now sizes an MPI launcher (`srun`/`mpirun`/`mpiexec`) the same way it already sizes the file-conversion worker pool — one number for how much of the machine this run gets, not two separate knobs.
- `srun` is used inside an active Slurm allocation (`SLURM_JOB_ID` set), `mpirun`/`mpiexec` otherwise (PBS sites like Derecho). Both optional — with neither on `PATH`, or `-j 1`, this is exactly the bare invocation from before.
- **Gated on the ESMF build actually supporting MPI.** Checked from ESMF's own `esmf.mk` (`$ESMFMKFILE`, or `<prefix>/lib/esmf.mk`). This gate exists because I measured the failure directly, not out of caution: conda-forge's `esmf` package (in `~/miniconda3/envs/mpas_env` on this machine) is a `mpiuni` build — compiled with no real MPI. Launching it under `mpirun -np 2` did **not** parallelize it; it ran two uncoordinated copies that both wrote the same output files in the same directory and corrupted each other, both failing on a nonsense NetCDF error. On a build declaring `ESMF_COMM=mpiuni`, or one whose `esmf.mk` can't be found at all, `ensure_weights` now declines the launcher and prints why, instead of silently downgrading to one rank or corrupting output.
- **What this does not cover**: a genuinely MPI-linked ESMF launched by a *mismatched* MPI implementation (e.g. Homebrew Open MPI's `mpirun` in front of a conda/MPICH-linked ESMF) fails the same uncoordinated-ranks way, and nothing in `esmf.mk` can detect that mismatch from outside. Added to the HPC validation TODO on #34 — only settleable on a real matched module+launcher pair (e.g. Derecho's own `module load esmf` + its `mpiexec`), which nothing on this machine reproduces.

## Test plan
- [x] `pytest` — 286 passed, 5 skipped, no failures
- [x] Verified `_esmf_supports_mpi` against the real `esmf.mk` in `~/miniconda3/envs/mpas_env` — correctly returns `False` (not a false "unknown")
- [x] Reproduced the corruption bare (`mpirun -np 2` against the mpiuni build fails as described above)
- [x] Confirmed the fix: same call with `ranks=8` now declines the launcher, prints the reason, and succeeds single-rank