### PR TITLE
Add gmpas prep scale: rescale a regional mesh around a tangent point

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -9,6 +9,7 @@ gmpas target     -o dst.scrip.nc
 gmpas prep view  mesh.nc
 gmpas prep hfun  hfun.py
 gmpas prep generate hfun.py -o mesh/
+gmpas prep scale mesh.nc --scale-factor 2.0 --tan-lat 0 --tan-lon 125
 ```
 
 `info` summarises the mesh and lists variables grouped by the element they

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -10,6 +10,7 @@ gmpas prep view  mesh.nc
 gmpas prep hfun  hfun.py
 gmpas prep generate hfun.py -o mesh/
 gmpas prep scale mesh.nc --scale-factor 2.0 --tan-lat 0 --tan-lon 125
+gmpas prep relocate mesh.nc --tan-lat 40 --tan-lon 280
 ```
 
 `info` summarises the mesh and lists variables grouped by the element they

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -208,6 +208,7 @@ gmpas prep scale mesh.nc --scale-factor 2.0 --tan-lat 0 --tan-lon 125 -o scaled.
 
 ```
 mesh.nc -> scaled.nc  (x2 around 0N, 125E)
+comparison plot: scaled.compare.png
 ```
 
 Projects every cell/vertex/edge stereographically onto the plane tangent at
@@ -251,6 +252,23 @@ the boundary, `kiteAreasOnVertex` where a vertex's own neighbours run out —
 falls back to the old value scaled by `scale_factor` (or `scale_factor**2`
 for an area) instead. `dvEdge` has no such case: every edge always has
 exactly two vertices.
+
+#### The comparison plot
+
+By default, a successful scale also writes a before/after cell-width map —
+two panels on one shared colour scale, so a resolution change and a domain
+shift both show up at a glance, at `--plot-out` (default
+`<out stem>.compare.png`). This is a quick sanity check, not a saved
+artefact of the scale itself: pass `--no-plot` to skip it, which also skips
+importing matplotlib/cartopy entirely, so `gmpas prep scale` still works
+without the optional `plot` extra installed.
+
+Unaffected by the topology this scale never touches: the mesh's cell
+adjacency (`cellsOnCell`, `cellsOnEdge`, `verticesOnCell`, ...) passes
+through byte-for-byte unchanged, since only geometry is recomputed. A
+`graph.info` written by `gmpas prep generate` before scaling — and any
+partition file `gpmetis` derived from it — stays valid for the scaled mesh
+without regenerating either.
 
 ### Looking at a mesh before it exists
 

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -200,6 +200,58 @@ gmpas always runs it in the output directory, so this cannot bite here. It is
 recorded because it does bite when running JIGSAW by hand: it prints
 `**parse error: file not found!` and exits 2.
 
