### PR TITLE
remap: pass --no_log to ESMF_RegridWeightGen

### DIFF
--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -261,7 +261,15 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
     launch, note = _mpi_launch_prefix(ranks, tool)
     cmd = launch + [tool, "-s", src_scrip.name, "-d", dst_scrip.name,
                     "-w", weights.name, "-m", method,
-                    "--src_regional", "--dst_regional", "--ignore_unmapped"]
+                    "--src_regional", "--dst_regional", "--ignore_unmapped",
+                    # ESMF's own default logs every message from every rank,
+                    # and warns that this "may cause slowdown in performance"
+                    # -- real cost under -np 64+ on a shared/parallel
+                    # filesystem, not just noise. gmpas's own error handling
+                    # only reads captured stdout/stderr (below), never these
+                    # per-PET log files, so there is nothing here that relies
+                    # on them existing.
+                    "--no_log"]
     if not quiet:
         if note:
             print(f"  {note}")

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -450,7 +450,8 @@ def test_ensure_weights_declines_the_launcher_on_a_mpiuni_build(tmp_path, monkey
 
     assert calls[0] == ["/fake/esmf", "-s", "src.scrip.nc", "-d", "dst.scrip.nc",
                         "-w", "map_conserve.nc", "-m", "conserve",
-                        "--src_regional", "--dst_regional", "--ignore_unmapped"]
+                        "--src_regional", "--dst_regional", "--ignore_unmapped",
+                        "--no_log"]
 
 
 # ------------------------------------------------------- output construction


### PR DESCRIPTION
## Summary
ESMF's own default logs every message from every rank, and its own banner warns "THIS MAY CAUSE SLOWDOWN IN PERFORMANCE ... FOR PRODUCTION RUNS, USE: ESMF_LOGKIND_Multi_On_Error" — confirmed by a real \`PET63.RegridWeightGen.Log\` from a Derecho run (\`-np 64\`, ESMF 8.9.1, \`ESMF_COMM: mpi\`) showing exactly that warning. 64 ranks each logging every message to a shared/parallel filesystem simultaneously is real I/O contention, not just noise.

\`ESMF_RegridWeightGen --help\` exposes \`--no_log\` directly. gmpas's own error handling (the crash-retry loop in \`ensure_weights()\`) only reads captured \`stdout\`/\`stderr\` from the subprocess — nothing reads the per-PET log files on disk, so there's no functional dependency on them existing.

## Test plan
- [x] \`pytest\` — 301 passed, 5 skipped
- [x] Verified against real ESMF: weight generation still succeeds, confirmed zero \`PET*.Log\` files are written with the flag present (previously always written)