### PR TITLE
viewer: lock Series's shared cache, bound the view/overlay caches

### DIFF
--- a/src/gmpas/series.py
+++ b/src/gmpas/series.py
@@ -118,7 +118,23 @@ class Series:
         self.files = expand(paths)
         self._open: OrderedDict[Path, xr.Dataset] = OrderedDict()
 
-        first = self._dataset(self.files[0])
+        # netCDF4/HDF5 is not safe for concurrent access from multiple
+        # threads, and the viewer serves every HTTP request on its own
+        # thread (ThreadingHTTPServer) -- a request scrubbing the time slider
+        # can run at the same moment as an animation's frame-by-frame loop,
+        # which nothing in the UI serializes. Every read through this Series
+        # -- cache lookup, LRU eviction, and the disk read itself -- happens
+        # under this one lock, held for the read's full duration rather than
+        # just around the dict bookkeeping: releasing it as soon as a cached
+        # handle is returned would still let one thread's eviction close a
+        # dataset another thread is mid-read on, corrupting or NaN-ing that
+        # frame rather than raising. `_scan`'s own handles are included, even
+        # though they never touch this cache, because the race is in the
+        # underlying C library, not just this dict.
+        self._lock = threading.Lock()
+
+        with self._lock:
+            first = self._dataset(self.files[0])
 
         if mesh_path:
             self.mesh = MpasMesh.load(resolve_path(mesh_path))
@@ -175,7 +191,13 @@ class Series:
 
         Uses netCDF4 rather than xarray -- 1.6 ms per file against 7.3 ms,
         because reading one dimension does not need xarray's decoding. Keeps
