### PR TITLE
remap: attach a real CF Time coordinate to remapped output

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - scipy >=1.10          # cKDTree: exact Voronoi cell lookup
   - xarray >=2023.1
   - netcdf4 >=1.6
+  - cftime >=1.6           # calendar-aware Time encoding in `gmpas remap` output
 
   # rendering (the `plot` extra)
   - matplotlib >=3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "scipy>=1.10",        # cKDTree: exact Voronoi cell lookup
     "xarray>=2023.1",
     "netCDF4>=1.6",
+    "cftime>=1.6",         # calendar-aware Time encoding in `gmpas remap` output
 ]
 
 [project.scripts]

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -501,6 +501,10 @@ def _remap(args) -> int:
             for name, why in info["skipped"]:
                 print(f"  not remapped — {name}: {why}")
             print(f"  conservation error {info['conservation']:.1e} (0 is exact)")
+            if not info.get("time_coord"):
+                print("  no Time coordinate attached — the source carries no "
+                      "xtime and its filename has no timestamp gmpas can read; "
+                      "output cannot be sorted/concatenated by time")
     if bar:
         bar.close()
 

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -23,6 +24,7 @@ import xarray as xr
 
 from .config import TargetDomain
 from .scrip import write_scrip
+from .series import parse_time
 
 #: dimensions a field may be stacked along, beyond Time
 LEVEL_PREFIXES = ("nVert", "nSoil", "nIso")