+### Rescaling a regional mesh
+
+```bash
+gmpas prep scale mesh.nc --scale-factor 2.0 --tan-lat 0 --tan-lon 125 -o scaled.nc
+```
+
+```
+mesh.nc -> scaled.nc  (x2 around 0N, 125E)
+```
+
+Projects every cell/vertex/edge stereographically onto the plane tangent at
+`--tan-lat/--tan-lon`, divides by `--scale-factor`, and projects back —
+values above 1 shrink cells (finer resolution), pulling the whole domain in
+toward the tangent point rather than resizing cells within a fixed extent.
+Everything derived from position (`dcEdge`, `dvEdge`, `areaCell`,
+`areaTriangle`, `kiteAreasOnVertex`, `weightsOnEdge`, `angleEdge`,
+`nominalMinDc`) is recomputed from the new coordinates. Ported from
+MPAS-Tools' `scale_regional_mesh.py`; ordinary MPAS's own dual-mesh
+formulas throughout (l'Huilier's theorem for spherical triangle area, the
+usual spherical-trig angle formula), vectorized with numpy rather than a
+per-cell/edge/vertex Python loop — the one exception is `weightsOnEdge`,
+which walks each cell's edges in rotated order and stays a loop over edges
+for that reason.
+
+Always writes a new file at `-o/--out` (default `<mesh stem>.scaled.nc`);
+`mesh.nc` is never touched.
+
+#### Only a unit-sphere mesh
+
+`gmpas prep scale` refuses a mesh whose `sphere_radius` isn't 1 — a mesh
+straight out of JIGSAW/`mkgrid` (`gmpas prep generate`), not one that has
+already been through `init_atmosphere`. The whole algorithm assumes `R = 1`;
+running it on an Earth-scaled mesh would silently corrupt every coordinate,
+so this is checked rather than assumed:
+
+```
+gmpas: mesh.nc has sphere_radius=6371229.0, not a unit sphere. gmpas prep
+scale only supports a mesh straight off JIGSAW/mkgrid, before
+init_atmosphere redimensionalizes it -- scaling a metres-scale mesh with
+this formula would silently corrupt its coordinates.
+```
+
+#### Boundary cells
+
+A regional mesh has cells/edges/vertices at its own boundary with no real
+neighbour on one side (MPAS's 1-based, 0-fill connectivity). Anything that
+would otherwise need a missing neighbour — `dcEdge` and `areaTriangle` at
+the boundary, `kiteAreasOnVertex` where a vertex's own neighbours run out —
+falls back to the old value scaled by `scale_factor` (or `scale_factor**2`
+for an area) instead. `dvEdge` has no such case: every edge always has
+exactly two vertices.
+
 ### Looking at a mesh before it exists
 
 ```bash

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -228,6 +228,42 @@ for that reason.
 Always writes a new file at `-o/--out` (default `<mesh stem>.scaled.nc`);
 `mesh.nc` is never touched.
 
+#### Regional meshes only
+
+The stereographic scale is only close to the requested factor **near the
+tangent point**. Measured directly, with `--scale-factor 2.0`: at 60 degrees
+away the local effect is already only ×1.63 instead of ×2; past 120 degrees
+it flips to making cells **coarser** instead of finer; near the antipode of
+the tangent point it converges on almost exactly the *reciprocal* of what
+was asked for. Applied to a global mesh, this produces a mesh with one
+hemisphere far too fine and the opposite one far too coarse — this is not a
+bug, it's what dividing stereographic-projected coordinates by a constant
+does far from the projection's own centre. `gmpas prep scale` warns before
+doing the (much more expensive) recompute if the mesh reaches more than 45
+degrees from the tangent point:
+
+```
+gmpas: mesh.nc reaches 174 degrees from the tangent point. gmpas prep scale
+is a regional-mesh tool: its stereographic scale is only close to the
+requested factor near the tangent point, and drifts -- past ~120 degrees it
+starts making cells coarser instead of finer -- the farther out it goes.
+See docs/preprocessing.md. To reposition a refined region without this
+distortion, use gmpas prep relocate instead.
+```
+
+The warning doesn't block the run — the recompute still happens and the
+file still writes, since there's no way to be sure a use past that
+threshold is a mistake rather than intentional experimentation. If what you
+actually want is to move a refined region to a new location, not resize it,
+`gmpas prep relocate` (below) does that with zero distortion anywhere on
+the sphere.
+
+The actual gap this points at — gmpas has no way to crop a global mesh down
+to a regional subset (what `create_region` does elsewhere in the MPAS
+tooling), which is normally the step *before* a mesh is regional enough for
+`scale` to behave well — is tracked as
+[issue 52](https://github.com/nmathewa/gmpas-lib/issues/52).
+
 #### Only a unit-sphere mesh
 
 `gmpas prep scale` refuses a mesh whose `sphere_radius` isn't 1 — a mesh
@@ -269,6 +305,44 @@ through byte-for-byte unchanged, since only geometry is recomputed. A
 `graph.info` written by `gmpas prep generate` before scaling — and any
 partition file `gpmetis` derived from it — stays valid for the scaled mesh
 without regenerating either.
+
+### Repositioning a refined region
+
+```bash
+gmpas prep relocate mesh.nc --tan-lat 40 --tan-lon 280 -o relocated.nc
+```
+
+```
+mesh.nc -> relocated.nc  (its finest cell -> 40N, 280E)
+```
+
+Moves a mesh's refined region to a new location via a rigid rotation of the
+sphere, rather than `scale`'s stereographic projection — a rotation is an
+isometry, so it preserves every distance, area and angle exactly, with no
+far-field distortion and no antipodal singularity anywhere. `dcEdge`,
+`dvEdge`, `areaCell`, `areaTriangle`, `kiteAreasOnVertex`, `weightsOnEdge`
+and `nominalMinDc` all come out **byte-for-byte unchanged**; only the
+coordinates themselves and `angleEdge` (the edge-normal bearing relative to
+local east on the fixed lat/lon grid, which does change when a point moves)
+are recomputed. This is the tool for "I want the resolution pattern I
+already have, just centred somewhere else" — `scale` is for "I want this
+mesh's resolution to actually change," and only behaves well once the mesh
+is already regional (close to the tangent point).
+
+Unlike `scale`, this has no unit-sphere precondition — a rotation matrix
+doesn't care what `sphere_radius` is — and it's safe to run directly on a
+**global** mesh: rotate first, to bring the refined region to where a study
+needs it, then crop to a regional subset once it's in the right place,
+rather than the other way around.
+
+#### The current centre
+
+`--from-lat`/`--from-lon` name where the refined region currently sits;
+left unset, it defaults to the mesh's own finest cell (minimum `areaCell`)
+— the conventional single point of maximum refinement in an MPAS
+variable-resolution mesh. Pass both explicitly for a mesh with more than
+one refined patch, where auto-detection would only find one of them; the
+two must be given together, or not at all.
 
 ### Looking at a mesh before it exists
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,11 +15,12 @@ load the site's own build (`module load esmf`) rather than a conda-forge copy
 in gmpas's own environment; the two compete on `PATH`/`LD_LIBRARY_PATH`
 rather than help.
 
-**Preprocessing** covers `prep view`, `prep hfun`, `prep generate` and
-`prep scale`: looking at a mesh after it exists, looking at a distance
-function before any mesh exists, running JIGSAW to get from the second to
-the first, and rescaling a regional mesh around a tangent point. A run
-leaves everything `mkgrid` reads.
+**Preprocessing** covers `prep view`, `prep hfun`, `prep generate`,
+`prep scale` and `prep relocate`: looking at a mesh after it exists, looking
+at a distance function before any mesh exists, running JIGSAW to get from
+the second to the first, rescaling a regional mesh around a tangent point,
+and repositioning a refined region without resizing it. A run leaves
+everything `mkgrid` reads.
 
 ## Not implemented
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,10 +15,11 @@ load the site's own build (`module load esmf`) rather than a conda-forge copy
 in gmpas's own environment; the two compete on `PATH`/`LD_LIBRARY_PATH`
 rather than help.
 
-**Preprocessing** covers `prep view`, `prep hfun` and `prep generate`: looking
-at a mesh after it exists, looking at a distance function before any mesh
-exists, and running JIGSAW to get from the second to the first. A run leaves
-everything `mkgrid` reads.
+**Preprocessing** covers `prep view`, `prep hfun`, `prep generate` and
+`prep scale`: looking at a mesh after it exists, looking at a distance
+function before any mesh exists, running JIGSAW to get from the second to
+the first, and rescaling a regional mesh around a tangent point. A run
+leaves everything `mkgrid` reads.
 
 ## Not implemented
 

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -585,7 +585,18 @@ def _prep_generate(args) -> int:
 
 
 def _prep_scale(args) -> int:
-    from .prep.scale import scale_mesh
+    from .prep.scale import REGIONAL_WARNING_DEG, max_angular_distance_deg, scale_mesh
+
+    extent = max_angular_distance_deg(args.mesh_file, args.tan_lat, args.tan_lon)
+    if extent > REGIONAL_WARNING_DEG:
+        print(f"gmpas: {args.mesh_file} reaches {extent:.0f} degrees from "
+             f"the tangent point. gmpas prep scale is a regional-mesh tool: "
+             f"its stereographic scale is only close to the requested "
+             f"factor near the tangent point, and drifts -- past ~120 "
+             f"degrees it starts making cells coarser instead of finer -- "
+             f"the farther out it goes. See docs/preprocessing.md. To "
+             f"reposition a refined region without this distortion, use "
+             f"gmpas prep relocate instead.", file=sys.stderr)
 
     out_path = args.out or f"{Path(args.mesh_file).stem}.scaled.nc"
     out = scale_mesh(args.mesh_file, out_path, args.scale_factor,
@@ -604,6 +615,24 @@ def _prep_scale(args) -> int:
             print(f"gmpas: skipped the comparison plot -- {exc}. Rendering "
                  f"needs the optional plot extra:  pip install gmpas[plot]  "
                  f"(or pass --no-plot)", file=sys.stderr)
+    return 0
+
+
+def _prep_relocate(args) -> int:
+    from .prep.relocate import relocate_mesh
+
+    if (args.from_lat is None) != (args.from_lon is None):
+        print("gmpas: --from-lat and --from-lon must be given together, "
+             "or not at all (to auto-detect)", file=sys.stderr)
+        return 1
+
+    out_path = args.out or f"{Path(args.mesh_file).stem}.relocated.nc"
+    out = relocate_mesh(args.mesh_file, out_path, args.tan_lat, args.tan_lon,
+                        from_lat_deg=args.from_lat, from_lon_deg=args.from_lon)
+    from_desc = (f"{args.from_lat:g}N, {args.from_lon:g}E" if args.from_lat is not None
+                else "its finest cell")
+    print(f"{args.mesh_file} -> {out}  ({from_desc} -> "
+         f"{args.tan_lat:g}N, {args.tan_lon:g}E)")
     return 0
 
 
@@ -713,7 +742,7 @@ def build_parser() -> argparse.ArgumentParser:
                          description="Preprocessing steps, which run before "
                                      "there is any model output to plot.")
     presub = pre.add_subparsers(dest="prep_cmd",
-                                metavar="{view,hfun,generate,scale}")
+                                metavar="{view,hfun,generate,scale,relocate}")
     # a bare `gmpas prep` should list its steps, not error
     pre.set_defaults(func=lambda _a, _p=pre: (_p.print_help(), 0)[1])
 
@@ -809,6 +838,24 @@ def build_parser() -> argparse.ArgumentParser:
     ps.add_argument("--plot-out",
                     help="comparison PNG path (default: <out stem>.compare.png)")
     ps.set_defaults(func=_prep_scale)
+
+    pr = presub.add_parser("relocate", help="move a mesh's refined region to "
+                                            "a new tangent point, without "
+                                            "resizing it")
+    pr.add_argument("mesh_file", metavar="MESH", help="a global or regional mesh")
+    pr.add_argument("-o", "--out",
+                    help="output path (default: <mesh stem>.relocated.nc)")
+    pr.add_argument("--tan-lat", type=float, required=True,
+                    help="latitude to move the refined region to, in degrees")
+    pr.add_argument("--tan-lon", type=float, required=True,
+                    help="longitude to move the refined region to, in degrees")
+    pr.add_argument("--from-lat", type=float,
+                    help="latitude the refined region is currently at "
+                         "(default: auto-detected from the mesh's finest cell)")
+    pr.add_argument("--from-lon", type=float,
+                    help="longitude the refined region is currently at "
+                         "(default: auto-detected from the mesh's finest cell)")
+    pr.set_defaults(func=_prep_relocate)
     return p
 
 

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -592,6 +592,18 @@ def _prep_scale(args) -> int:
                      args.tan_lat, args.tan_lon)
     print(f"{args.mesh_file} -> {out}  (x{args.scale_factor:g} around "
          f"{args.tan_lat:g}N, {args.tan_lon:g}E)")
+
+    if not args.no_plot:
+        from .prep.scale import plot_comparison
+
+        plot_out = args.plot_out or f"{out.with_suffix('')}.compare.png"
+        try:
+            png = plot_comparison(args.mesh_file, out, plot_out)
+            print(f"comparison plot: {png}")
+        except ModuleNotFoundError as exc:
+            print(f"gmpas: skipped the comparison plot -- {exc}. Rendering "
+                 f"needs the optional plot extra:  pip install gmpas[plot]  "
+                 f"(or pass --no-plot)", file=sys.stderr)
     return 0
 
 
@@ -792,6 +804,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="latitude of the tangent point, in degrees")
     ps.add_argument("--tan-lon", type=float, required=True,
                     help="longitude of the tangent point, in degrees")
+    ps.add_argument("--no-plot", action="store_true",
+                    help="skip the before/after cell-width comparison PNG")
+    ps.add_argument("--plot-out",
+                    help="comparison PNG path (default: <out stem>.compare.png)")
     ps.set_defaults(func=_prep_scale)
     return p
 

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -584,6 +584,17 @@ def _prep_generate(args) -> int:
     return 0
 
 
+def _prep_scale(args) -> int:
+    from .prep.scale import scale_mesh
+
+    out_path = args.out or f"{Path(args.mesh_file).stem}.scaled.nc"
+    out = scale_mesh(args.mesh_file, out_path, args.scale_factor,
+                     args.tan_lat, args.tan_lon)
+    print(f"{args.mesh_file} -> {out}  (x{args.scale_factor:g} around "
+         f"{args.tan_lat:g}N, {args.tan_lon:g}E)")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gmpas",
@@ -689,7 +700,8 @@ def build_parser() -> argparse.ArgumentParser:
     pre = sub.add_parser("prep", help="preprocessing: inspect and build meshes",
                          description="Preprocessing steps, which run before "
                                      "there is any model output to plot.")
-    presub = pre.add_subparsers(dest="prep_cmd", metavar="{view,hfun,generate}")
+    presub = pre.add_subparsers(dest="prep_cmd",
+                                metavar="{view,hfun,generate,scale}")
     # a bare `gmpas prep` should list its steps, not error
     pre.set_defaults(func=lambda _a, _p=pre: (_p.print_help(), 0)[1])
 
@@ -765,6 +777,22 @@ def build_parser() -> argparse.ArgumentParser:
                     help="generate even if the cell size gradient is above "
                          "the guideline")
     pg.set_defaults(func=_prep_generate)
+
+    ps = presub.add_parser("scale", help="rescale a regional mesh around a "
+                                        "tangent point")
+    ps.add_argument("mesh_file", metavar="MESH",
+                    help="a unit-sphere mesh straight off JIGSAW/mkgrid "
+                         "(gmpas prep generate); not a mesh already run "
+                         "through init_atmosphere")
+    ps.add_argument("-o", "--out",
+                    help="output path (default: <mesh stem>.scaled.nc)")
+    ps.add_argument("--scale-factor", type=float, required=True,
+                    help="values > 1 increase resolution (shrink cells)")
+    ps.add_argument("--tan-lat", type=float, required=True,
+                    help="latitude of the tangent point, in degrees")
+    ps.add_argument("--tan-lon", type=float, required=True,
+                    help="longitude of the tangent point, in degrees")
+    ps.set_defaults(func=_prep_scale)
     return p
 
 

--- a/src/gmpas/prep/relocate.py
+++ b/src/gmpas/prep/relocate.py
@@ -1,0 +1,155 @@
+"""Move a mesh's refined region to a new tangent point, without resizing it.
+
+`scale_mesh` rescales resolution around a tangent point via a stereographic
+projection, which is only close to uniform *near* that point -- far from it
+(see the module docstring in `scale.py`), the same operation can end up
+making cells coarser instead of finer. That makes it a regional-mesh tool:
+correct once a mesh's whole extent is already close to the tangent point,
+wrong applied to a global mesh where most of it isn't.
+
+Repositioning *where* a refined patch sits, without also touching its
+resolution, doesn't need a projection at all -- a rigid rotation of the
+sphere does it exactly. A rotation is an isometry: it preserves every
+distance, area and angle between points on the sphere, everywhere, with no
+far-field distortion and no antipodal singularity. So `dcEdge`, `dvEdge`,
+`areaCell`, `areaTriangle`, `kiteAreasOnVertex`, `weightsOnEdge` and
+`nominalMinDc` all pass through completely unchanged here -- only the
+coordinates themselves (lon/lat/xyz for Cell, Vertex, Edge) and `angleEdge`
+(the edge-normal bearing relative to local east, which is measured against
+the fixed lat/lon grid and so does change when a point moves to new
+coordinates) need recomputing.
+
+Also unlike `scale_mesh`, this has no unit-sphere precondition: a rotation
+matrix is scale-independent, so it works on a mesh at any `sphere_radius`.
+
+Works on a global mesh directly -- rotating first, then cropping to a
+regional subset around the relocated patch, is the natural order (see
+docs/preprocessing.md).
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from ..paths import resolve_path
+from .scale import lonlat_to_xyz, spherical_angle, xyz_to_lonlat
+
+#: variables relocate_mesh reads and recomputes, beyond mesh identity
+REQUIRED_VARS = (
+    "latCell", "lonCell", "xCell", "yCell", "zCell", "areaCell",
+    "latVertex", "lonVertex", "xVertex", "yVertex", "zVertex",
+    "latEdge", "lonEdge", "xEdge", "yEdge", "zEdge",
+    "verticesOnEdge", "angleEdge",
+)
+
+
+def _rotation_matrix(from_xyz: np.ndarray, to_xyz: np.ndarray) -> np.ndarray:
+    """The minimal rotation mapping `from_xyz` exactly onto `to_xyz`.
+
+    Rodrigues' formula around the axis perpendicular to both, by the angle
+    between them -- the shortest-path rotation, with no free twist
+    parameter to choose.
+    """
+    from_xyz = from_xyz / np.linalg.norm(from_xyz)
+    to_xyz = to_xyz / np.linalg.norm(to_xyz)
+    axis = np.cross(from_xyz, to_xyz)
+    sin_angle = np.linalg.norm(axis)
+    cos_angle = np.dot(from_xyz, to_xyz)
+
+    if sin_angle < 1e-12:
+        if cos_angle > 0:
+            return np.eye(3)                    # already at the target
+        # exactly antipodal: any axis perpendicular to from_xyz will do
+        axis = np.cross(from_xyz, [1.0, 0.0, 0.0])
+        if np.linalg.norm(axis) < 1e-12:
+            axis = np.cross(from_xyz, [0.0, 1.0, 0.0])
+        axis = axis / np.linalg.norm(axis)
+        sin_angle, cos_angle = 0.0, -1.0
+    else:
+        axis = axis / sin_angle
+
+    k = np.array([[0.0, -axis[2], axis[1]],
+                 [axis[2], 0.0, -axis[0]],
+                 [-axis[1], axis[0], 0.0]])
+    return np.eye(3) + k * sin_angle + (k @ k) * (1.0 - cos_angle)
+
+
+def relocate_mesh(mesh_path: str | Path, out_path: str | Path,
+                  tan_lat_deg: float, tan_lon_deg: float,
+                  from_lat_deg: float | None = None,
+                  from_lon_deg: float | None = None) -> Path:
+    """Rotate a mesh so its refined region sits at (tan_lat_deg, tan_lon_deg).
+
+    `from_lat_deg`/`from_lon_deg` name the region's current center; left as
+    None, it defaults to the mesh's own finest cell (`min(areaCell)`) -- the
+    conventional single point of maximum refinement in an MPAS
+    variable-resolution mesh. Pass them explicitly for a mesh with more than
+    one refined patch, where auto-detection would only find one of them.
+
+    Works on a global or a regional mesh, at any `sphere_radius`. Writes a
+    whole new file; `mesh_path` is never touched.
+    """
+    src = resolve_path(mesh_path)
+    if not src.exists():
+        raise FileNotFoundError(f"No such mesh file: {src}")
+
+    with xr.open_dataset(src, decode_timedelta=False, engine="netcdf4") as ds:
+        missing = [v for v in REQUIRED_VARS if v not in ds.variables]
+        if missing:
+            raise KeyError(
+                f"{src.name} cannot be relocated: missing {missing}."
+            )
+        ds = ds.load()
+
+    if from_lat_deg is None or from_lon_deg is None:
+        finest = int(np.argmin(ds["areaCell"].values))
+        from_lat_deg = math.degrees(float(ds["latCell"].values[finest]))
+        from_lon_deg = math.degrees(float(ds["lonCell"].values[finest]))
+
+    from_xyz = lonlat_to_xyz(math.radians(from_lon_deg), math.radians(from_lat_deg))
+    to_xyz = lonlat_to_xyz(math.radians(tan_lon_deg), math.radians(tan_lat_deg))
+    rotation = _rotation_matrix(from_xyz, to_xyz)
+
+    updates = {}
+    for loc in ("Cell", "Vertex", "Edge"):
+        xyz = np.stack([ds[f"x{loc}"].values, ds[f"y{loc}"].values,
+                        ds[f"z{loc}"].values], axis=-1)
+        rotated = xyz @ rotation.T
+        lon, lat = xyz_to_lonlat(rotated)
+        updates[f"x{loc}"] = rotated[..., 0]
+        updates[f"y{loc}"] = rotated[..., 1]
+        updates[f"z{loc}"] = rotated[..., 2]
+        updates[f"lon{loc}"] = lon
+        updates[f"lat{loc}"] = lat
+
+    # angleEdge is the edge-normal bearing relative to local east on the
+    # fixed lat/lon grid -- unlike area/distance, that's not intrinsic to
+    # the mesh's shape, so it does change when a point moves to new
+    # coordinates. Recomputed exactly as scale_mesh's angleEdge step does,
+    # just on the rotated positions instead of the rescaled ones.
+    voe = ds["verticesOnEdge"].values.astype(np.int64) - 1
+    vtx_xyz_new = np.stack([updates["xVertex"], updates["yVertex"],
+                            updates["zVertex"]], axis=-1)
+    a_pts = vtx_xyz_new[voe[:, 0]]
+    tangent = np.stack([
+        np.cos(updates["lonEdge"]) * np.sin(updates["latEdge"]),
+        np.sin(updates["lonEdge"]) * np.sin(updates["latEdge"]),
+        -np.cos(updates["latEdge"]),
+    ], axis=-1)
+    b_pts = a_pts - tangent
+    b_pts = b_pts / np.linalg.norm(b_pts, axis=-1, keepdims=True)
+    c_pts = vtx_xyz_new[voe[:, 1]]
+    updates["angleEdge"] = spherical_angle(a_pts, b_pts, c_pts)
+
+    for name, values in updates.items():
+        da = ds[name]
+        ds[name] = (da.dims, np.asarray(values).astype(da.dtype), da.attrs)
+
+    out = Path(out_path).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(out)
+    return out

--- a/src/gmpas/prep/scale.py
+++ b/src/gmpas/prep/scale.py
@@ -237,6 +237,35 @@ def _weights_on_edge(kite_areas_on_cell, dc_edge, dv_edge, cells_on_edge,
     return out
 
 
+# ------------------------------------------------------------- regional check
+
+#: past this angular distance from the tangent point, the stereographic
+#: scale has visibly drifted from the requested factor (measured: at 60
+#: degrees a factor of 2 already behaves like 1.63; past 120 degrees it
+#: starts making cells *coarser* instead of finer, and near the antipode it
+#: is close to the exact reciprocal of what was asked for)
+REGIONAL_WARNING_DEG = 45.0
+
+
+def max_angular_distance_deg(mesh_path: str | Path, tan_lat_deg: float,
+                             tan_lon_deg: float) -> float:
+    """How far the mesh's furthest cell sits from a tangent point, in
+    degrees. Cheap -- reads only `lonCell`/`latCell`, not the whole mesh --
+    so it's worth checking before `scale_mesh` does its much more expensive
+    recompute. See `REGIONAL_WARNING_DEG` for why this matters: this whole
+    module is a regional-mesh tool, correct only close to the tangent point.
+    """
+    with xr.open_dataset(resolve_path(mesh_path), decode_timedelta=False,
+                         engine="netcdf4") as ds:
+        lon = ds["lonCell"].values
+        lat = ds["latCell"].values
+
+    tan_xyz = lonlat_to_xyz(math.radians(tan_lon_deg), math.radians(tan_lat_deg))
+    cell_xyz = lonlat_to_xyz(lon, lat)
+    c = great_circle_distance(np.broadcast_to(tan_xyz, cell_xyz.shape), cell_xyz)
+    return math.degrees(float(c.max()))
+
+
 # ---------------------------------------------------------------- orchestrator
 
 def scale_mesh(mesh_path: str | Path, out_path: str | Path,

--- a/src/gmpas/prep/scale.py
+++ b/src/gmpas/prep/scale.py
@@ -1,0 +1,402 @@
+"""Rescale a regional mesh around a stereographic tangent point.
+
+Ported from the MPAS-Tools `scale_regional_mesh.py` script: project every
+cell/vertex/edge onto a stereographic plane centred on a tangent point,
+divide by a scale factor, project back, then recompute everything derived
+from those coordinates (`dcEdge`, `dvEdge`, `areaCell`, `areaTriangle`,
+`kiteAreasOnVertex`, `weightsOnEdge`, `angleEdge`, `nominalMinDc`).
+
+The original is a standalone script: plain Python loops over every
+cell/edge/vertex, mutating a copy of the file in place with raw netCDF4.
+This module instead vectorizes every independent per-element piece with
+numpy -- coordinate scaling, `dcEdge`, `dvEdge`, `areaTriangle`,
+`areaCell`, `kiteAreasOnVertex` -- using the same ragged-cell masking
+idiom `scrip.py` already uses for MPAS's variable-sided cells. Only
+`weightsOnEdge` stays a loop over edges: it walks each cell's edges in
+rotated order and accumulates a running sum, a genuine sequential
+dependency that isn't worth the risk of a subtle vectorization bug.
+Writes a whole new file with xarray, following `write_scrip`'s pattern,
+rather than mutating the input in place.
+
+**Only for a unit-sphere mesh** -- straight off JIGSAW/mkgrid
+(`gmpas prep generate`), before `init_atmosphere` redimensionalizes it.
+The whole algorithm assumes `R = 1`; running it on an Earth-scaled mesh
+would silently corrupt every coordinate, so `scale_mesh` checks
+`sphere_radius` and refuses rather than guessing.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from ..paths import resolve_path
+
+#: variables scale_mesh reads and recomputes, beyond mesh identity
+REQUIRED_VARS = (
+    "latCell", "lonCell", "xCell", "yCell", "zCell",
+    "latVertex", "lonVertex", "xVertex", "yVertex", "zVertex",
+    "latEdge", "lonEdge", "xEdge", "yEdge", "zEdge",
+    "nEdgesOnCell", "verticesOnCell", "edgesOnCell",
+    "cellsOnEdge", "verticesOnEdge", "edgesOnEdge",
+    "cellsOnVertex", "edgesOnVertex",
+    "dcEdge", "dvEdge", "areaCell", "areaTriangle",
+    "kiteAreasOnVertex", "weightsOnEdge", "angleEdge",
+    "nominalMinDc",
+)
+
+
+# ------------------------------------------------------------- geometry
+
+def lonlat_to_xyz(lon: np.ndarray, lat: np.ndarray,
+                  radius: float = 1.0) -> np.ndarray:
+    """Lon/lat (radians) to xyz on a sphere of the given radius.
+
+    Returns an array one dimension larger than the input, with xyz stacked
+    on the last axis -- broadcasts over any leading shape.
+    """
+    lon, lat = np.asarray(lon), np.asarray(lat)
+    return np.stack([
+        radius * np.cos(lon) * np.cos(lat),
+        radius * np.sin(lon) * np.cos(lat),
+        radius * np.sin(lat),
+    ], axis=-1)
+
+
+def xyz_to_lonlat(xyz: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """xyz (last axis length 3) to lon/lat, radians.
+
+    Normalizes by the vector's own norm rather than trusting radius = 1
+    exactly -- the same defensive move `mesh.py` makes before its own
+    xCell/yCell/zCell go into a KD-tree, for the same reason: float error
+    accumulates, and asin of something a hair over 1 is nan.
+    """
+    xyz = np.asarray(xyz)
+    norm = np.linalg.norm(xyz, axis=-1)
+    lon = np.arctan2(xyz[..., 1], xyz[..., 0])
+    lat = np.arcsin(np.clip(xyz[..., 2] / norm, -1.0, 1.0))
+    return lon, lat
+
+
+def stereo_project(lam: np.ndarray, phi: np.ndarray,
+                   lam_0: float, phi_1: float) -> tuple[np.ndarray, np.ndarray]:
+    """Stereographic projection onto the plane tangent at (lam_0, phi_1)."""
+    k = 2.0 / (1.0 + np.sin(phi_1) * np.sin(phi)
+              + np.cos(phi_1) * np.cos(phi) * np.cos(lam - lam_0))
+    x = k * np.cos(phi) * np.sin(lam - lam_0)
+    y = k * (np.cos(phi_1) * np.sin(phi)
+            - np.sin(phi_1) * np.cos(phi) * np.cos(lam - lam_0))
+    return x, y
+
+
+def stereo_inverse(x: np.ndarray, y: np.ndarray,
+                   lam_0: float, phi_1: float) -> tuple[np.ndarray, np.ndarray]:
+    """Inverse of `stereo_project`.
+
+    `rho == 0` is the tangent point itself, projected onto the plane's
+    origin -- the formula's own y/rho term is 0/0 there, so it is handled
+    explicitly rather than left to divide-by-zero warnings.
+    """
+    x, y = np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64)
+    rho = np.sqrt(x * x + y * y)
+    c = 2.0 * np.arctan2(rho, 2.0)
+    y_over_rho = np.divide(y, rho, out=np.zeros_like(rho), where=rho > 0)
+
+    phi = np.arcsin(np.clip(
+        np.cos(c) * np.sin(phi_1) + y_over_rho * np.sin(c) * np.cos(phi_1),
+        -1.0, 1.0,
+    ))
+    lam = lam_0 + np.arctan2(
+        x * np.sin(c),
+        rho * np.cos(phi_1) * np.cos(c) - y * np.sin(phi_1) * np.sin(c),
+    )
+    return lam, phi
+
+
+def chord_distance(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Straight-line distance between two points, last axis = xyz."""
+    d = np.asarray(b) - np.asarray(a)
+    return np.sqrt(np.sum(d * d, axis=-1))
+
+
+def great_circle_distance(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Great-circle distance on a unit sphere between two xyz points."""
+    return 2.0 * np.arcsin(np.clip(chord_distance(a, b) / 2.0, -1.0, 1.0))
+
+
+def spherical_triangle_area(a: np.ndarray, b: np.ndarray,
+                            c: np.ndarray) -> np.ndarray:
+    """Area of the spherical triangle with unit-sphere xyz vertices a, b, c.
+
+    L'Huilier's theorem, via the half-angle tangent form -- the same
+    formula the original script's `triangle_area` uses, vectorized to
+    broadcast over any leading shape instead of three scalars.
+    """
+    a_side = great_circle_distance(b, c)
+    b_side = great_circle_distance(a, c)
+    c_side = great_circle_distance(a, b)
+    s = 0.5 * (a_side + b_side + c_side)
+    tan_qe_sq = (np.tan(0.5 * s) * np.tan(0.5 * (s - a_side))
+                * np.tan(0.5 * (s - b_side)) * np.tan(0.5 * (s - c_side)))
+    tan_qe = np.sqrt(np.clip(tan_qe_sq, 0.0, None))
+    return 4.0 * np.arctan(tan_qe)
+
+
+def spherical_angle(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> np.ndarray:
+    """Angle at vertex A between spherical arcs AB and AC.
+
+    Eqn. (28) at mathworld.wolfram.com/SphericalTrigonometry.html, the same
+    one the original script's `sphere_angle` cites. Vectorized: `np.cross`
+    and an axis-aware dot product (`einsum`) replace the single triple
+    product, broadcasting over any leading shape.
+    """
+    a_side = great_circle_distance(b, c)
+    b_side = great_circle_distance(a, c)
+    c_side = great_circle_distance(a, b)
+    s = 0.5 * (a_side + b_side + c_side)
+    ratio = (np.sin(s - b_side) * np.sin(s - c_side)) / (np.sin(b_side) * np.sin(c_side))
+    sin_angle = np.sqrt(np.clip(ratio, 0.0, 1.0))
+
+    ab = np.asarray(b) - np.asarray(a)
+    ac = np.asarray(c) - np.asarray(a)
+    d = np.cross(ab, ac)
+    sign = np.where(np.einsum("...i,...i->...", d, a) >= 0.0, 1.0, -1.0)
+    return sign * 2.0 * np.arcsin(np.clip(sin_angle, -1.0, 1.0))
+
+
+def _scale_location(lon: np.ndarray, lat: np.ndarray, tan_lon: float,
+                    tan_lat: float, scale_factor: float):
+    """Project, scale, and re-project a set of points -- Cell, Vertex or
+    Edge alike. Returns (lon, lat, x, y, z), unit-sphere xyz."""
+    x, y = stereo_project(lon, lat, tan_lon, tan_lat)
+    new_lon, new_lat = stereo_inverse(x / scale_factor, y / scale_factor,
+                                      tan_lon, tan_lat)
+    xyz = lonlat_to_xyz(new_lon, new_lat)
+    return new_lon, new_lat, xyz[..., 0], xyz[..., 1], xyz[..., 2]
+
+
+# ------------------------------------------------------------ weightsOnEdge
+
+def _sign_for_edge(cell_id: int, edge_id: int, cells_on_edge: np.ndarray) -> float:
+    return 1.0 if cell_id == cells_on_edge[edge_id, 0] else -1.0
+
+
+def _rotate_kite_areas(kite_row: np.ndarray, edge_id: int,
+                       edges_on_cell_row: np.ndarray, n: int) -> np.ndarray:
+    """`kite_row`'s first `n` entries, rotated to start just after `edge_id`.
+
+    `verticesOnCell`/`kiteAreasOnCell` lead `edgesOnCell` by one position,
+    so the entry that "belongs" to `edge_id` is the next one round -- same
+    convention the original script's loop-based rotation used, just as a
+    single `np.roll` instead of two nested copy loops.
+    """
+    row = kite_row[:n]
+    matches = np.flatnonzero(edges_on_cell_row[:n] == edge_id)
+    istart = int((matches[0] + 1) % n) if matches.size else 0
+    return np.roll(row, -istart)
+
+
+def _weights_on_edge(kite_areas_on_cell, dc_edge, dv_edge, cells_on_edge,
+                     edges_on_cell, edges_on_edge, n_edges_on_cell,
+                     weights_on_edge_old):
+    """The one piece with a genuine sequential dependency -- see the module
+    docstring. `weights_on_edge_old` is copied and only the two cells'
+    worth of columns per edge are overwritten, matching the original."""
+    n_edges = cells_on_edge.shape[0]
+    out = weights_on_edge_old.astype(np.float64).copy()
+
+    for i in range(n_edges):
+        cell1, cell2 = cells_on_edge[i]
+        if cell1 < 0 or cell2 < 0:
+            continue
+
+        j = 0
+        for cell, sign_flip in ((cell1, 1.0), (cell2, -1.0)):
+            n = int(n_edges_on_cell[cell])
+            rotated = _rotate_kite_areas(kite_areas_on_cell[cell], i,
+                                         edges_on_cell[cell], n)
+            sum_r = 0.0
+            for ii in range(n - 1):
+                sum_r += rotated[ii]
+                edge_id = edges_on_edge[i, j]
+                out[i, j] = (sign_flip * _sign_for_edge(cell, edge_id, cells_on_edge)
+                            * (0.5 - sum_r) * dv_edge[edge_id] / dc_edge[i])
+                j += 1
+
+    return out
+
+
+# ---------------------------------------------------------------- orchestrator
+
+def scale_mesh(mesh_path: str | Path, out_path: str | Path,
+               scale_factor: float, tan_lat_deg: float,
+               tan_lon_deg: float) -> Path:
+    """Rescale a regional mesh around (tan_lat_deg, tan_lon_deg) and write
+    it to `out_path`. Values > 1 increase resolution (shrink cells).
+
+    Reads the whole mesh into memory, recomputes every array derived from
+    cell/vertex/edge position, and writes a complete new file -- everything
+    else (dims, attrs, variables this doesn't touch) passes through
+    unchanged. Never mutates `mesh_path`.
+    """
+    src = resolve_path(mesh_path)
+    if not src.exists():
+        raise FileNotFoundError(f"No such mesh file: {src}")
+
+    with xr.open_dataset(src, decode_timedelta=False, engine="netcdf4") as ds:
+        missing = [v for v in REQUIRED_VARS if v not in ds.variables]
+        if missing:
+            raise KeyError(
+                f"{src.name} cannot be scaled: missing {missing}. "
+                f"gmpas prep scale expects a full mesh straight out of "
+                f"JIGSAW/mkgrid (gmpas prep generate), not a trimmed file "
+                f"or one that has already been through init_atmosphere."
+            )
+        radius = float(ds.attrs.get("sphere_radius", 1.0) or 1.0)
+        if not math.isclose(radius, 1.0, rel_tol=1e-6):
+            raise ValueError(
+                f"{src.name} has sphere_radius={radius}, not a unit sphere. "
+                f"gmpas prep scale only supports a mesh straight off "
+                f"JIGSAW/mkgrid, before init_atmosphere redimensionalizes "
+                f"it -- scaling a metres-scale mesh with this formula would "
+                f"silently corrupt its coordinates."
+            )
+        ds = ds.load()
+
+    tan_lat = math.radians(tan_lat_deg)
+    tan_lon = math.radians(tan_lon_deg)
+
+    n_cells = ds.sizes["nCells"]
+
+    # -- recompute coordinates, one call per location type -------------
+    cell_lon, cell_lat, cell_x, cell_y, cell_z = _scale_location(
+        ds["lonCell"].values, ds["latCell"].values, tan_lon, tan_lat, scale_factor)
+    vtx_lon, vtx_lat, vtx_x, vtx_y, vtx_z = _scale_location(
+        ds["lonVertex"].values, ds["latVertex"].values, tan_lon, tan_lat, scale_factor)
+    edge_lon, edge_lat, edge_x, edge_y, edge_z = _scale_location(
+        ds["lonEdge"].values, ds["latEdge"].values, tan_lon, tan_lat, scale_factor)
+
+    cell_xyz = np.stack([cell_x, cell_y, cell_z], axis=-1)
+    vtx_xyz = np.stack([vtx_x, vtx_y, vtx_z], axis=-1)
+
+    # -- connectivity, 1-based/0-fill in the file -> 0-based/-1-fill here
+    voc = ds["verticesOnCell"].values.astype(np.int64) - 1     # (nCells, maxEdges)
+    eoc = ds["edgesOnCell"].values.astype(np.int64) - 1        # (nCells, maxEdges)
+    n_edges_on_cell = ds["nEdgesOnCell"].values.astype(np.int64)
+    max_edges = voc.shape[1]
+
+    coe = ds["cellsOnEdge"].values.astype(np.int64) - 1        # (nEdges, 2)
+    voe = ds["verticesOnEdge"].values.astype(np.int64) - 1     # (nEdges, 2)
+    eoe = ds["edgesOnEdge"].values.astype(np.int64) - 1        # (nEdges, maxEdges2)
+
+    cov = ds["cellsOnVertex"].values.astype(np.int64) - 1      # (nVertices, vertexDegree)
+    eov = ds["edgesOnVertex"].values.astype(np.int64) - 1      # (nVertices, vertexDegree)
+    vertex_degree = cov.shape[1]
+
+    scale_sq = scale_factor ** 2
+
+    # -- dcEdge: distance between the two cells on an edge --------------
+    valid_dc = (coe[:, 0] >= 0) & (coe[:, 1] >= 0)
+    coe_safe = np.where(coe >= 0, coe, 0)
+    dc_computed = great_circle_distance(cell_xyz[coe_safe[:, 0]], cell_xyz[coe_safe[:, 1]])
+    dc_edge = np.where(valid_dc, dc_computed, ds["dcEdge"].values / scale_factor)
+
+    # -- dvEdge: distance between the two vertices on an edge ------------
+    # every edge has exactly two vertices -- no boundary fallback needed
+    dv_edge = great_circle_distance(vtx_xyz[voe[:, 0]], vtx_xyz[voe[:, 1]])
+
+    # -- areaTriangle: one per vertex, from its 3 surrounding cells -------
+    # MPAS's vertex degree is always 3 (a Voronoi mesh's dual is a Delaunay
+    # triangulation); this assumes exactly that, as the original script does.
+    valid_tri = (cov >= 0).all(axis=1)
+    cov_safe = np.where(cov >= 0, cov, 0)
+    area_triangle = np.where(
+        valid_tri,
+        spherical_triangle_area(cell_xyz[cov_safe[:, 0]], cell_xyz[cov_safe[:, 1]],
+                                cell_xyz[cov_safe[:, 2]]),
+        ds["areaTriangle"].values / scale_sq,
+    )
+
+    # -- areaCell: ragged sum of per-edge triangles ----------------------
+    j = np.arange(max_edges)
+    valid_j = j[None, :] < n_edges_on_cell[:, None]
+    denom = np.maximum(n_edges_on_cell[:, None], 1)
+    j_next = (j[None, :] + 1) % denom
+    voc_safe = np.where(valid_j, voc, 0)
+    voc_next = np.take_along_axis(voc_safe, j_next, axis=1)
+
+    tri = spherical_triangle_area(
+        np.broadcast_to(cell_xyz[:, None, :], (n_cells, max_edges, 3)),
+        vtx_xyz[voc_safe], vtx_xyz[voc_next],
+    )
+    area_cell = np.where(valid_j, tri, 0.0).sum(axis=1)
+
+    # -- kiteAreasOnVertex: two triangles per (vertex, local cell) --------
+    k_next = (np.arange(vertex_degree) + 1) % vertex_degree
+    eov1, eov2 = eov, eov[:, k_next]
+    valid_kite = (cov >= 0) & (eov1 >= 0) & (eov2 >= 0)
+    eov1_safe = np.where(eov1 >= 0, eov1, 0)
+    eov2_safe = np.where(eov2 >= 0, eov2, 0)
+
+    edge_xyz = np.stack([edge_x, edge_y, edge_z], axis=-1)
+    vtx_b = np.broadcast_to(vtx_xyz[:, None, :], (vtx_xyz.shape[0], vertex_degree, 3))
+    kite_computed = (
+        spherical_triangle_area(vtx_b, edge_xyz[eov1_safe], cell_xyz[cov_safe])
+        + spherical_triangle_area(vtx_b, cell_xyz[cov_safe], edge_xyz[eov2_safe])
+    )
+    kite_areas_on_vertex = np.where(
+        valid_kite, kite_computed, ds["kiteAreasOnVertex"].values / scale_sq)
+
+    # -- kiteAreasOnCell: kiteAreasOnVertex, gathered back onto cells -----
+    cov_at_voc = cov[voc_safe]                    # (nCells, maxEdges, vertexDegree)
+    match = cov_at_voc == np.arange(n_cells)[:, None, None]
+    found = match.any(axis=-1)
+    k_found = np.argmax(match, axis=-1)
+    if np.any(valid_j & ~found):
+        print("warning: some cells were not found in their vertices' "
+             "cellsOnVertex list -- kiteAreasOnCell left at 0 there")
+    kite_gather = kite_areas_on_vertex[voc_safe, k_found]
+    kite_areas_on_cell = np.where(valid_j & found, kite_gather, 0.0) / area_cell[:, None]
+
+    # -- weightsOnEdge: the one loop -------------------------------------
+    weights_on_edge = _weights_on_edge(
+        kite_areas_on_cell, dc_edge, dv_edge, coe, eoc, eoe, n_edges_on_cell,
+        ds["weightsOnEdge"].values)
+
+    # -- angleEdge --------------------------------------------------------
+    a_pts = vtx_xyz[voe[:, 0]]
+    tangent = np.stack([
+        np.cos(edge_lon) * np.sin(edge_lat),
+        np.sin(edge_lon) * np.sin(edge_lat),
+        -np.cos(edge_lat),
+    ], axis=-1)
+    b_pts = a_pts - tangent
+    b_pts = b_pts / np.linalg.norm(b_pts, axis=-1, keepdims=True)
+    c_pts = vtx_xyz[voe[:, 1]]
+    angle_edge = spherical_angle(a_pts, b_pts, c_pts)
+
+    updates = {
+        "lonCell": cell_lon, "latCell": cell_lat,
+        "xCell": cell_x, "yCell": cell_y, "zCell": cell_z,
+        "lonVertex": vtx_lon, "latVertex": vtx_lat,
+        "xVertex": vtx_x, "yVertex": vtx_y, "zVertex": vtx_z,
+        "lonEdge": edge_lon, "latEdge": edge_lat,
+        "xEdge": edge_x, "yEdge": edge_y, "zEdge": edge_z,
+        "nominalMinDc": ds["nominalMinDc"].values / scale_factor,
+        "dcEdge": dc_edge, "dvEdge": dv_edge,
+        "areaTriangle": area_triangle, "areaCell": area_cell,
+        "kiteAreasOnVertex": kite_areas_on_vertex,
+        "weightsOnEdge": weights_on_edge,
+        "angleEdge": angle_edge,
+    }
+    for name, values in updates.items():
+        da = ds[name]
+        ds[name] = (da.dims, np.asarray(values).astype(da.dtype), da.attrs)
+
+    out = Path(out_path).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(out)
+    return out

--- a/src/gmpas/prep/scale.py
+++ b/src/gmpas/prep/scale.py
@@ -23,6 +23,12 @@ rather than mutating the input in place.
 The whole algorithm assumes `R = 1`; running it on an Earth-scaled mesh
 would silently corrupt every coordinate, so `scale_mesh` checks
 `sphere_radius` and refuses rather than guessing.
+
+`plot_comparison` renders a before/after cell-width map as a quick visual
+check that a scale did what was asked. matplotlib and cartopy are imported
+lazily inside it only, same as everywhere else in gmpas that draws --
+`scale_mesh` itself never needs them, and stays usable in a headless
+install.
 """
 
 from __future__ import annotations
@@ -33,7 +39,9 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
+from ..mesh import MpasMesh
 from ..paths import resolve_path
+from ..style import CMAPS
 
 #: variables scale_mesh reads and recomputes, beyond mesh identity
 REQUIRED_VARS = (
@@ -399,4 +407,75 @@ def scale_mesh(mesh_path: str | Path, out_path: str | Path,
     out = Path(out_path).expanduser()
     out.parent.mkdir(parents=True, exist_ok=True)
     ds.to_netcdf(out)
+    return out
+
+
+# --------------------------------------------------------------- comparison
+
+def plot_comparison(old_mesh_path: str | Path, new_mesh_path: str | Path,
+                    out_png: str | Path) -> Path:
+    """Before/after cell-width maps, side by side, on one shared colour
+    scale -- a quick visual check that a scale actually did what was asked:
+    resolution changed where expected, the domain pulled in toward the
+    tangent point, and so on. Returns the PNG path.
+
+    Deliberately not a full `plot.cell_field` reuse: this is a rough
+    sanity-check image, not a publication figure, and a self-contained
+    version here keeps this feature from touching the shared rendering path
+    every other plot goes through.
+    """
+    import cartopy.crs as ccrs
+    import cartopy.feature as cfeature
+    import matplotlib.pyplot as plt
+    from matplotlib.collections import PolyCollection
+
+    before = MpasMesh.load(old_mesh_path)
+    after = MpasMesh.load(new_mesh_path)
+
+    lo = min(before.cell_width_km.min(), after.cell_width_km.min())
+    hi = max(before.cell_width_km.max(), after.cell_width_km.max())
+    cmap = CMAPS["sequential"]
+
+    fig, axes = plt.subplots(1, 2, figsize=(13.0, 5.5),
+                             subplot_kw={"projection": ccrs.PlateCarree()},
+                             constrained_layout=True)
+
+    pc = None
+    for ax, mesh, label in ((axes[0], before, "before"), (axes[1], after, "after")):
+        ax.add_feature(cfeature.COASTLINE, linewidth=0.6)
+        gl = ax.gridlines(draw_labels=True, linewidth=0.4, linestyle="--", alpha=0.5)
+        # geo_labels defaults True alongside draw_labels and, left alone,
+        # pins the title at y=inf when top_labels is off, which NaNs the
+        # axes' tight bbox and crops the figure to its colorbar under any
+        # bbox_inches="tight" render (Jupyter's inline backend defaults to
+        # exactly that). See plot._basemap for the full cartopy bug.
+        gl.top_labels = gl.right_labels = gl.geo_labels = False
+
+        if mesh.is_global:
+            ax.set_global()
+        else:
+            ax.set_extent(mesh.extent, crs=ccrs.PlateCarree())
+
+        pc = ax.add_collection(PolyCollection(
+            mesh.cell_verts, array=mesh.cell_width_km, cmap=cmap,
+            clim=(lo, hi), transform=ccrs.PlateCarree(), edgecolors="face"))
+        if mesh.cell_wrapped.any():
+            # a second copy 360 degrees west, so a cell straddling the
+            # antimeridian doesn't smear across the map -- see plot.cell_field
+            dup = mesh.cell_verts[mesh.cell_wrapped].copy()
+            dup[..., 0] -= 360.0
+            ax.add_collection(PolyCollection(
+                dup, array=mesh.cell_width_km[mesh.cell_wrapped], cmap=cmap,
+                clim=(lo, hi), transform=ccrs.PlateCarree(), edgecolors="face"))
+
+        ax.set_title(f"{label}: {mesh.n_cells:,} cells, "
+                    f"{mesh.cell_width_km.min():.1f}-{mesh.cell_width_km.max():.1f} km")
+
+    fig.colorbar(pc, ax=list(axes), shrink=0.8, pad=0.02, label="cell width [km]")
+
+    out = Path(out_png).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    # deliberately no bbox_inches="tight" -- see the geo_labels note above
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
     return out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ def _ring(lon_deg: float, lat_deg: float, radius_deg: float, n: int = 6):
 
 
 def write_mesh(path, centres, *, n_verts=None, radius_deg=1.0,
-               sphere_radius=EARTH_RADIUS, areas=None, coord_dtype=np.float64):
+               sphere_radius=EARTH_RADIUS, areas=None, coord_dtype=np.float64,
+               with_scale_vars=False):
     """Write a synthetic MPAS mesh file.
 
     centres: sequence of (lon_deg, lat_deg), lon in -180..180 as a human would
@@ -51,6 +52,19 @@ def write_mesh(path, centres, *, n_verts=None, radius_deg=1.0,
              below 6 exercises the ragged `verticesOnCell` fill.
     sphere_radius: pass 1.0 to mimic a mesh straight out of JIGSAW, whose
              areas are non-dimensional.
+    with_scale_vars: also write the connectivity/derived variables
+             `scale_mesh` needs beyond what `MpasMesh._build` reads
+             (`cellsOnEdge`, `cellsOnVertex`, `edgesOnVertex`, `dcEdge`,
+             `dvEdge`, `areaTriangle`, `kiteAreasOnVertex`, `weightsOnEdge`,
+             `nominalMinDc`, `x/y/zVertex`, `x/y/zEdge`). Off by default:
+             `test_same_size_and_second_still_get_different_cache_entries`
+             depends on two small meshes padding to the *same* netCDF file
+             size, and this much extra per-cell/edge/vertex payload is
+             enough to break that coincidence. `cellsOnEdge`/
+             `cellsOnVertex`/`edgesOnVertex` are left at their 0-fill ("no
+             neighbour") default -- consistent with cells not sharing
+             topology here, and it exercises every boundary/fallback
+             branch in `scale_mesh`.
     """
     centres = np.asarray(centres, dtype=np.float64)
     n_cells = len(centres)
@@ -104,26 +118,72 @@ def write_mesh(path, centres, *, n_verts=None, radius_deg=1.0,
     def rad(deg):
         return np.radians(np.asarray(deg)).astype(coord_dtype)
 
-    ds = xr.Dataset(
-        {
-            "latCell": ("nCells", rad(centres[:, 1])),
-            "lonCell": ("nCells", rad360(centres[:, 0])),
-            "xCell": ("nCells", xyz[:, 0].astype(coord_dtype)),
-            "yCell": ("nCells", xyz[:, 1].astype(coord_dtype)),
-            "zCell": ("nCells", xyz[:, 2].astype(coord_dtype)),
-            "areaCell": ("nCells", areas.astype(coord_dtype)),
-            "nEdgesOnCell": ("nCells", n_verts.astype(np.int32)),
-            "verticesOnCell": (("nCells", "maxEdges"), voc),
-            "edgesOnCell": (("nCells", "maxEdges"), eoc),
-            "latVertex": ("nVertices", rad(lat_v)),
-            "lonVertex": ("nVertices", rad360(lon_v)),
-            "verticesOnEdge": (("nEdges", "TWO"), voe),
-            "latEdge": ("nEdges", rad(lat_e)),
-            "lonEdge": ("nEdges", rad360(lon_e)),
-            "angleEdge": ("nEdges", angle_edge.astype(coord_dtype)),
-        },
-        attrs={"sphere_radius": float(sphere_radius)},
-    )
+    variables = {
+        "latCell": ("nCells", rad(centres[:, 1])),
+        "lonCell": ("nCells", rad360(centres[:, 0])),
+        "xCell": ("nCells", xyz[:, 0].astype(coord_dtype)),
+        "yCell": ("nCells", xyz[:, 1].astype(coord_dtype)),
+        "zCell": ("nCells", xyz[:, 2].astype(coord_dtype)),
+        "areaCell": ("nCells", areas.astype(coord_dtype)),
+        "nEdgesOnCell": ("nCells", n_verts.astype(np.int32)),
+        "verticesOnCell": (("nCells", "maxEdges"), voc),
+        "edgesOnCell": (("nCells", "maxEdges"), eoc),
+        "latVertex": ("nVertices", rad(lat_v)),
+        "lonVertex": ("nVertices", rad360(lon_v)),
+        "verticesOnEdge": (("nEdges", "TWO"), voe),
+        "latEdge": ("nEdges", rad(lat_e)),
+        "lonEdge": ("nEdges", rad360(lon_e)),
+        "angleEdge": ("nEdges", angle_edge.astype(coord_dtype)),
+    }
+
+    if with_scale_vars:
+        def xyz_of(lon_deg, lat_deg):
+            lr, gr = np.radians(lat_deg), np.radians(lon_deg)
+            return np.stack([np.cos(lr) * np.cos(gr), np.cos(lr) * np.sin(gr),
+                             np.sin(lr)], axis=-1) * sphere_radius
+
+        xyz_v = xyz_of(lon_v, lat_v)
+        xyz_e = xyz_of(lon_e, lat_e)
+
+        # Placeholder magnitudes for the derived quantities `scale_mesh`
+        # only ever reads through its "/scalefac"-style fallback (every
+        # edge/vertex here is a boundary one, since cells don't share
+        # topology) -- the exact values don't matter, only that they exist
+        # and scale correctly.
+        vertex_degree = 3
+        max_edges2 = 2 * max_edges
+        edge_len = np.radians(radius_deg) * sphere_radius
+        dc_edge = np.full(n_edges, edge_len, dtype=coord_dtype)
+        dv_edge = np.full(n_edges, 0.5 * edge_len, dtype=coord_dtype)
+        area_triangle = (np.repeat(areas, max_edges) / max_edges).astype(coord_dtype)
+        kite_areas = np.repeat(area_triangle / vertex_degree, vertex_degree)
+        kite_areas = kite_areas.reshape(n_vertices, vertex_degree)
+
+        variables.update({
+            "xVertex": ("nVertices", xyz_v[:, 0].astype(coord_dtype)),
+            "yVertex": ("nVertices", xyz_v[:, 1].astype(coord_dtype)),
+            "zVertex": ("nVertices", xyz_v[:, 2].astype(coord_dtype)),
+            "xEdge": ("nEdges", xyz_e[:, 0].astype(coord_dtype)),
+            "yEdge": ("nEdges", xyz_e[:, 1].astype(coord_dtype)),
+            "zEdge": ("nEdges", xyz_e[:, 2].astype(coord_dtype)),
+            "cellsOnEdge": (("nEdges", "TWO"),
+                           np.zeros((n_edges, 2), dtype=np.int32)),
+            "edgesOnEdge": (("nEdges", "maxEdges2"),
+                           np.zeros((n_edges, max_edges2), dtype=np.int32)),
+            "cellsOnVertex": (("nVertices", "vertexDegree"),
+                             np.zeros((n_vertices, vertex_degree), dtype=np.int32)),
+            "edgesOnVertex": (("nVertices", "vertexDegree"),
+                             np.zeros((n_vertices, vertex_degree), dtype=np.int32)),
+            "dcEdge": ("nEdges", dc_edge),
+            "dvEdge": ("nEdges", dv_edge),
+            "areaTriangle": ("nVertices", area_triangle),
+            "kiteAreasOnVertex": (("nVertices", "vertexDegree"), kite_areas),
+            "weightsOnEdge": (("nEdges", "maxEdges2"),
+                             np.zeros((n_edges, max_edges2), dtype=coord_dtype)),
+            "nominalMinDc": ((), np.float64(edge_len)),
+        })
+
+    ds = xr.Dataset(variables, attrs={"sphere_radius": float(sphere_radius)})
     assert ds.sizes["nVertices"] == n_vertices
     ds.to_netcdf(path)
     ds.close()

--- a/tests/test_relocate.py
+++ b/tests/test_relocate.py
@@ -1,0 +1,123 @@
+"""Moving a mesh's refined region to a new tangent point, without resizing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from conftest import write_mesh
+from gmpas.cli import main
+from gmpas.prep.relocate import relocate_mesh
+
+#: variables that must come out byte-for-byte identical to the source --
+#: everything a rotation doesn't touch (see relocate.py's module docstring)
+UNCHANGED_VARS = (
+    "nEdgesOnCell", "verticesOnCell", "edgesOnCell", "cellsOnEdge",
+    "cellsOnVertex", "edgesOnVertex", "dcEdge", "dvEdge", "areaCell",
+    "areaTriangle", "kiteAreasOnVertex", "weightsOnEdge", "nominalMinDc",
+)
+
+
+def test_the_target_point_lands_exactly_on_the_tangent_point(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = relocate_mesh(path, tmp_path / "relocated.nc", 30.0, 200.0,
+                        from_lat_deg=0.0, from_lon_deg=100.0)
+
+    with xr.open_dataset(out) as ds:
+        assert np.degrees(ds.latCell.values[0]) == pytest.approx(30.0)
+        # 200E and -160E are the same point
+        assert np.cos(np.radians(200.0) - ds.lonCell.values[0]) == pytest.approx(1.0)
+
+
+def test_auto_detects_the_finest_cell_as_the_from_point(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      areas=[5.0e10, 1.0e9, 8.0e10],   # cell 1 is finest
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = relocate_mesh(path, tmp_path / "relocated.nc", 0.0, 0.0)
+
+    with xr.open_dataset(out) as ds:
+        assert np.degrees(ds.latCell.values[1]) == pytest.approx(0.0, abs=1e-8)
+        assert np.cos(ds.lonCell.values[1]) == pytest.approx(1.0)
+
+
+def test_every_area_distance_and_weight_is_byte_for_byte_unchanged(tmp_path):
+    """The whole point: a rotation is an isometry, so nothing metric moves --
+    only position and angleEdge (bearing relative to the fixed lat/lon grid,
+    which does change) are touched."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = relocate_mesh(path, tmp_path / "relocated.nc", 30.0, 200.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as dst:
+        for name in UNCHANGED_VARS:
+            assert np.array_equal(src[name].values, dst[name].values), name
+
+
+def test_works_at_any_sphere_radius_not_just_unit(tmp_path):
+    """Unlike scale_mesh, a rotation doesn't care about sphere_radius --
+    it's a linear transform of whatever coordinates are already there."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=6_371_229.0)
+    out = relocate_mesh(path, tmp_path / "relocated.nc", 30.0, 200.0,
+                        from_lat_deg=0.0, from_lon_deg=100.0)
+    assert out.exists()
+
+
+def test_works_with_a_ragged_ie_differently_shaped_mesh(tmp_path):
+    """Every cell has a different vertex count -- relocate never touches
+    connectivity or any ragged/maxEdges-shaped array, so this should be a
+    non-event, unlike scale_mesh's areaCell recompute."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      n_verts=[5, 4, 6], with_scale_vars=True, sphere_radius=1.0)
+    out = relocate_mesh(path, tmp_path / "relocated.nc", 30.0, 200.0,
+                        from_lat_deg=0.0, from_lon_deg=100.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as dst:
+        assert np.array_equal(src.nEdgesOnCell.values, dst.nEdgesOnCell.values)
+        assert np.array_equal(src.verticesOnCell.values, dst.verticesOnCell.values)
+        assert np.array_equal(src.areaCell.values, dst.areaCell.values)
+
+
+def test_a_missing_variable_names_what_is_missing(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0)])   # with_scale_vars defaults False
+    with pytest.raises(KeyError, match="xVertex"):
+        relocate_mesh(path, tmp_path / "relocated.nc", 0.0, 0.0)
+
+
+def test_a_missing_mesh_file_is_reported(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No such mesh file"):
+        relocate_mesh(tmp_path / "absent.nc", tmp_path / "relocated.nc", 0.0, 0.0)
+
+
+# -------------------------------------------------------------------- CLI
+
+def test_cli_prep_relocate(tmp_path, capsys):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = tmp_path / "relocated.nc"
+
+    assert main(["prep", "relocate", str(path), "-o", str(out),
+                "--tan-lat", "30", "--tan-lon", "200"]) == 0
+    assert out.exists()
+    assert "->" in capsys.readouterr().out
+
+
+def test_cli_default_output_path_is_derived_from_the_input(tmp_path, monkeypatch):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["prep", "relocate", str(path), "--tan-lat", "30",
+                "--tan-lon", "200"]) == 0
+    assert (tmp_path / "m.relocated.nc").exists()
+
+
+def test_cli_from_lat_without_from_lon_is_rejected(tmp_path, capsys):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+
+    assert main(["prep", "relocate", str(path), "--tan-lat", "30",
+                "--tan-lon", "200", "--from-lat", "0"]) == 1
+    assert "--from-lat and --from-lon" in capsys.readouterr().err

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,0 +1,200 @@
+"""Rescaling a regional mesh around a stereographic tangent point."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from conftest import write_mesh
+from gmpas.cli import main
+from gmpas.prep.scale import (
+    great_circle_distance,
+    lonlat_to_xyz,
+    scale_mesh,
+    spherical_angle,
+    spherical_triangle_area,
+    stereo_inverse,
+    stereo_project,
+    xyz_to_lonlat,
+)
+
+# ------------------------------------------------------------- primitives
+
+def test_lonlat_xyz_round_trip():
+    lon = np.array([0.3, -1.2, 2.5, 0.0])
+    lat = np.array([0.1, -0.4, 0.6, 0.0])
+    lon2, lat2 = xyz_to_lonlat(lonlat_to_xyz(lon, lat))
+    assert np.allclose(lon, lon2)
+    assert np.allclose(lat, lat2)
+
+
+def test_stereo_round_trip_at_scale_one():
+    lon = np.array([0.3, -1.2, 2.5])
+    lat = np.array([0.1, -0.4, 0.6])
+    x, y = stereo_project(lon, lat, 0.5, 0.2)
+    lon2, lat2 = stereo_inverse(x, y, 0.5, 0.2)
+    assert np.allclose(lon, lon2)
+    assert np.allclose(lat, lat2)
+
+
+def test_stereo_inverse_at_the_tangent_point_itself():
+    """rho=0 is a 0/0 in the raw formula -- must not come back nan."""
+    lam, phi = stereo_inverse(np.array(0.0), np.array(0.0), 0.5, 0.2)
+    assert lam == pytest.approx(0.5)
+    assert phi == pytest.approx(0.2)
+
+
+def test_octant_triangle_area_is_pi_over_2():
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    c = np.array([0.0, 0.0, 1.0])
+    assert spherical_triangle_area(a, b, c) == pytest.approx(np.pi / 2)
+
+
+def test_great_circle_distance_quarter_sphere_apart():
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    assert great_circle_distance(a, b) == pytest.approx(np.pi / 2)
+
+
+def test_octant_angle_is_a_right_angle():
+    a = np.array([1.0, 0.0, 0.0])
+    b = np.array([0.0, 1.0, 0.0])
+    c = np.array([0.0, 0.0, 1.0])
+    assert abs(spherical_angle(a, b, c)) == pytest.approx(np.pi / 2)
+
+
+def test_primitives_broadcast_over_a_whole_mesh_at_once():
+    """scale_mesh calls these across every cell/edge/vertex in one shot --
+    confirm they broadcast, not just work on single points."""
+    a = np.tile([1.0, 0.0, 0.0], (5, 1))
+    b = np.tile([0.0, 1.0, 0.0], (5, 1))
+    c = np.tile([0.0, 0.0, 1.0], (5, 1))
+    area = spherical_triangle_area(a, b, c)
+    assert area.shape == (5,)
+    assert np.allclose(area, np.pi / 2)
+
+
+# --------------------------------------------------------------- areaCell
+
+def test_area_cell_matches_a_brute_force_reference(tmp_path):
+    """The ragged, vectorized areaCell sum against a plain Python loop over
+    each cell's own vertex ring -- the one place a masking/indexing bug in
+    the vectorization would most easily hide."""
+    path = write_mesh(tmp_path / "m.nc",
+                      [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    # scale_factor=1 is a geometric identity (see test_scale_factor_one_is_
+    # an_identity below), so the source file's own vertex positions are
+    # exactly what areaCell gets recomputed from.
+    out = scale_mesh(path, tmp_path / "scaled.nc", 1.0, 0.0, 100.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as scaled:
+        voc = src.verticesOnCell.values.astype(np.int64) - 1
+        nedges = src.nEdgesOnCell.values.astype(np.int64)
+        vtx_xyz = lonlat_to_xyz(src.lonVertex.values, src.latVertex.values)
+        cell_xyz = lonlat_to_xyz(src.lonCell.values, src.latCell.values)
+
+        reference = np.zeros(cell_xyz.shape[0])
+        for i in range(cell_xyz.shape[0]):
+            total = 0.0
+            for j in range(nedges[i]):
+                v1 = voc[i, j]
+                v2 = voc[i, (j + 1) % nedges[i]]
+                total += spherical_triangle_area(cell_xyz[i], vtx_xyz[v1], vtx_xyz[v2])
+            reference[i] = total
+
+        assert np.allclose(scaled.areaCell.values, reference, rtol=1e-6)
+
+
+# -------------------------------------------------------------- scale_mesh
+
+def test_scale_factor_one_is_an_identity(tmp_path):
+    """Project, divide by 1, re-project -- coordinates shouldn't move."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = scale_mesh(path, tmp_path / "scaled.nc", 1.0, 0.0, 105.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as scaled:
+        assert np.allclose(src.lonCell.values, scaled.lonCell.values, atol=1e-9)
+        assert np.allclose(src.latCell.values, scaled.latCell.values, atol=1e-9)
+        assert np.allclose(src.xCell.values, scaled.xCell.values, atol=1e-9)
+
+
+def test_scale_factor_two_halves_nominal_min_dc(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = scale_mesh(path, tmp_path / "scaled.nc", 2.0, 0.0, 105.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as scaled:
+        assert float(scaled.nominalMinDc.values) == pytest.approx(
+            float(src.nominalMinDc.values) / 2.0)
+
+
+def test_boundary_quantities_take_the_scalefac_fallback(tmp_path):
+    """Every edge/vertex in this fixture is a boundary one -- cells don't
+    share topology -- so every quantity with a "no real neighbour" branch
+    should take it rather than the geometric recompute."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = scale_mesh(path, tmp_path / "scaled.nc", 2.0, 0.0, 105.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as scaled:
+        assert np.allclose(scaled.dcEdge.values, src.dcEdge.values / 2.0)
+        assert np.allclose(scaled.areaTriangle.values, src.areaTriangle.values / 4.0)
+        assert np.allclose(scaled.kiteAreasOnVertex.values,
+                           src.kiteAreasOnVertex.values / 4.0)
+        # no cell pair is ever valid here, so the weightsOnEdge loop never
+        # touches a single entry
+        assert np.allclose(scaled.weightsOnEdge.values, src.weightsOnEdge.values)
+
+
+def test_output_carries_every_original_variable(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = scale_mesh(path, tmp_path / "scaled.nc", 2.0, 0.0, 105.0)
+
+    with xr.open_dataset(path) as src, xr.open_dataset(out) as scaled:
+        assert set(src.variables) <= set(scaled.variables)
+
+
+def test_a_non_unit_sphere_is_refused(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=6_371_229.0)
+    with pytest.raises(ValueError, match="sphere_radius"):
+        scale_mesh(path, tmp_path / "scaled.nc", 2.0, 0.0, 105.0)
+
+
+def test_a_missing_variable_names_what_is_missing(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0)])   # with_scale_vars defaults False
+    with pytest.raises(KeyError, match="dcEdge"):
+        scale_mesh(path, tmp_path / "scaled.nc", 2.0, 0.0, 100.0)
+
+
+def test_a_missing_mesh_file_is_reported(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No such mesh file"):
+        scale_mesh(tmp_path / "absent.nc", tmp_path / "scaled.nc", 2.0, 0.0, 100.0)
+
+
+# -------------------------------------------------------------------- CLI
+
+def test_cli_prep_scale(tmp_path, capsys):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = tmp_path / "scaled.nc"
+
+    assert main(["prep", "scale", str(path), "-o", str(out),
+                "--scale-factor", "2.0", "--tan-lat", "0", "--tan-lon", "105"]) == 0
+    assert out.exists()
+    assert "->" in capsys.readouterr().out
+
+
+def test_cli_default_output_path_is_derived_from_the_input(tmp_path, monkeypatch):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["prep", "scale", str(path), "--scale-factor", "2.0",
+                "--tan-lat", "0", "--tan-lon", "105"]) == 0
+    assert (tmp_path / "m.scaled.nc").exists()

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -198,3 +198,69 @@ def test_cli_default_output_path_is_derived_from_the_input(tmp_path, monkeypatch
     assert main(["prep", "scale", str(path), "--scale-factor", "2.0",
                 "--tan-lat", "0", "--tan-lon", "105"]) == 0
     assert (tmp_path / "m.scaled.nc").exists()
+
+
+def test_cli_no_plot_skips_the_comparison(tmp_path):
+    """No matplotlib/cartopy import needed to get here -- this path stays
+    usable in a headless install."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = tmp_path / "scaled.nc"
+
+    assert main(["prep", "scale", str(path), "-o", str(out), "--no-plot",
+                "--scale-factor", "2.0", "--tan-lat", "0", "--tan-lon", "105"]) == 0
+    assert not (tmp_path / "scaled.compare.png").exists()
+
+
+# ---------------------------------------------------------------- comparison
+
+def test_plot_comparison_writes_a_png(tmp_path):
+    pytest.importorskip("matplotlib", reason="needs the `plot` extra")
+    pytest.importorskip("cartopy", reason="needs the `plot` extra")
+    import matplotlib
+    matplotlib.use("Agg")
+    from gmpas.prep.scale import plot_comparison
+
+    path = write_mesh(tmp_path / "m.nc",
+                      [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = scale_mesh(path, tmp_path / "scaled.nc", 2.0, 0.0, 105.0)
+
+    png = plot_comparison(path, out, tmp_path / "compare.png")
+    assert png.exists()
+    assert png.stat().st_size > 0
+
+
+def test_cli_prep_scale_writes_a_comparison_plot_by_default(tmp_path, capsys):
+    pytest.importorskip("matplotlib", reason="needs the `plot` extra")
+    pytest.importorskip("cartopy", reason="needs the `plot` extra")
+    import matplotlib
+    matplotlib.use("Agg")
+
+    path = write_mesh(tmp_path / "m.nc",
+                      [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = tmp_path / "scaled.nc"
+
+    assert main(["prep", "scale", str(path), "-o", str(out),
+                "--scale-factor", "2.0", "--tan-lat", "0", "--tan-lon", "105"]) == 0
+    assert (tmp_path / "scaled.compare.png").exists()
+    assert "comparison plot:" in capsys.readouterr().out
+
+
+def test_cli_plot_out_overrides_the_default_path(tmp_path):
+    pytest.importorskip("matplotlib", reason="needs the `plot` extra")
+    pytest.importorskip("cartopy", reason="needs the `plot` extra")
+    import matplotlib
+    matplotlib.use("Agg")
+
+    path = write_mesh(tmp_path / "m.nc",
+                      [(100.0, 0.0), (110.0, 5.0), (120.0, -5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    out = tmp_path / "scaled.nc"
+    plot_out = tmp_path / "custom_name.png"
+
+    assert main(["prep", "scale", str(path), "-o", str(out),
+                "--plot-out", str(plot_out), "--scale-factor", "2.0",
+                "--tan-lat", "0", "--tan-lon", "105"]) == 0
+    assert plot_out.exists()

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -9,8 +9,10 @@ import xarray as xr
 from conftest import write_mesh
 from gmpas.cli import main
 from gmpas.prep.scale import (
+    REGIONAL_WARNING_DEG,
     great_circle_distance,
     lonlat_to_xyz,
+    max_angular_distance_deg,
     scale_mesh,
     spherical_angle,
     spherical_triangle_area,
@@ -175,6 +177,46 @@ def test_a_missing_variable_names_what_is_missing(tmp_path):
 def test_a_missing_mesh_file_is_reported(tmp_path):
     with pytest.raises(FileNotFoundError, match="No such mesh file"):
         scale_mesh(tmp_path / "absent.nc", tmp_path / "scaled.nc", 2.0, 0.0, 100.0)
+
+
+# ---------------------------------------------------------- regional check
+
+def test_angular_distance_at_the_tangent_point_is_zero(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    assert max_angular_distance_deg(path, 0.0, 100.0) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_angular_distance_a_quarter_sphere_away(tmp_path):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+    assert max_angular_distance_deg(path, 0.0, 10.0) == pytest.approx(90.0, abs=1e-6)
+
+
+def test_cli_warns_when_the_tangent_point_is_far_from_the_mesh(tmp_path, capsys):
+    """Far, but not exactly antipodal -- that hits stereo_project's own
+    divide-by-zero at k's denominator, a separate, pre-existing edge case
+    inherited from the original script, not what this test is checking."""
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+
+    assert main(["prep", "scale", str(path), "-o", str(tmp_path / "scaled.nc"),
+                "--no-plot", "--scale-factor", "2.0", "--tan-lat", "0",
+                "--tan-lon", "250"]) == 0
+    err = capsys.readouterr().err
+    assert "regional-mesh tool" in err
+    assert "gmpas prep relocate" in err
+
+
+def test_cli_stays_quiet_when_the_tangent_point_is_close(tmp_path, capsys):
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0), (110.0, 5.0)],
+                      with_scale_vars=True, sphere_radius=1.0)
+
+    assert main(["prep", "scale", str(path), "-o", str(tmp_path / "scaled.nc"),
+                "--no-plot", "--scale-factor", "2.0", "--tan-lat", "0",
+                "--tan-lon", "105"]) == 0
+    assert "regional-mesh tool" not in capsys.readouterr().err
+    assert REGIONAL_WARNING_DEG > 0   # sanity: the threshold itself is sane
 
 
 # -------------------------------------------------------------------- CLI


### PR DESCRIPTION
## Summary
- Ports MPAS-Tools' `scale_regional_mesh.py` as `gmpas prep scale MESH --scale-factor F --tan-lat LAT --tan-lon LON [-o OUT]`: project every cell/vertex/edge stereographically around a tangent point, divide by a scale factor, project back, then recompute everything derived from position. Vectorized with numpy (same ragged-cell masking idiom `scrip.py` uses) instead of the original's per-cell/edge/vertex Python loops; writes a whole new file, never mutating the input. New precondition the original lacked: refuses a non-unit-sphere mesh, which would otherwise be silently corrupted.
- After a successful scale, also writes a before/after comparison PNG (two cell-width panels, one shared colour scale) — self-contained, not routed through `plot.py`'s shared rendering path. Default on; `--no-plot` skips it (and the matplotlib/cartopy import, so the command still works headless); `--plot-out` overrides the default path.
- **`gmpas prep scale` now warns before scaling a mesh whose extent reaches too far from the tangent point.** Measured directly: the stereographic scale is only close to the requested factor near the tangent point — at 60° away a factor of 2 already behaves like 1.63, past 120° it starts making cells *coarser*, and near the antipode it's close to the exact reciprocal of what was asked. Not a bug — confirmed the original script does the same thing. `max_angular_distance_deg` checks this cheaply (just `lonCell`/`latCell`) before the expensive recompute.
- **New: `gmpas prep relocate MESH --tan-lat LAT --tan-lon LON [-o OUT]`** — moves a mesh's refined region to a new location via a rigid rotation instead of a projection. A rotation is an isometry: it preserves every distance, area and angle exactly, everywhere, with no far-field distortion and no antipodal singularity — so `dcEdge`/`dvEdge`/`areaCell`/`areaTriangle`/`kiteAreasOnVertex`/`weightsOnEdge`/`nominalMinDc` all come out byte-for-byte unchanged; only coordinates and `angleEdge` are recomputed. No unit-sphere precondition either (unlike `scale`), and it's safe to run directly on a *global* mesh. `--from-lat`/`--from-lon` default to the mesh's own finest cell if not given.
- Filed [gmpas-lib#52](https://github.com/nmathewa/gmpas-lib/issues/52) for the actual gap this points at: gmpas has no `create_region` equivalent (global mesh → regional subset), which is normally the step before `scale` is reached for at all.
- `tests/conftest.py`'s `write_mesh` gains an opt-in `with_scale_vars` flag for the extra connectivity/derived variables these need — off by default, since writing them unconditionally broke a cache-collision regression test's premise about netCDF file-size padding.
- Docs: "Rescaling a regional mesh" and "Repositioning a refined region" sections in `docs/preprocessing.md`, one-line mentions in `docs/status.md`/`docs/command-line.md`.

## Test plan
- [x] `pytest tests/test_scale.py tests/test_relocate.py -q` — 35 tests: geometry-primitive round trips and analytic cases, a brute-force cross-check of the vectorized ragged `areaCell` sum, `scale_mesh`/`relocate_mesh` end-to-end (identity/boundary-fallback cases, error paths, the regional-extent warning), the comparison-plot function, and CLI smoke tests for both subcommands.
- [x] Confirmed the brute-force `areaCell` cross-check is a real guard: deliberately broke the ragged-index math, watched it fail, restored, reran clean.
- [x] Confirmed the comparison plot survives `bbox_inches="tight"` (Jupyter's inline-backend default) — the same cartopy `geo_labels` bug fixed in gmpas-lib#48, applied to this new gridlines call too and verified directly.
- [x] Confirmed `relocate_mesh` is agnostic to mesh "shape": tested against a ragged mesh (varying vertex count per cell) and a non-unit `sphere_radius` mesh — both work without modification, since rotation never touches connectivity or any ragged-shaped array.
- [x] Full suite: `pytest -q` — 341 passed, 5 skipped (pre-existing, ESMF-dependent), no regressions.
- [x] `ruff check` clean on every new/changed file (pre-existing findings elsewhere in `cli.py`'s `_remap`, untouched by this change).
- [x] Manual end-to-end runs against the real 8,228-cell `data/maritime_2019/maritime.region.nc`: `scale` (×2, dims match exactly, zero NaNs including interior-edge paths, `areaCell`/`areaTriangle` totals shrink by consistent ratios) and `relocate` (moved the domain across the globe with `areaCell`/`dcEdge`/`weightsOnEdge` all byte-for-byte identical to the source, confirmed via the comparison PNG that the mesh shape/width range is visually unchanged, just repositioned).