### PR TITLE
Report missing matplotlib/cartopy as a hint, not a traceback

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -809,6 +809,11 @@ def main(argv=None) -> int:
     except (FileNotFoundError, KeyError, ValueError) as exc:
         print(f"gmpas: {exc}", file=sys.stderr)
         return 1
+    except ModuleNotFoundError as exc:
+        print(f"gmpas: {exc}. Rendering needs matplotlib and cartopy, which are "
+              f"an optional extra — install them with:  pip install gmpas[plot]",
+              file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,29 @@ def test_a_missing_file_is_reported_not_traced(capsys, tmp_path):
     assert "gmpas:" in capsys.readouterr().err
 
 
+def test_missing_plot_dependency_is_reported_not_traced(
+    capsys, tmp_path, simple_mesh_file, monkeypatch
+):
+    """matplotlib/cartopy are the optional `plot` extra -- point at it, don't trace."""
+    diag = write_diag(tmp_path / "diag.nc", n_cells=4, n_edges=24)
+
+    real_import = __import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "matplotlib":
+            raise ModuleNotFoundError("No module named 'matplotlib'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked)
+
+    assert main(["plot", str(diag), "mslp", "--mesh", str(simple_mesh_file),
+                 "-o", str(tmp_path / "out.png")]) == 1
+
+    err = capsys.readouterr().err
+    assert "gmpas:" in err
+    assert "pip install gmpas[plot]" in err
+
+
 def test_all_steps_requires_a_step_placeholder(capsys, tmp_path, simple_mesh_file):
     """A format spec like {step:04d} must count -- it has no bare {step}."""
     diag = write_diag(tmp_path / "diag.nc", n_cells=4, n_edges=24)


### PR DESCRIPTION
## Summary
- `plot`/`view`/`prep` all lazily import matplotlib and cartopy so a headless install (no `plot` extra) stays usable for geometry/rasterizing/remap work — but a user who *does* try to render without the extra got a raw `ModuleNotFoundError` traceback instead of a message pointing at the fix.
- `main()` in `cli.py` already converts known error types (`RemapError`, `MeshCacheError`, `GenerateError`, `FileNotFoundError`, `KeyError`, `ValueError`) into a one-line `gmpas: ...` message on stderr instead of a traceback. This extends that same handling to `ModuleNotFoundError`, appending `pip install gmpas[plot]` (the exact extra declared in `pyproject.toml`).

Surfaced while working the MCP-server side of this project locally, where the equivalent gap was matplotlib being imported unconditionally at module import time — this package already avoids that structurally (lazy imports + optional `plot` extra), so the fix here is just the error message, not the import structure.

## Test plan
- [x] `pytest tests/test_cli.py -q` — 11 passed, including a new `test_missing_plot_dependency_is_reported_not_traced` that monkeypatches `builtins.__import__` to simulate a missing `matplotlib` and asserts `main()` returns 1 with `gmpas:` and `pip install gmpas[plot]` on stderr rather than raising.
- [x] Full suite: `pytest -q` — 305 passed, 5 skipped (pre-existing, ESMF-dependent), no regressions.
- [x] `ruff check` on both changed files — no new findings (pre-existing unrelated issues elsewhere in `cli.py`).