### PR TITLE
release: 0.4.2

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,19 @@
 # Status
 
-As of 0.4.0, gmpas covers the pipeline from both ends.
+As of 0.4.2, gmpas covers the pipeline from both ends.
 
 **Postprocessing** — plotting, the interactive viewer, and conservative
-remapping — is implemented. gmpas does not compute remapping weights itself;
-it writes the grid files ESMF or TempestRemap need, applies the result and
-checks that it conserved. See [REMAPPING.md](./REMAPPING.md).
+remapping — is implemented. `gmpas remap` writes the grid files ESMF needs,
+runs it, applies the result and checks that it conserved, all from the
+command line; gmpas does not compute the weights itself. On a machine with
+`srun` or `mpirun`/`mpiexec` available and an MPI-capable ESMF build, weight
+generation uses `-j` ranks instead of one. See [REMAPPING.md](./REMAPPING.md).
+
+gmpas does not install ESMF (or NCO) itself, on purpose — see
+[issue 34](https://github.com/nmathewa/gmpas-lib/issues/34). On an HPC site,
+load the site's own build (`module load esmf`) rather than a conda-forge copy
+in gmpas's own environment; the two compete on `PATH`/`LD_LIBRARY_PATH`
+rather than help.
 
 **Preprocessing** covers `prep view`, `prep hfun` and `prep generate`: looking
 at a mesh after it exists, looking at a distance function before any mesh
@@ -18,11 +26,14 @@ everything `mkgrid` reads.
   out to, named by `$JIGSAWDIR` and `$MKGRIDFILE`. `gmpas prep generate` runs
   the whole chain through to `grid.nc`, but only if you have built them
   ([issue 30](https://github.com/nmathewa/gmpas-lib/issues/30)).
-- **Applying weights from the command line**
-  ([issue 2](https://github.com/nmathewa/gmpas-lib/issues/2)). `ncremap -m`
-  does it today.
 - **Comparing a generated mesh against the `hfun.py` that asked for it** —
   the two are one click apart in the viewer, but nothing yet differences them.
+- **Confirming the MPI launcher and the ESMF build it runs actually match**
+  on real HPC hardware. The `esmf.mk`-based check only rules out a build with
+  no MPI at all (`mpiuni`); a real-MPI build launched by a *different* MPI
+  implementation than it was linked against fails the same uncoordinated-rank
+  way and cannot be detected from outside
+  ([issue 34](https://github.com/nmathewa/gmpas-lib/issues/34)).
 
 ## Known rough edges
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.1"
+version = "0.4.2"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = [
     # entry points


### PR DESCRIPTION
Version bump to 0.4.2 and a status-doc correction, ahead of tagging the release.

v0.4.1 was tagged after #31 but never got a published release, and predates everything below — 0.4.2 is the next free version, not a redo.

Five PRs landed since v0.4.1 (#33, #35, #36, #37, #38), all about running `gmpas remap` correctly on HPC:

- xarray's automatic backend detection was importing MetPy's whole `calc` module on the first file open in a process, adding ~1s before anything else could run. Pinned `engine="netcdf4"` everywhere.
- gmpas no longer installs ESMF or NCO via conda — both are HPC-module-style executables, and a conda-forge copy in gmpas's own environment competes with a site's module rather than helping.
- `gmpas remap -j N` now sizes an MPI launcher (`srun`/`mpirun`/`mpiexec`) for `ESMF_RegridWeightGen` the same way it already sizes the file-conversion worker pool, gated on the ESMF build actually supporting MPI — checked from `esmf.mk`, preferring the file next to the resolved binary over a possibly-stale `$ESMFMKFILE`.

Also corrects `docs/status.md`, which still listed "applying weights from the command line" as unimplemented — that shipped before this session, in 29c0766. Closed as #2.