-        its own handles so it never touches the LRU another thread is using.
+        its own handles so it never touches the LRU another thread is using
+        -- but still takes `self._lock` per file, held only for that one
+        open+read: the cache dict is not the only thing at risk here, the
+        underlying netCDF4/HDF5 library itself is not safe under concurrent
+        access from another thread, whether or not the two sides share a
+        handle. Locked per file rather than for the whole scan so a frame
+        request only ever waits as long as one file's dimension read.
         """
         import netCDF4
 
@@ -184,7 +206,7 @@ class Series:
             if path in counts:
                 continue
             try:
-                with netCDF4.Dataset(path) as nc:
+                with self._lock, netCDF4.Dataset(path) as nc:
                     dim = nc.dimensions.get("Time")
                     counts[path] = len(dim) if dim is not None else 1
             except Exception:
@@ -197,6 +219,7 @@ class Series:
     # -- files -----------------------------------------------------------
 
     def _dataset(self, path: Path) -> xr.Dataset:
+        """Caller must hold `self._lock` -- see the note in `__init__`."""
         if path in self._open:
             self._open.move_to_end(path)
             return self._open[path]
@@ -209,9 +232,10 @@ class Series:
         return ds
 
     def close(self) -> None:
-        for ds in self._open.values():
-            ds.close()
-        self._open.clear()
+        with self._lock:
+            for ds in self._open.values():
+                ds.close()
+            self._open.clear()
 
     # -- access ----------------------------------------------------------
 
@@ -231,7 +255,8 @@ class Series:
     @property
     def first(self) -> xr.Dataset:
         """The dataset backing step 0 -- what to introspect for variables."""
-        return self._dataset(self.files[0])
+        with self._lock:
+            return self._dataset(self.files[0])
 
     @property
     def n_files(self) -> int:
@@ -241,19 +266,31 @@ class Series:
         return self.groups.get(dim, [])
 
     def dataarray(self, var: str, step: int = 0) -> xr.DataArray:
+        """A lazy reference -- `.attrs`/`.dims`/`.sizes` are safe to read
+        afterward, but not `.values`: the file behind it can be evicted and
+        closed by another thread before you get to it. Use `values()` to
+        actually read data."""
         path, _ = self.steps[step]
-        ds = self._dataset(path)
-        if var not in ds:
-            raise KeyError(f"{var!r} not in {path.name}")
-        return ds[var]
+        with self._lock:
+            ds = self._dataset(path)
+            if var not in ds:
+                raise KeyError(f"{var!r} not in {path.name}")
+            return ds[var]
 
     def values(self, var: str, step: int = 0, level: int = 0) -> np.ndarray:
-        """One field at one step in the series, as a flat per-element array."""
+        """One field at one step in the series, as a flat per-element array.
+
+        The actual disk read (`select` materialises `.values`) happens
+        inside the lock along with the cache lookup, not after it -- the
+        returned array is a plain, fully detached numpy array, so nothing
+        else needs to hold the lock once this returns.
+        """
         path, local = self.steps[step]
-        ds = self._dataset(path)
-        if var not in ds:
-            raise KeyError(f"{var!r} not in {path.name}")
-        return select(ds[var], time=local, level=level)
+        with self._lock:
+            ds = self._dataset(path)
+            if var not in ds:
+                raise KeyError(f"{var!r} not in {path.name}")
+            return select(ds[var], time=local, level=level)
 
     def __repr__(self) -> str:
         return (f"<Series {len(self.steps)} steps across {self.n_files} files"

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -20,6 +20,7 @@ import io
 import json
 import threading
 import webbrowser
+from collections import OrderedDict
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -34,6 +35,13 @@ from .series import Series
 #: colormaps offered in the picker, chosen to cover the usual field kinds
 CMAPS = ["viridis", "plasma", "magma", "cividis", "turbo",
          "RdBu_r", "coolwarm", "BrBG", "Blues", "Spectral_r"]
+
+#: distinct view boxes to keep a ViewIndex/overlay cached for. Each entry is
+#: an nx*ny array pair (~7.5 MB at the 1200x700 default), and nothing evicted
+#: this before -- panning and zooming around over a long session, which is
+#: exactly what building up several animations for different variables looks
+#: like, grew both dicts without bound for the life of the server process.
+VIEW_LRU_SIZE = 12
 
 
 def ramp(name: str, n: int = 32) -> list[str]:
@@ -168,8 +176,8 @@ class Viewer:
         self.mesh = self.series.mesh
         self.nx, self.ny = nx, ny
         self.home = self.mesh.extent
-        self._views: dict[tuple, ViewIndex] = {}
-        self._overlays: dict[tuple, bytes] = {}
+        self._views: OrderedDict[tuple, ViewIndex] = OrderedDict()
+        self._overlays: OrderedDict[tuple, bytes] = OrderedDict()
         self._lock = threading.Lock()
 
     # -- variables -------------------------------------------------------
@@ -221,17 +229,27 @@ class Viewer:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
         with self._lock:
-            if key not in self._views:
-                self._views[key] = ViewIndex(self.mesh, extent, nx, ny)
-            return self._views[key]
+            if key in self._views:
+                self._views.move_to_end(key)
+                return self._views[key]
+            index = ViewIndex(self.mesh, extent, nx, ny)
+            self._views[key] = index
+            if len(self._views) > VIEW_LRU_SIZE:
+                self._views.popitem(last=False)
+            return index
 
     def overlay(self, extent, nx=None, ny=None) -> bytes:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
         with self._lock:
-            if key not in self._overlays:
-                self._overlays[key] = _overlay(extent, nx, ny)
-            return self._overlays[key]
+            if key in self._overlays:
+                self._overlays.move_to_end(key)
+                return self._overlays[key]
+            png = _overlay(extent, nx, ny)
+            self._overlays[key] = png
+            if len(self._overlays) > VIEW_LRU_SIZE:
+                self._overlays.popitem(last=False)
+            return png
 
     def values(self, var: str, time: int, level: int) -> np.ndarray:
         """`time` indexes the whole series, across files, not one file."""

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -153,6 +153,22 @@ def test_the_view_cache_keys_on_size_not_just_extent(small_viewer):
     assert small_viewer.view(box, 80, 50) is a       # still cached
 
 
+def test_the_view_cache_does_not_grow_without_bound(small_viewer):
+    """Nothing evicted this before: panning and zooming around over a long
+    session -- exactly what setting up several animations for different
+    variables looks like -- grew _views/_overlays forever, for the life of
+    the server process."""
+    from gmpas.viewer import VIEW_LRU_SIZE
+
+    box = small_viewer.home
+    for i in range(VIEW_LRU_SIZE + 8):
+        small_viewer.view(box, 80 + i, 50)
+        small_viewer.overlay(box, 80 + i, 50)
+
+    assert len(small_viewer._views) == VIEW_LRU_SIZE
+    assert len(small_viewer._overlays) == VIEW_LRU_SIZE
+
+
 def test_a_frame_can_be_asked_for_at_a_larger_size(small_viewer):
     """The margin is fetched at proportionally more pixels to stay sharp."""
     from PIL import Image
@@ -276,6 +292,67 @@ def test_gif_export_holds_every_step(tmp_path):
         gif = v.gif("fld", 0, v.home, "viridis", 0.0, 100.0, 60, 40, fps=5)
         with Image.open(io.BytesIO(gif)) as im:
             assert im.n_frames == 4
+    finally:
+        v.series.close()
+
+
+def test_concurrent_reads_do_not_corrupt_each_other(tmp_path, monkeypatch):
+    """The bug this guards against: an animation's frame-by-frame loop and
+    ordinary navigation (scrubbing, panning, a probe click) are never
+    serialized by the UI, and both end up calling Series.values() on their
+    own ThreadingHTTPServer request thread. Without a lock spanning the
+    whole read -- cache lookup, LRU eviction, and the disk read itself --
+    one thread's eviction can close a file another thread is mid-read on,
+    which came back as NaN or a neighbour's value rather than an exception.
+
+    Each file's field is a distinct, exactly-checkable constant so any
+    cross-contamination or NaN is caught rather than merely suspected. A
+    small LRU_SIZE against many more files forces the eviction this bug
+    needs to happen on nearly every read, not rarely.
+    """
+    import threading
+
+    import xarray as xr
+
+    import gmpas.series as series_mod
+    from conftest import write_mesh
+    from gmpas.viewer import Viewer
+
+    monkeypatch.setattr(series_mod, "LRU_SIZE", 2)
+
+    run = tmp_path / "run"
+    run.mkdir()
+    n_files = 10
+    for i in range(n_files):
+        fp = run / f"history.2012-02-{i + 1:02d}_00.00.00.nc"
+        write_mesh(fp, [(0.0, 0.0), (5.0, 0.0), (0.0, 5.0)])
+        with xr.open_dataset(fp) as d:
+            ds = d.load()
+        ds["fld"] = (("Time", "nCells"), np.full((1, 3), i * 1000.0, dtype="f8"))
+        ds.to_netcdf(fp, mode="w")
+
+    v = Viewer(run, nx=20, ny=20)
+    errors = []
+
+    def hammer(step):
+        try:
+            for _ in range(30):
+                got = v.series.values("fld", step=step, level=0)
+                expected = step * 1000.0
+                if not np.array_equal(got, np.full(3, expected)):
+                    errors.append(
+                        f"step {step}: expected all {expected}, got {got}")
+        except Exception as exc:                # a race must not raise either
+            errors.append(f"step {step}: {type(exc).__name__}: {exc}")
+
+    try:
+        threads = [threading.Thread(target=hammer, args=(i % n_files,))
+                  for i in range(32)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert errors == []
     finally:
         v.series.close()
 


### PR DESCRIPTION
Addresses #41, but read that issue's "What I could not confirm" section before assuming this is a full fix — I found and fixed two real defects by code review; I was not able to reproduce the reported NaN frames directly in a stress test.

## Summary
- **`Series._dataset()`'s LRU cache had no locking**, despite being reached from multiple `ThreadingHTTPServer` request threads (nothing in the UI serializes "animate" against normal navigation — scrubbing/panning/a probe click can and do land on other threads while a long animation load is in flight). Locked for the full duration of a read (cache lookup + LRU eviction + the actual disk read) so eviction can never race a read still in flight on the handle it's about to close. `_scan()`'s own separate netCDF4 handles included, locked per file — the underlying C library is the concern, not just this one dict.
- **`Viewer._views`/`._overlays` had no bound at all** — every distinct `(extent, nx, ny)` a session ever touched stayed cached forever. Bounded to an LRU of 12, matching `Series._open`'s existing pattern.

## Test plan
- [x] `pytest` — 289 passed, 5 skipped (this branch is off `main`, without the still-open #40; count differs from that branch, not a regression)
- [x] New concurrency stress test (`test_concurrent_reads_do_not_corrupt_each_other`) — 32 threads hammering `Series.values()` against a small `LRU_SIZE` to force heavy eviction churn, each file carrying an exactly-checkable constant so any corruption or NaN is caught rather than merely suspected
- [x] New bound test (`test_the_view_cache_does_not_grow_without_bound`) confirming `_views`/`_overlays` actually evict past `VIEW_LRU_SIZE`
- [x] Verified the stress test passes on the fixed code and reran it against the pre-fix code to check it would catch the bug — it did not reproduce corruption either way in this environment (see #41 for what that does and doesn't mean)