### PR TITLE
docs: show open_mfdataset for multi-file time means in a notebook

### DIFF
--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -40,4 +40,25 @@ values = run.values("precipw", step=7)   # opens only the file that step needs
 
 For time means, composites and anomalies across a run, use
 `xarray.open_mfdataset` with dask instead — that is what it is good at, and
-`Series` deliberately does not try to replace it.
+`Series` deliberately does not try to replace it:
+
+```python
+import glob
+import xarray as xr
+import gmpas
+
+# MPAS's own file naming sorts chronologically as plain text (zero-padded,
+# big-endian), so a lexicographic sort is a valid Time order here -- no
+# coordinate values to combine on, so combine="nested" rather than "by_coords"
+files = sorted(glob.glob("/path/to/run/history.*.nc"))
+ds = xr.open_mfdataset(files, combine="nested", concat_dim="Time")
+
+mean = ds["precipw"].mean("Time").compute()   # or an anomaly, a composite, ...
+
+mesh = gmpas.MpasMesh.load("/path/to/run/mesh.nc")
+fig, ax = gmpas.cell_field(mesh, mean.values)
+```
+
+`open_mfdataset` isn't routed through `open_mpas`, so there is no `.mpas`
+accessor here — attach the mesh and call `gmpas.cell_field`/`edge_field`
+directly, as above.


### PR DESCRIPTION
## Summary
`docs/notebook.md` told readers to reach for `xarray.open_mfdataset` + dask for cross-file analysis (time means, composites, anomalies) but gave no example. Adds one.

Verified against a real multi-file run rather than written from memory: `combine="by_coords"` fails on MPAS output with `ValueError: Could not find any dimension coordinates to use to order the Dataset objects for concatenation`, because MPAS files carry a bare `Time` *dimension* with no coordinate values. `combine="nested", concat_dim="Time"` on a lexicographically sorted file list works, and matches what `series.py` already documents about MPAS's own zero-padded filenames sorting chronologically as plain text.

Also notes that `open_mfdataset` isn't routed through `open_mpas`, so there's no `.mpas` accessor on the result — the mesh has to be attached and `cell_field`/`edge_field` called directly.

## Test plan
- [x] Ran the example end-to-end against synthetic multi-file MPAS output (two `history.*.nc` files + a mesh, via the test fixtures): `combine="nested"` produces the expected `(nCells,)` time-mean array, and `gmpas.cell_field` renders it without error.
- [x] Confirmed `combine="by_coords"` (my first attempt) fails with the coordinate error above, which is why the doc explicitly calls out `nested`.