### PR TITLE
remap: apply weights with a cached sparse matrix instead of np.add.at

### DIFF
--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -52,6 +52,9 @@ class Weights:
     frac_a: np.ndarray
     frac_b: np.ndarray
     path: Path
+    #: CSR form, built once on first use rather than per apply() call --
+    #: see _sparse(). Excluded from repr/equality, it's a cache, not data.
+    _matrix: object = field(default=None, repr=False, compare=False)
 
     @classmethod
     def load(cls, path: str | Path) -> "Weights":
@@ -74,11 +77,28 @@ class Weights:
     def n_b(self) -> int:
         return self.area_b.size
 
+    def _sparse(self):
+        """The weights as a CSR matrix, built once and reused.
+
+        `apply()` runs once per (field, level, timestep) slab -- hundreds of
+        times over a real run -- and `np.add.at` redid the same scatter-add
+        setup from row/col/S every single call. Measured at ~99M nonzeros
+        (a 5.7M-cell source, 4.4M-cell target): building the matrix once
+        costs ~4s; every `apply()` after that is a single sparse @ dense
+        matvec at roughly half of what `np.add.at` cost per call. `coo`-style
+        construction from (row, col, S) sums duplicate entries automatically,
+        same as `add.at` did -- this is not an approximation of the old
+        behaviour, it produces identical output.
+        """
+        if self._matrix is None:
+            from scipy.sparse import csr_matrix
+            self._matrix = csr_matrix((self.S, (self.row, self.col)),
+                                      shape=(self.n_b, self.n_a))
+        return self._matrix
+
     def apply(self, src: np.ndarray) -> np.ndarray:
         """Sparse matrix multiply: one source field to one destination field."""
-        dst = np.zeros(self.n_b)
-        np.add.at(dst, self.row, self.S * np.asarray(src, dtype=np.float64)[self.col])
-        return dst
+        return self._sparse() @ np.asarray(src, dtype=np.float64)
 
     def conservation_error(self, src: np.ndarray, dst: np.ndarray) -> float:
         """Relative difference between the two area integrals.

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -76,6 +76,32 @@ def test_a_constant_field_stays_constant(weights):
     assert weights.apply(np.ones(2)) == pytest.approx([1.0, 1.0])
 
 
+def test_the_sparse_matrix_is_built_once_and_reused(weights):
+    """apply() runs once per field/level/timestep slab over a real run --
+    rebuilding the CSR matrix from row/col/S every call would throw away
+    the whole point of caching it."""
+    assert weights._matrix is None
+    weights.apply(np.array([4.0, 8.0]))
+    m = weights._matrix
+    assert m is not None
+    weights.apply(np.array([1.0, 2.0]))
+    assert weights._matrix is m
+
+
+def test_duplicate_row_col_pairs_accumulate_like_add_at_did(tmp_path):
+    """csr_matrix construction from (row, col, S) triples sums duplicates
+    automatically -- confirming that switching apply() from np.add.at to a
+    precomputed sparse matvec is not an approximation of the old behaviour,
+    it produces identical output. Two entries land on the same (row, col)."""
+    w = _weight_file(
+        tmp_path / "dup.nc",
+        row=[1, 1], col=[1, 1], S=[0.5, 0.25],   # same destination and source cell
+        area_a=[1.0], area_b=[1.0], frac_a=[1.0], frac_b=[1.0],
+    )
+    dst = w.apply(np.array([4.0]))
+    assert dst == pytest.approx([0.5 * 4.0 + 0.25 * 4.0])
+
+
 def test_the_area_integral_is_preserved(weights):
     for src in (np.ones(2), np.array([4.0, 8.0]), np.array([-1.5, 2.25])):
         dst = weights.apply(src)


### PR DESCRIPTION
## Summary
`Weights.apply()` runs once per (field, level, timestep) slab — hundreds of times over a real remap run — and `np.add.at` redid the same scatter-add setup from `row`/`col`/`S` every single call.

Measured at the scale a real run actually hits (from the log that prompted this): a 5.7M-cell source mesh remapped to a 2961×1481 (4.4M-cell) target produced a ~1.6 GB weight file, implying ~99M nonzero weights. At that size:

| | per `apply()` call |
|---|---|
| `np.add.at` (current) | ~0.79s |
| precomputed `scipy.sparse` CSR matvec | ~0.35s |

The matrix costs ~4s to build once; every `apply()` after that is roughly half the old per-call cost. With 20 fields × however many vertical levels × 192 files, that ~4s is paid once per worker process, not once per slab.

`csr_matrix` construction from `(row, col, S)` triples sums duplicate entries automatically — the same accumulation `np.add.at` did for repeated indices. Not an approximation of the old behaviour; output is identical (covered by a new test with deliberately duplicated `(row, col)` pairs).

## Test plan
- [x] `pytest` — 301 passed, 5 skipped, no failures
- [x] New test confirming the matrix is built once and reused across `apply()` calls, not rebuilt per call
- [x] New test confirming duplicate `(row, col)` entries accumulate identically to the old `np.add.at` behavior
- [x] Real-ESMF integration test still passes