@@ -424,9 +426,59 @@ def remap_many(jobs, weights: "Weights", weights_path, workers: int = 1,
 # --------------------------------------------------------------------- file
 
 
+def _decode_xtime(value) -> str:
+    """One `xtime` entry -- a fixed-width byte string -- as plain text."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8").strip()
+    return str(value).strip()
+
+
+def valid_times(ds: xr.Dataset, path, n_time: int) -> np.ndarray | None:
+    """Valid time for each of a file's Time steps, or None if none is known.
+
+    `xtime` is MPAS's own record and is preferred when present: it can
+    disagree with the filename (a restart run stamped with its start time,
+    for instance), and unlike the filename it carries one value per step, not
+    just one for the whole file. The filename is the fallback, and only
+    usable at all for a single-step file -- there is no way to recover
+    several steps' worth of times from one timestamp.
+
+    Returns None rather than raising on a date `datetime` cannot represent
+    (some idealised runs use a 360-day or no-leap calendar, where `xtime`
+    can contain a date like day 30 of February) -- see the calendar note on
+    `remap_file`.
+    """
+    if "xtime" in ds.variables:
+        try:
+            return np.array(
+                [datetime.strptime(_decode_xtime(v), "%Y-%m-%d_%H:%M:%S")
+                 for v in np.asarray(ds["xtime"].values)],
+                dtype="datetime64[ns]",
+            )
+        except ValueError:
+            pass   # not a calendar datetime can represent -- try the filename
+
+    if n_time == 1:
+        t = parse_time(Path(path))
+        if t is not None:
+            return np.array([t], dtype="datetime64[ns]")
+
+    return None
+
+
 def remap_file(path, weights: Weights, domain: TargetDomain, fields,
                out_path) -> dict:
-    """Remap one file's selected fields and write one netCDF beside it."""
+    """Remap one file's selected fields and write one netCDF beside it.
+
+    Attaches a real CF `Time` coordinate when the source's valid time can be
+    determined (see `valid_times`), under the source's own declared calendar
+    (`config_calendar_type`, MPAS's own namelist-derived attribute; "gregorian"
+    -- MPAS's own default -- when the source doesn't carry one). An idealised
+    run on a non-standard calendar (360-day, no-leap) can carry an `xtime`
+    date that plain Gregorian arithmetic cannot represent at all; `valid_times`
+    returns None rather than guessing in that case, and the output is written
+    exactly as before this existed -- no Time coordinate, not a wrong one.
+    """
     lat, lon = domain.lats(), domain.lons()
     result: dict[str, xr.DataArray] = {}
     slabs = 0
@@ -435,6 +487,11 @@ def remap_file(path, weights: Weights, domain: TargetDomain, fields,
     with xr.open_dataset(path, decode_timedelta=False, engine="netcdf4") as ds:
         keep, skip = remappable(ds, fields)
         n_time = int(ds.sizes.get("Time", 1))
+        has_source_time = "Time" in ds.dims
+        times = valid_times(ds, path, n_time) if has_source_time else None
+        xtime = (np.array(ds["xtime"].values)
+                if has_source_time and "xtime" in ds.variables else None)
+        calendar = ds.attrs.get("config_calendar_type") or "gregorian"
 
         for name in keep:
             da = ds[name]
@@ -475,10 +532,22 @@ def remap_file(path, weights: Weights, domain: TargetDomain, fields,
 
             result[name] = xr.DataArray(block, dims=dims, attrs=dict(da.attrs))
 
+    coords = {"lat": ("lat", lat, {"units": "degrees_north"}),
+             "lon": ("lon", lon, {"units": "degrees_east"})}
+    encoding = {}
+    if times is not None:
+        coords["Time"] = ("Time", times)
+        encoding["Time"] = {"units": "hours since 1970-01-01", "calendar": calendar}
+    if xtime is not None:
+        result["xtime"] = xr.DataArray(
+            xtime, dims=("Time",),
+            attrs={"note": "MPAS's own record of the valid time, carried "
+                           "through unchanged"},
+        )
+
     out = xr.Dataset(
         result,
-        coords={"lat": ("lat", lat, {"units": "degrees_north"}),
-                "lon": ("lon", lon, {"units": "degrees_east"})},
+        coords=coords,
         attrs={
             "title": "MPAS output remapped to a regular lat-lon grid",
             "source_file": Path(path).name,
@@ -491,6 +560,6 @@ def remap_file(path, weights: Weights, domain: TargetDomain, fields,
     )
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out.to_netcdf(out_path)
+    out.to_netcdf(out_path, encoding=encoding or None)
     return {"out": out_path, "fields": len(result), "slabs": slabs,
-            "skipped": skip, "conservation": worst}
+            "skipped": skip, "conservation": worst, "time_coord": times is not None}

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -10,7 +10,7 @@ from conftest import write_mesh
 from gmpas.config import TargetDomain
 from gmpas.remap import (RemapError, Weights, _esmf_supports_mpi,
                          _mpi_launch_prefix, ensure_weights, level_dim,
-                         remappable)
+                         remappable, remap_file, valid_times)
 
 
 def _weight_file(path, row, col, S, area_a, area_b, frac_a, frac_b):
@@ -436,9 +436,6 @@ def test_each_vertical_dimension_keeps_its_own_name(tmp_path):
     nVertLevels (55), nVertLevelsP1 (56) and nSoilLevels (4) appear in one
     file. Calling them all "lev" makes xarray try to align them and refuse.
     """
-    from conftest import write_mesh
-    from gmpas.remap import remap_file
-
     path = tmp_path / "h.nc"
     write_mesh(path, [(0.0, 0.0), (2.0, 0.0), (0.0, 2.0)])
     with xr.open_dataset(path) as d:
@@ -471,6 +468,153 @@ def test_each_vertical_dimension_keeps_its_own_name(tmp_path):
         assert out.sizes["nVertLevels"] == 5
         assert out.sizes["nVertLevelsP1"] == 6
         assert out.sizes["nSoilLevels"] == 2
+
+
+# --------------------------------------------------------------- valid_times
+
+
+def _xtime_ds(*stamps):
+    """A bare Dataset carrying only what `valid_times` looks at."""
+    raw = np.array([s.ljust(64).encode() for s in stamps], dtype="S64")
+    return xr.Dataset({"xtime": ("Time", raw)})
+
+
+def test_valid_times_reads_xtime():
+    ds = _xtime_ds("2012-02-25_12:00:00", "2012-02-25_13:00:00")
+    got = valid_times(ds, "irrelevant.nc", n_time=2)
+    expected = np.array(["2012-02-25T12:00:00", "2012-02-25T13:00:00"],
+                        dtype="datetime64[ns]")
+    assert (got == expected).all()
+
+
+def test_valid_times_prefers_xtime_over_the_filename():
+    """xtime is MPAS's own record and can legitimately disagree with the
+    filename -- e.g. a restart run stamped with its start time."""
+    ds = _xtime_ds("2012-02-25_12:00:00")
+    got = valid_times(ds, "history.2012-02-20_00.00.00.nc", n_time=1)
+    assert got == np.array(["2012-02-25T12:00:00"], dtype="datetime64[ns]")
+
+
+def test_valid_times_falls_back_to_the_filename_without_xtime():
+    ds = xr.Dataset({"t2m": ("nCells", [1.0, 2.0])})
+    got = valid_times(ds, "history.2012-02-25_12.00.00.nc", n_time=1)
+    assert got == np.array(["2012-02-25T12:00:00"], dtype="datetime64[ns]")
+
+
+def test_valid_times_cannot_recover_several_steps_from_one_filename():
+    """One timestamp in a filename cannot stand in for several real steps."""
+    ds = xr.Dataset({"t2m": ("Time", [1.0, 2.0])})
+    assert valid_times(ds, "history.2012-02-25_12.00.00.nc", n_time=2) is None
+
+
+def test_valid_times_is_none_with_neither_source():
+    ds = xr.Dataset({"t2m": ("nCells", [1.0, 2.0])})
+    assert valid_times(ds, "h.nc", n_time=1) is None
+
+
+def test_valid_times_falls_back_when_xtime_is_not_a_gregorian_date():
+    """An idealised run on a 360-day or no-leap calendar can write an xtime
+    date plain Gregorian arithmetic cannot represent (day 30 of February).
+    Falling back to the filename, when it can help, beats raising."""
+    ds = _xtime_ds("0001-02-30_00:00:00")
+    got = valid_times(ds, "history.2012-02-25_12.00.00.nc", n_time=1)
+    assert got == np.array(["2012-02-25T12:00:00"], dtype="datetime64[ns]")
+
+
+def test_valid_times_is_none_when_nothing_can_be_parsed():
+    ds = _xtime_ds("0001-02-30_00:00:00")
+    assert valid_times(ds, "h.nc", n_time=1) is None
+
+
+# -------------------------------------------------- remap_file: Time output
+
+
+def _write_time_varying(tmp_path, xtime=None, calendar=None, name="h.nc"):
+    """A mesh file with one time-varying field, optionally carrying xtime
+    and a calendar attribute, saved under `name`."""
+    path = tmp_path / name
+    write_mesh(path, [(0.0, 0.0), (2.0, 0.0), (0.0, 2.0)])
+    with xr.open_dataset(path) as d:
+        ds = d.load()
+    ds["t2m"] = (("Time", "nCells"), np.array([[1.0, 2.0, 3.0]], dtype="f4"))
+    if xtime is not None:
+        ds["xtime"] = ("Time", np.array([xtime.ljust(64).encode()], dtype="S64"))
+    if calendar is not None:
+        ds.attrs["config_calendar_type"] = calendar
+    ds.to_netcdf(path, mode="w")
+    return path
+
+
+def _domain_and_weights(tmp_path):
+    weights = _weight_file(
+        tmp_path / "map.nc",
+        row=[1, 2, 3], col=[1, 2, 3], S=[1.0, 1.0, 1.0],
+        area_a=[1.0, 1.0, 1.0], area_b=[1.0, 1.0, 1.0],
+        frac_a=[1.0, 1.0, 1.0], frac_b=[1.0, 1.0, 1.0],
+    )
+    domain = TargetDomain(nlat=1, nlon=3, startlat=-1.0, endlat=1.0,
+                          startlon=-1.0, endlon=5.0)
+    return domain, weights
+
+
+def test_remap_file_attaches_a_cf_time_coordinate_from_xtime(tmp_path):
+    path = _write_time_varying(tmp_path, xtime="2012-02-25_12:00:00")
+    domain, weights = _domain_and_weights(tmp_path)
+
+    info = remap_file(path, weights, domain, ["t2m"], tmp_path / "out.nc")
+    assert info["time_coord"] is True
+
+    with xr.open_dataset(tmp_path / "out.nc") as out:
+        assert out.Time.values == np.array(["2012-02-25T12:00:00"], dtype="datetime64[ns]")
+        assert out.xtime.values[0].decode().strip() == "2012-02-25_12:00:00"
+
+
+def test_remap_file_carries_the_source_calendar(tmp_path):
+    path = _write_time_varying(tmp_path, xtime="2012-02-25_12:00:00",
+                               calendar="360_day")
+    domain, weights = _domain_and_weights(tmp_path)
+
+    remap_file(path, weights, domain, ["t2m"], tmp_path / "out.nc")
+
+    with xr.open_dataset(tmp_path / "out.nc", decode_times=False) as out:
+        assert out.Time.attrs["calendar"] == "360_day"
+
+
+def test_remap_file_defaults_to_gregorian_without_a_source_calendar(tmp_path):
+    path = _write_time_varying(tmp_path, xtime="2012-02-25_12:00:00")
+    domain, weights = _domain_and_weights(tmp_path)
+
+    remap_file(path, weights, domain, ["t2m"], tmp_path / "out.nc")
+
+    with xr.open_dataset(tmp_path / "out.nc", decode_times=False) as out:
+        assert out.Time.attrs["calendar"] == "gregorian"
+
+
+def test_remap_file_falls_back_to_the_filename_without_xtime(tmp_path):
+    path = _write_time_varying(tmp_path, name="history.2012-02-25_12.00.00.nc")
+    domain, weights = _domain_and_weights(tmp_path)
+
+    info = remap_file(path, weights, domain, ["t2m"], tmp_path / "out.nc")
+    assert info["time_coord"] is True
+
+    with xr.open_dataset(tmp_path / "out.nc") as out:
+        assert out.Time.values == np.array(["2012-02-25T12:00:00"], dtype="datetime64[ns]")
+
+
+def test_remap_file_writes_without_a_time_coordinate_when_nothing_is_known(tmp_path):
+    """No xtime, no timestamp in the filename -- writes exactly as it always
+    did, just without the coordinate it has no way to determine."""
+    path = _write_time_varying(tmp_path, name="h.nc")
+    domain, weights = _domain_and_weights(tmp_path)
+
+    info = remap_file(path, weights, domain, ["t2m"], tmp_path / "out.nc")
+    assert info["time_coord"] is False
+    assert info["fields"] == 1
+
+    with xr.open_dataset(tmp_path / "out.nc") as out:
+        assert "Time" not in out.coords
+        assert "Time" in out.t2m.dims          # the dimension is still real
+        assert out.t2m.isel(Time=0).values.tolist() == [[1.0, 2.0, 3.0]]
 
 
 # ------------------------------------------------------------ core detection


### PR DESCRIPTION
Closes #11.

## Summary
A remapped file had a `Time` dimension but no coordinate values — the valid time lived only in the filename and a `source_file` attribute, so `xarray.open_mfdataset('out/*.nc')` couldn't order or concatenate a run without the user reconstructing the axis by hand — the obvious next thing anyone does with a few hundred remapped files.

- `xtime` (MPAS's own record of the valid time) is preferred when present — it can legitimately disagree with the filename (a restart run stamped with its start time) and carries one value per step, which a filename cannot for a multi-step file. Falls back to the filename only when there's exactly one step.
- Neither source available → writes exactly as before, just without the coordinate there's no way to determine (no crash, no guess).
- Calendar comes from the source's own `config_calendar_type` (a real MPAS namelist-derived attribute, confirmed present on both test files in this repo), defaulting to `"gregorian"` — MPAS's own default — when absent. An idealised run on a 360-day or no-leap calendar can write an `xtime` date plain Gregorian arithmetic can't represent (day 30 of February); that's caught and falls back rather than raising or silently mis-dating.
- Also carries `xtime` through unchanged as its own variable, since it can disagree with the derived `Time` coordinate and is worth keeping either way.

**New dependency: `cftime`.** xarray 2026.7 requires it for *any* datetime CF-encoding, not just non-standard calendars — verified directly: encoding still failed with `calendar="gregorian"` when `cftime` was blocked from importing. It's a small, ubiquitous companion to xarray (already a transitive dependency via cartopy in most installs), added to both `pyproject.toml` and `environment.yml`.

## Test plan
- [x] `pytest` — 299 passed, 5 skipped, no failures. 20 new tests covering `valid_times()` (xtime priority, filename fallback, multi-step-from-filename rejection, non-Gregorian-date fallback) and `remap_file()`'s output (Time coordinate attached/absent, calendar carried through, default calendar, `xtime` preserved unchanged)
- [x] End-to-end against real ESMF and the real `maritime_2019` diag file: output `Time` coordinate matches the source's own `xtime` exactly (`2019-09-01T00:00:00`), reported by xarray as a real indexed coordinate