### PR TITLE
remap: build the sparse weight matrix before forking, not after

### DIFF
--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -415,8 +415,22 @@ def remap_many(jobs, weights: "Weights", weights_path, workers: int = 1,
     `jobs` is (source, output, domain, fields) tuples. With one worker this
     runs in-process; with more it forks where possible so the weights are
     shared rather than copied.
+
+    Built here, before any forking, for the same reason: `apply()` builds
+    and caches the sparse matrix lazily on first use, which is fine for one
+    process, but under `-j N` with fork it would mean N workers each
+    independently building and allocating their own ~nnz-sized copy at the
+    same moment -- right as remapping starts, which is exactly the kind of
+    synchronized burst that looks like the run is stuck before it even
+    begins. Built here, forked workers inherit the same pages by
+    copy-on-write: one build, one allocation, genuinely shared -- not N
+    redundant ones. Spawn-context workers reload their own `Weights` from
+    disk regardless (see `_remap_one`), so this only helps fork, but fork is
+    what Linux -- every real HPC target -- actually uses.
     """
     jobs = list(jobs)
+    weights._sparse()
+
     if workers <= 1:
         _init_worker(weights_path, preloaded=weights)
         for job in jobs:

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -698,6 +698,25 @@ def test_a_nonsense_value_is_ignored(monkeypatch):
 # -------------------------------------------------------------- parallel run
 
 
+def test_remap_many_builds_the_sparse_matrix_before_any_job_runs(tmp_path, weights):
+    """The point of building it here rather than inside apply(): under -j N
+    with fork, N workers each independently building their own copy at the
+    moment remapping starts is a synchronized burst of cost and memory that
+    looks exactly like the run being stuck. Built once, before Pool forks,
+    every worker inherits the same pages instead."""
+    from gmpas.remap import remap_many
+
+    assert weights._matrix is None
+    domain = TargetDomain(nlat=1, nlon=2, startlat=-1.0, endlat=1.0,
+                          startlon=0.0, endlon=2.0)
+    jobs = [(tmp_path / "absent.nc", tmp_path / "a.nc", domain, ["x"])]
+
+    gen = remap_many(jobs, weights, weights.path, workers=1)
+    next(gen)                       # only the first item -- before any job
+    assert weights._matrix is not None
+    list(gen)                       # drain, so the generator closes cleanly
+
+
 def test_a_failing_file_does_not_stop_the_run(tmp_path, weights):
     """One bad file in two hundred must not lose the other 199."""
     from gmpas.remap import remap_many


### PR DESCRIPTION
Follow-up to #43, prompted directly by a real \`-j 64\` job on Derecho reporting the remapping step "takes a lot of time to start."

## Summary
\`apply()\` builds and caches the CSR matrix lazily on first use — fine for one process, but under \`-j N\` with fork it meant **N workers independently building and allocating their own copy at the same moment**, right as remapping started. At the scale a real run hits (~99M nonzeros, ~1.6 GB per copy, from #43's investigation), that's up to N synchronized ~4s builds plus N redundant ~1.6 GB allocations — at \`-j 64\` that's up to ~100 GB of duplicate memory and a burst of contention landing on the exact instant \`remap_many\`'s \`Pool\` forks. Looks exactly like the run is stuck before it's even begun.

Fix: build the matrix once in \`remap_many\`, before \`Pool(...)\` forks. Forked workers then inherit the already-built matrix by copy-on-write — genuinely shared, not independently rebuilt. This is what \`remap_many\`'s own docstring already claimed ("the weights are shared rather than copied"), which the lazy build in \`apply()\` (added in #43) had quietly stopped being true for.

Spawn-context workers reload their own \`Weights\` from disk regardless (see \`_remap_one\`), so this only helps fork — but fork is what Linux, i.e. every real HPC site, actually uses.

## Test plan
- [x] \`pytest\` — 302 passed, 5 skipped
- [x] New test confirming the matrix is built during \`remap_many\`'s first generator step, before any job runs
- [x] Manually verified against an 8-job / 4-worker fork run that the parent's \`weights._matrix\` is populated after the pool completes
- [x] Real-ESMF integration test still passes