### PR TITLE
Fix cartopy title stuck at y=inf, cropping plots to their colorbar in notebooks

### DIFF
--- a/src/gmpas/plot.py
+++ b/src/gmpas/plot.py
@@ -63,6 +63,14 @@ def _basemap(mesh: MpasMesh, style: Style, extent, central_lon: float = 0.0,
     gl = ax.gridlines(draw_labels=True, linewidth=style.gridline_lw,
                       linestyle="--", alpha=0.5)
     gl.top_labels = gl.right_labels = False
+    # geo_labels defaults True whenever draw_labels does. GeoAxes title
+    # placement checks `top_labels or geo_labels` and, when true, measures
+    # gl.top_label_artists even though top_labels is off here -- those Texts
+    # are hidden, so matplotlib's null-bbox sentinel leaves .ymax == inf and
+    # the title gets pinned there (cartopy bug). A title stuck at y=inf NaNs
+    # the axes' tight bbox, so any inline display (Jupyter's default
+    # bbox_inches="tight") renders nothing but the colorbar.
+    gl.geo_labels = False
 
     if box[0] <= -179.9 and 179.9 <= box[1] <= 180.0:
         ax.set_global()

--- a/src/gmpas/style.py
+++ b/src/gmpas/style.py
@@ -72,9 +72,10 @@ def save_figure(fig, path: str | Path, style: Style | None = None) -> Path:
     Unlike the MCP server this grew out of, nothing here writes to a fixed
     project directory -- a library saves where the caller says.
 
-    Deliberately no bbox_inches="tight": these figures use constrained_layout,
-    and the two together crop a cartopy GeoAxes down to nothing but its
-    colorbar. constrained_layout already packs the figure.
+    Deliberately no bbox_inches="tight": constrained_layout already packs the
+    figure, so it buys nothing here. It also isn't a safe default in general
+    -- see the geo_labels note in `plot._basemap` for the cartopy bug it used
+    to trigger (title pinned at y=inf, cropping the figure to its colorbar).
     """
     import matplotlib.pyplot as plt
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -81,6 +81,38 @@ def test_mesh_structure_is_labelled_in_km(simple_mesh):
     matplotlib.pyplot.close(fig)
 
 
+def test_title_position_survives_notebook_style_tight_bbox(simple_mesh, values):
+    """Regression: a cartopy GeoAxes title can get pinned at y=inf.
+
+    `Gridliner.geo_labels` defaults True whenever `draw_labels=True` does,
+    even with top/right labels turned off. `GeoAxes._update_title_position`
+    then measures the (hidden) top label artists anyway; their null bbox's
+    `.ymax` comes back `inf` rather than the intended `-inf`, and the title
+    gets pinned there. A title at y=inf NaNs the axes' tight bbox, so
+    `bbox_inches="tight"` -- what Jupyter's inline backend uses by default
+    to auto-display a returned figure -- crops the map away entirely and
+    leaves only the colorbar. `_basemap` clears `geo_labels` too to avoid
+    this; guard both the position and the rendered size so a regression
+    here is caught without a notebook.
+    """
+    import io
+
+    fig, ax = cell_field(simple_mesh, values, method="poly")
+    assert ax.title.get_position()[1] == pytest.approx(1.0)
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    matplotlib.pyplot.close(fig)
+
+    full = io.BytesIO()
+    fig2, _ = cell_field(simple_mesh, values, method="poly")
+    fig2.savefig(full, format="png")
+    matplotlib.pyplot.close(fig2)
+
+    # a crop-to-colorbar comes back at a few KB; the real map is much larger
+    assert buf.tell() > full.tell() * 0.5
+
+
 # -------------------------------------------------------------------- errors
 
 


### PR DESCRIPTION
## Summary

Reported symptom: `ds.mpas.quiver(...)` (and every other gmpas plot function) auto-displayed in a Jupyter notebook renders as just the colorbar — the map is gone.

Root cause, isolated by reading cartopy source and reproducing at each step:

1. `_basemap` calls `ax.gridlines(draw_labels=True, ...)` then sets `gl.top_labels = gl.right_labels = False`. It never touches `gl.geo_labels`, which `Gridliner.__init__` also set to `True` because `draw_labels=True` was passed as a plain bool (`geoaxes.py` / `gridliner.py`: all four label flags — `top`, `bottom`, `left`/`right`, `geo` — take the same value unless a dict/list is passed).
2. `GeoAxes._update_title_position` (`cartopy/mpl/geoaxes.py:511`) runs `if gl.top_labels or gl.geo_labels:` — true here purely because of `geo_labels` — and walks `gl.top_label_artists` even though `top_labels` is off and those Text artists are hidden.
3. A hidden Text's `get_tightbbox()` returns matplotlib's null-bbox sentinel `Bbox(inf, inf, -inf, -inf)`. Cartopy reads `.ymax` off it for its `top = max(top, bb.ymax)` running max. `Bbox.ymax` is `max(y0, y1)`, so on this sentinel it evaluates to `+inf` (not the `-inf` the "no contribution" convention intends).
4. That `+inf` reaches `title.set_position((x, max(1.0, yn)))`, permanently pinning the (empty-text, so never otherwise touched) title at `y=inf`.
5. A title at `y=inf` makes `Axes.get_tightbbox()` return `nan` x-bounds for the whole GeoAxes (verified directly). `Figure.savefig(bbox_inches="tight")` then drops that axes from the crop entirely, leaving only the well-behaved colorbar axes — exactly the screenshot.

`save_figure` (`style.py`) was already safe, since it deliberately never passes `bbox_inches="tight"` — but that only covers the explicit-save path. Jupyter's inline backend (`matplotlib_inline.config.InlineBackend.print_figure_kwargs`, confirmed by reading the installed config: default `{"bbox_inches": "tight"}`) is a separate code path outside gmpas's control, used whenever a returned `fig` is auto-displayed without an explicit save. That's the primary way gmpas figures get viewed in a notebook, so this hit essentially every interactive use.

`save_figure`'s docstring blamed `constrained_layout` for a similar-sounding crop. Measured directly: disabling `constrained_layout` alone does not fix the crop, and disabling `geo_labels` alone (with `constrained_layout` still on) does. Corrected the docstring.

## Fix
`_basemap` now also clears `gl.geo_labels = False`. gmpas only draws `PlateCarree` (rectangular) frames, where `geo_labels` (labels near a *non-rectangular* boundary) has no effect anyway, so this is a no-op visually and only removes the trigger for the cartopy bug.

## Test plan
- [x] New regression test `test_title_position_survives_notebook_style_tight_bbox` in `tests/test_plot.py`: asserts the title's y-position stays finite, and that a `bbox_inches="tight"` render comes back close in size to an untight one rather than collapsed to a colorbar strip.
- [x] Verified the new test fails on the pre-fix code (`git stash` the fix, rerun) and passes after.
- [x] `pytest -q` on `main` with the fix: 306 passed, 5 skipped (pre-existing, ESMF-dependent) — same skip set as `main` without the fix, one more pass for the new test.
- [x] `ruff check` on all three changed files — no new findings (pre-existing issues elsewhere in `plot.py`/`style.py`, untouched by this diff).
- [x] Manually reproduced end-to-end: `cell_field(...)` figure saved with `bbox_inches="tight"` went from **75×493px** (colorbar only) before the fix to **1011×505px** (full map) after.