### PR TITLE
release: 0.4.3

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-As of 0.4.2, gmpas covers the pipeline from both ends.
+As of 0.4.3, gmpas covers the pipeline from both ends.
 
 **Postprocessing** — plotting, the interactive viewer, and conservative
 remapping — is implemented. `gmpas remap` writes the grid files ESMF needs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.2"
+version = "0.4.3"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     # entry points


### PR DESCRIPTION
## Summary
- **Fix (#48):** cartopy's `GeoAxes` title could get pinned at `y=inf` whenever gridline labels were drawn (`geo_labels` defaults `True` alongside `draw_labels=True`, even after `top_labels`/`right_labels` are turned off). That NaNs the axes' tight bbox, so any `bbox_inches="tight"` render — notably Jupyter's inline backend, which uses that by default to auto-display a returned figure — cropped every gmpas plot down to nothing but its colorbar. This was the primary way anyone views a gmpas figure interactively, so it affected essentially all notebook usage. `_basemap` now also clears `geo_labels`.
- **Fix (#47):** `gmpas plot`/`view`/etc. without the optional `plot` extra installed raised a raw `ModuleNotFoundError` traceback instead of a clear message. `main()`'s existing friendly-error handling now covers it, pointing at `pip install gmpas[plot]`.
- Bumps `0.4.2` → `0.4.3` in `pyproject.toml` and `src/gmpas/__init__.py`, and updates `docs/status.md`.

## Test plan
- [x] `pytest -q`: 306 passed, 5 skipped (pre-existing, ESMF-dependent) — includes `test_version.py`, which checks `pyproject.toml` and `__version__` agree.