### PR TITLE
remap: check the tool-adjacent esmf.mk before $ESMFMKFILE, not after

### DIFF
--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -97,9 +97,21 @@ def _esmf_supports_mpi(tool: str) -> bool | None:
 
     Only rules out the case actually observed: a `mpiuni` build -- ESMF's
     internal stub for "compiled with no real MPI library" -- identified from
-    ESMF's own build-info makefile fragment, `esmf.mk`. `module load esmf`
-    conventionally sets `$ESMFMKFILE` to it; failing that, it lives at
-    `<prefix>/lib/esmf.mk` next to the binary.
+    ESMF's own build-info makefile fragment, `esmf.mk`.
+
+    Checked next to `tool` first (`<prefix>/lib/esmf.mk`), `$ESMFMKFILE`
+    only as a fallback when that can't be read or has no ESMF_COMM line --
+    deliberately the opposite of the order `module load esmf` usually
+    implies. `$ESMFMKFILE` describes whichever module was last loaded, not
+    necessarily the binary `tool` actually resolved to: this is the same
+    shadowing issue 34 is about, one level down. `module load esmf` (real
+    MPI) followed by `conda activate` (PATH now finds the conda mpiuni
+    copy) leaves a stale `$ESMFMKFILE` pointing at a build that is not the
+    one about to run. Trusting it first would call a mpiuni binary
+    MPI-capable because a *different*, no-longer-relevant build says so --
+    reintroducing the exact corruption this function exists to prevent.
+    The file next to the resolved binary is the one description of that
+    binary that can't be shadowed this way.
 
     Measured directly, not assumed: launching a `mpiuni` ESMF_RegridWeightGen
     (the conda-forge build) under `mpirun -np 2` did not parallelize it -- it
@@ -118,11 +130,10 @@ def _esmf_supports_mpi(tool: str) -> bool | None:
     """
     import os
 
-    candidates = []
+    candidates = [Path(tool).resolve().parent.parent / "lib" / "esmf.mk"]
     mkfile = os.environ.get("ESMFMKFILE")
     if mkfile:
         candidates.append(Path(mkfile))
-    candidates.append(Path(tool).resolve().parent.parent / "lib" / "esmf.mk")
 
     for mk in candidates:
         try:

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -219,11 +219,29 @@ def test_a_real_mpi_build_is_detected(tmp_path, monkeypatch):
     assert _esmf_supports_mpi(str(tool)) is True
 
 
-def test_esmfmkfile_env_var_wins_over_the_relative_path(tmp_path, monkeypatch):
+def test_the_path_beside_the_resolved_tool_wins_over_esmfmkfile(tmp_path, monkeypatch):
+    """The bug this guards against: `module load esmf` (real MPI) sets
+    $ESMFMKFILE, then `conda activate` shadows PATH so the resolved tool is
+    actually the conda mpiuni copy. $ESMFMKFILE is now stale -- it describes
+    a build that isn't the one about to run. Trusting it over the file next
+    to the *actual* resolved binary would call the mpiuni copy MPI-capable
+    and reintroduce the corruption this function exists to prevent."""
     tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
     tool.parent.mkdir()
     (tmp_path / "lib").mkdir()
-    _write_esmf_mk(tmp_path / "lib" / "esmf.mk", comm="mpiuni")   # would say False
+    _write_esmf_mk(tmp_path / "lib" / "esmf.mk", comm="mpiuni")   # the real answer
+
+    stale_module = tmp_path / "elsewhere.mk"
+    _write_esmf_mk(stale_module, comm="openmpi")   # describes a *different* build
+    monkeypatch.setenv("ESMFMKFILE", str(stale_module))
+
+    assert _esmf_supports_mpi(str(tool)) is False
+
+
+def test_esmfmkfile_is_used_only_when_the_local_path_has_nothing(tmp_path, monkeypatch):
+    tool = tmp_path / "bin" / "ESMF_RegridWeightGen"
+    tool.parent.mkdir()
+    # no lib/esmf.mk beside the tool at all
 
     elsewhere = tmp_path / "elsewhere.mk"
     _write_esmf_mk(elsewhere, comm="openmpi")


### PR DESCRIPTION
## Summary
Follow-up to #37, from review feedback on \`_esmf_supports_mpi\`.

The function checked \`\$ESMFMKFILE\` before the makefile next to the resolved \`tool\` binary — backwards for the one scenario this whole feature exists to protect against. \`module load esmf\` (a real-MPI build) sets \`\$ESMFMKFILE\`; a later \`conda activate\` in the same shell shadows \`PATH\` so \`ESMF_RegridWeightGen\` now resolves to the conda \`mpiuni\` copy instead — but \`\$ESMFMKFILE\` is untouched by that and still points at the module's (different, no-longer-relevant) build. Checking it first meant the mpiuni binary that's actually about to run could be called MPI-capable because a *different* build said so, wrapping it in \`mpirun\` and reintroducing the exact uncoordinated-ranks output corruption #37 was written to prevent.

Fix: check the makefile next to the resolved tool first — it's the one description of that specific binary that can't be shadowed this way — and fall back to \`\$ESMFMKFILE\` only when that can't be read or has no \`ESMF_COMM\` line.

## Test plan
- [x] \`pytest\` — 287 passed, 5 skipped, no failures
- [x] Inverted the existing priority-order test (was asserting the old, wrong behavior) and added a fallback-only test
- [x] Reproduced the exact stale-\$ESMFMKFILE scenario directly: a fake \$ESMFMKFILE claiming \`openmpi\` no longer overrides the real (mpiuni) answer read from next to the actual resolved binary on this machine