### PR TITLE
Add gmpas prep create-region: crop a global mesh to a regional subset

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -11,6 +11,7 @@ gmpas prep hfun  hfun.py
 gmpas prep generate hfun.py -o mesh/
 gmpas prep scale mesh.nc --scale-factor 2.0 --tan-lat 0 --tan-lon 125
 gmpas prep relocate mesh.nc --tan-lat 40 --tan-lon 280
+gmpas prep create-region mesh.nc --polygon 40,-129 50,-129 50,-65 40,-65
 ```
 
 `info` summarises the mesh and lists variables grouped by the element they

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -354,7 +354,14 @@ gmpas prep create-region mesh.nc \
 ```
 mesh.nc -> conus.region.nc  (4-point boundary)
 partition file: conus.region.graph.info
+region plot: conus.region.png
 ```
+
+Also writes a PNG of the cropped mesh coloured by boundary zone (0 for the
+untouched interior, up through 7 at the outer edge) by default -- a quick
+visual check that the kept cells and relaxation rings form actual rings, not
+a smear. `--no-plot` skips it (and the matplotlib/cartopy import, so the
+command still works headless); `--plot-out` overrides the default path.
 
 The step this package was previously missing entirely
 ([gmpas-lib#52](https://github.com/nmathewa/gmpas-lib/issues/52)): going

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -344,6 +344,61 @@ variable-resolution mesh. Pass both explicitly for a mesh with more than
 one refined patch, where auto-detection would only find one of them; the
 two must be given together, or not at all.
 
+### Cropping a global mesh to a region
+
+```bash
+gmpas prep create-region mesh.nc \
+    --polygon 40,-129 50,-129 50,-65 40,-65 -o conus.region.nc
+```
+
+```
+mesh.nc -> conus.region.nc  (4-point boundary)
+partition file: conus.region.graph.info
+```
+
+The step this package was previously missing entirely
+([gmpas-lib#52](https://github.com/nmathewa/gmpas-lib/issues/52)): going
+from a global (or larger regional) mesh to the actual regional subset a
+limited-area run uses. `--polygon` is a closed boundary as `lat,lon` pairs
+in degrees, at least 3, in either winding order; `--point` names a point
+known to be inside it and defaults to the polygon's spherical centroid,
+which is only reliable for a convex (or near-convex) boundary — pass it
+explicitly otherwise.
+
+Every mesh cell inside the boundary is kept, plus 7 more rings of cells
+grown outward beyond it — not part of what was asked for, but required for
+the file to be usable: `init_atmosphere` and the atmosphere core relax the
+forecast toward driving boundary data in those rings every step, most
+strongly in the outermost 2 (the "specified" zone, overwritten directly)
+and with decreasing weight through the next 5 (the "relaxation" zone). That
+7-ring split (`N_SPEC_ZONE = 2`, `N_RELAX_ZONE = 5`) is not a tuning choice
+made here — it is hardcoded in MPAS-Model's own
+`mpas_atm_boundaries.F`/`mpas_init_atm_cases.F`, and `bdyMaskCell`'s value
+at each kept cell (`0` for the untouched interior, up through `7` at the
+outer edge) is a file-format contract with those routines, not an
+implementation detail. `bdyMaskEdge`/`bdyMaskVertex` follow the more
+interior (lower) of their adjoining cells' values.
+
+An independent implementation, not a port — see the module docstring in
+`gmpas/prep/region.py` for why: MPAS-Dev/MPAS-Limited-Area does the same
+job but carries no LICENSE file, unlike MPAS-Tools (the source for `scale`
+and `relocate`), which is permissively licensed. Built instead from graph
+traversal over `cellsOnCell` and from MPAS-Model's own public
+Registry.xml/Fortran source for the `bdyMaskCell` semantics above.
+
+Since there is no `mkgrid` run over a cropped subset, `create-region` also
+writes the accompanying `graph.info` `gpmetis` partition file itself, in
+the same directory as the output mesh.
+
+#### Concave regions
+
+A concave boundary (or one spanning a pole, or a large longitude range, on
+a `grid.nc`) can produce incorrect terrain during `init_atmosphere`'s
+static-field interpolation — a property of that downstream interpolation
+step, not of the cropping itself, but worth keeping in mind when drawing
+`--polygon`. Prefer a convex boundary, or crop a `static.nc` (already past
+that interpolation) instead.
+
 ### Looking at a mesh before it exists
 
 ```bash

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,11 +16,12 @@ in gmpas's own environment; the two compete on `PATH`/`LD_LIBRARY_PATH`
 rather than help.
 
 **Preprocessing** covers `prep view`, `prep hfun`, `prep generate`,
-`prep scale` and `prep relocate`: looking at a mesh after it exists, looking
-at a distance function before any mesh exists, running JIGSAW to get from
-the second to the first, rescaling a regional mesh around a tangent point,
-and repositioning a refined region without resizing it. A run leaves
-everything `mkgrid` reads.
+`prep scale`, `prep relocate` and `prep create-region`: looking at a mesh
+after it exists, looking at a distance function before any mesh exists,
+running JIGSAW to get from the second to the first, rescaling a regional
+mesh around a tangent point, repositioning a refined region without
+resizing it, and cropping a global mesh down to a regional subset. A run
+leaves everything `mkgrid` reads.
 
 ## Not implemented
 

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -636,6 +636,31 @@ def _prep_relocate(args) -> int:
     return 0
 
 
+def _prep_create_region(args) -> int:
+    from .prep.region import create_region, write_graph_info
+
+    try:
+        points = [tuple(float(v) for v in token.split(",")) for token in args.polygon]
+        if any(len(p) != 2 for p in points):
+            raise ValueError
+    except ValueError:
+        print("gmpas: --polygon points must be 'lat,lon' pairs, e.g. "
+             "--polygon 40.0,-100.0 50.0,-100.0 50.0,-70.0", file=sys.stderr)
+        return 1
+    boundary_lat, boundary_lon = zip(*points, strict=True)
+
+    point_lat, point_lon = args.point if args.point else (None, None)
+
+    out_path = args.out or f"{Path(args.mesh_file).stem}.region.nc"
+    out = create_region(args.mesh_file, out_path, boundary_lat, boundary_lon,
+                        point_lat_deg=point_lat, point_lon_deg=point_lon)
+    print(f"{args.mesh_file} -> {out}  ({len(points)}-point boundary)")
+
+    graph = write_graph_info(out, f"{out.with_suffix('')}.graph.info")
+    print(f"partition file: {graph}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gmpas",
@@ -742,7 +767,8 @@ def build_parser() -> argparse.ArgumentParser:
                          description="Preprocessing steps, which run before "
                                      "there is any model output to plot.")
     presub = pre.add_subparsers(dest="prep_cmd",
-                                metavar="{view,hfun,generate,scale,relocate}")
+                                metavar="{view,hfun,generate,scale,relocate,"
+                                        "create-region}")
     # a bare `gmpas prep` should list its steps, not error
     pre.set_defaults(func=lambda _a, _p=pre: (_p.print_help(), 0)[1])
 
@@ -856,6 +882,21 @@ def build_parser() -> argparse.ArgumentParser:
                     help="longitude the refined region is currently at "
                          "(default: auto-detected from the mesh's finest cell)")
     pr.set_defaults(func=_prep_relocate)
+
+    pc = presub.add_parser("create-region", help="crop a global (or larger "
+                                                 "regional) mesh to a "
+                                                 "boundary-defined subset")
+    pc.add_argument("mesh_file", metavar="MESH", help="a global or regional mesh")
+    pc.add_argument("-o", "--out",
+                    help="output path (default: <mesh stem>.region.nc)")
+    pc.add_argument("--polygon", nargs="+", required=True, metavar="LAT,LON",
+                    help="boundary vertices as 'lat,lon' pairs, in degrees, "
+                         "at least 3 (e.g. --polygon 40,-100 50,-100 50,-70)")
+    pc.add_argument("--point", type=float, nargs=2, metavar=("LAT", "LON"),
+                    help="a point known to be inside the boundary (default: "
+                         "the polygon's spherical centroid -- only reliable "
+                         "for a convex boundary)")
+    pc.set_defaults(func=_prep_create_region)
     return p
 
 

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -658,6 +658,18 @@ def _prep_create_region(args) -> int:
 
     graph = write_graph_info(out, f"{out.with_suffix('')}.graph.info")
     print(f"partition file: {graph}")
+
+    if not args.no_plot:
+        from .prep.region import plot_region
+
+        plot_out = args.plot_out or f"{out.with_suffix('')}.png"
+        try:
+            png = plot_region(out, plot_out)
+            print(f"region plot: {png}")
+        except ModuleNotFoundError as exc:
+            print(f"gmpas: skipped the region plot -- {exc}. Rendering "
+                 f"needs the optional plot extra:  pip install gmpas[plot]  "
+                 f"(or pass --no-plot)", file=sys.stderr)
     return 0
 
 
@@ -896,6 +908,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="a point known to be inside the boundary (default: "
                          "the polygon's spherical centroid -- only reliable "
                          "for a convex boundary)")
+    pc.add_argument("--no-plot", action="store_true",
+                    help="skip the boundary-zone PNG")
+    pc.add_argument("--plot-out",
+                    help="region plot path (default: <out stem>.png)")
     pc.set_defaults(func=_prep_create_region)
     return p
 

--- a/src/gmpas/prep/region.py
+++ b/src/gmpas/prep/region.py
@@ -227,17 +227,35 @@ def _relaxation_zones(cells_on_cell: np.ndarray, n_edges_on_cell: np.ndarray,
 
 
 def _neighbour_zone(zone: np.ndarray, cells_on: np.ndarray) -> np.ndarray:
-    """The minimum zone among a row's kept (>= 0) neighbour cells --
-    `bdyMaskEdge`/`bdyMaskVertex` take the more-interior (lower) of their
-    adjoining cells' zones, following the actual boundary inward. A side
-    with no kept cell at all (0-fill, or a neighbour this crop dropped)
-    contributes `_NO_NEIGHBOUR`, so it never wins the min unless every side
-    is like that -- which means this edge/vertex is dropped too.
+    """An edge's/vertex's own zone, derived from the zones of its
+    surrounding cells.
+
+    An element fully surrounded by kept cells takes the *more interior*
+    (lower) of their zones -- it follows the most-restrictive neighbour
+    inward. But an element with at least one side missing (0-fill, or a
+    neighbour this crop dropped entirely) sits structurally at the outer
+    rim of whatever it does touch, with nothing beyond to inform it -- it
+    takes the *more boundary-like* (higher, i.e. max) of the sides it does
+    have, not the lower. An edge only ever has 2 sides, so this distinction
+    is invisible there (one reached side makes min and max the same value)
+    -- it only shows up on a vertex with 3+ neighbours, some kept at
+    different zones and at least one not. An element with no kept
+    neighbours at all gets a sentinel above `N_BDY_LAYERS`, so the caller's
+    keep-filter drops it.
     """
-    zone_ext = np.append(zone, _NO_NEIGHBOUR)          # index n_cells == "none"
+    zone_ext = np.append(zone, -1)                     # index n_cells == "none"
     idx = np.where(cells_on > 0, cells_on - 1, zone_ext.shape[0] - 1)
-    per_side = np.where(zone_ext[idx] >= 0, zone_ext[idx], _NO_NEIGHBOUR)
-    return per_side.min(axis=1)
+    side_zone = zone_ext[idx]
+    reached = side_zone >= 0
+    n_reached = reached.sum(axis=1)
+
+    min_reached = np.where(reached, side_zone, N_BDY_LAYERS + 1).min(axis=1)
+    max_reached = np.where(reached, side_zone, -1).max(axis=1)
+    all_reached = n_reached == cells_on.shape[1]
+
+    result = np.where(all_reached, min_reached, max_reached)
+    result = np.where(n_reached == 0, _NO_NEIGHBOUR, result)
+    return result
 
 
 def _spherical_centroid(lon_deg: np.ndarray, lat_deg: np.ndarray) -> tuple[float, float]:

--- a/src/gmpas/prep/region.py
+++ b/src/gmpas/prep/region.py
@@ -34,6 +34,15 @@ The shape:
    `write_graph_info` -- since there is no `mkgrid` run to produce one, as
    there is for a freshly generated global mesh.
 
+`plot_region` renders the cropped mesh coloured by `bdyMaskCell`, as a quick
+visual check that the kept cells and relaxation rings look right -- reusing
+`plot.cell_field` rather than a custom rendering path, unlike `scale.py`'s
+`plot_comparison`: that one needs two different meshes side by side on a
+shared colour scale, which `cell_field` doesn't support, but this is a
+single mesh and a single field, exactly `cell_field`'s own shape. matplotlib
+and cartopy are imported lazily inside it only, same as everywhere else in
+gmpas that draws -- `create_region` itself never needs them.
+
 A concave region (or one spanning a pole or a large longitude range on a
 `grid.nc`, before static interpolation) can produce incorrect terrain during
 `init_atmosphere`'s static-field interpolation -- a property of that
@@ -410,3 +419,29 @@ def write_graph_info(regional_mesh_path: str | Path, out_path: str | Path) -> Pa
             row = cells_on_cell[c, : n_edges_on_cell[c]]
             f.write(" ".join(str(int(n)) for n in row if n > 0) + "\n")
     return out_path
+
+
+# --------------------------------------------------------------- comparison
+
+def plot_region(regional_mesh_path: str | Path, out_png: str | Path) -> Path:
+    """Render the cropped mesh coloured by `bdyMaskCell` -- 0 for the
+    untouched interior, up through `N_BDY_LAYERS` at the outer edge -- a
+    quick visual check that `create_region` kept the right cells and that
+    the relaxation rings form actual rings, not a smear. Returns the PNG
+    path.
+    """
+    from ..mesh import MpasMesh
+    from ..plot import cell_field
+    from ..style import Style, save_figure
+
+    path = resolve_path(regional_mesh_path)
+    with xr.open_dataset(path, decode_timedelta=False, engine="netcdf4") as ds:
+        zone = ds["bdyMaskCell"].values
+
+    mesh = MpasMesh.load(path)
+    fig, _ = cell_field(
+        mesh, zone, style=Style.preset("mesh"), vmin=0, vmax=N_BDY_LAYERS,
+        label=f"boundary zone (0 = interior, {N_BDY_LAYERS} = edge)",
+        title=f"{mesh.n_cells:,} cells, {N_BDY_LAYERS} relaxation rings",
+    )
+    return save_figure(fig, out_png)

--- a/src/gmpas/prep/region.py
+++ b/src/gmpas/prep/region.py
@@ -1,0 +1,394 @@
+"""Crop a global (or larger regional) mesh down to a boundary-defined subset.
+
+Independent implementation -- not a port. MPAS-Dev/MPAS-Limited-Area does
+the same job and is the tool referenced from `gmpas prep scale`'s docs, but
+carries no LICENSE file (no explicit grant to redistribute or adapt its
+source), unlike MPAS-Tools (used for `scale`/`relocate`), which is
+permissively licensed. So this module is built from first principles --
+graph traversal over `cellsOnCell` -- and from MPAS-Model's own public
+Registry.xml/Fortran source for the one piece that is a real file-format
+contract with the model, not an implementation detail: see `N_SPEC_ZONE`/
+`N_RELAX_ZONE` below.
+
+The shape:
+
+1. Snap each boundary polygon vertex to its nearest cell (a cKDTree over
+   cell centres, same technique `mesh.py`'s `MpasMesh.cell_of` already uses
+   elsewhere in this package).
+2. Walk the mesh graph between consecutive boundary cells, staying close to
+   the great-circle arc between them -- `_walk_boundary`.
+3. Flood-fill from an interior point out to that boundary -- `_flood_fill`.
+   Together, 2 and 3 mark every cell inside the requested polygon as
+   relaxation zone 0.
+4. Grow `N_BDY_LAYERS` more rings of cells outward beyond the polygon --
+   `_relaxation_zones` -- these are the cells `init_atmosphere`/the
+   atmosphere core relax toward driving boundary data at runtime, not part
+   of what the user asked for but required for the regional file to be
+   usable.
+5. Derive `bdyMaskEdge`/`bdyMaskVertex` from the cell zones -- `_edge_zone`/
+   `_vertex_zone`.
+6. Subset every variable to the kept cells/edges/vertices and renumber every
+   connectivity array from the old (global) index space to the new one,
+   preserving the 1-based/0-fill convention -- `_subset_and_remap`.
+7. Write a `graph.info` METIS adjacency file for the regional subset --
+   `write_graph_info` -- since there is no `mkgrid` run to produce one, as
+   there is for a freshly generated global mesh.
+
+A concave region (or one spanning a pole or a large longitude range on a
+`grid.nc`, before static interpolation) can produce incorrect terrain during
+`init_atmosphere`'s static-field interpolation -- a property of that
+downstream interpolation, not of this cropping step, but worth keeping in
+mind when drawing `--polygon`. Prefer a convex boundary, or subset a
+`static.nc` (post-interpolation) instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from ..paths import resolve_path
+from .scale import great_circle_distance, lonlat_to_xyz, xyz_to_lonlat
+
+#: MPAS-Model's own boundary-zone layout (mpas_atm_boundaries.F,
+#: mpas_init_atm_cases.F): the outermost `N_SPEC_ZONE` layers are
+#: prescribed directly from driving boundary data every step; the
+#: `N_RELAX_ZONE` layers inward of those are blended toward it with
+#: decreasing weight. `bdyMaskCell` is registered in Registry.xml with
+#: `default_value="0"`, and `blend_bdy_terrain`'s own docstring states "for
+#: global meshes, where bdyMaskCell == 0 everywhere, this routine will have
+#: no impact" -- 0 is the deep interior, unrelated to the boundary, not a
+#: "dropped" sentinel. This is a file-format contract with the model, not an
+#: implementation choice: getting it wrong produces a file MPAS accepts but
+#: relaxes incorrectly, silently.
+N_SPEC_ZONE = 2
+N_RELAX_ZONE = 5
+N_BDY_LAYERS = N_SPEC_ZONE + N_RELAX_ZONE   # 7
+
+#: value used to mean "no kept neighbour on this side" in the zone-of-edge/
+#: vertex reductions below -- must sort after every real zone value (0..7)
+_NO_NEIGHBOUR = N_BDY_LAYERS + 1
+
+#: connectivity variables and the id-space their *values* belong to (as
+#: opposed to the dimension they are indexed *by* -- e.g. `verticesOnCell`
+#: is indexed by nCells but its entries are vertex ids). Only variables
+#: present in a given mesh are touched.
+CONNECTIVITY_VARS = {
+    "cellsOnCell": "nCells", "cellsOnEdge": "nCells", "cellsOnVertex": "nCells",
+    "indexToCellID": "nCells",
+    "edgesOnCell": "nEdges", "edgesOnEdge": "nEdges", "edgesOnVertex": "nEdges",
+    "indexToEdgeID": "nEdges",
+    "verticesOnCell": "nVertices", "verticesOnEdge": "nVertices",
+    "indexToVertexID": "nVertices",
+}
+
+#: variables `create_region` needs to read directly, beyond mesh identity
+REQUIRED_VARS = (
+    "latCell", "lonCell", "xCell", "yCell", "zCell",
+    "nEdgesOnCell", "cellsOnCell", "verticesOnCell", "edgesOnCell",
+    "cellsOnEdge", "verticesOnEdge", "cellsOnVertex", "edgesOnVertex",
+)
+
+
+# --------------------------------------------------------------- geometry
+
+def _ragged_neighbours(cells_on_cell: np.ndarray, n_edges_on_cell: np.ndarray,
+                       cell: int) -> np.ndarray:
+    """0-based neighbour cell ids of `cell`, its ragged tail and any
+    "no neighbour" (0) slots dropped."""
+    row = cells_on_cell[cell, : n_edges_on_cell[cell]]
+    return row[row > 0] - 1
+
+
+def _nearest_cells(cell_xyz: np.ndarray, lon_deg: np.ndarray,
+                   lat_deg: np.ndarray) -> np.ndarray:
+    """0-based index of the cell nearest each (lon_deg, lat_deg) point."""
+    from scipy.spatial import cKDTree
+
+    pts = lonlat_to_xyz(np.radians(lon_deg), np.radians(lat_deg))
+    return cKDTree(cell_xyz).query(np.atleast_2d(pts))[1]
+
+
+def _walk_boundary(cells_on_cell: np.ndarray, n_edges_on_cell: np.ndarray,
+                   cell_xyz: np.ndarray, boundary_cells: np.ndarray) -> np.ndarray:
+    """Cells along the closed path connecting consecutive boundary cells,
+    each segment staying close to the great-circle arc between its
+    endpoints. Returns a boolean mask over all cells.
+
+    Each step must strictly not increase the great-circle distance to the
+    segment's target -- among neighbours that satisfy that, the one closest
+    to the source/target great-circle plane is taken. The distance
+    constraint guarantees termination on a finite mesh; ties are broken by
+    lowest cell index, for determinism.
+    """
+    n_cells = cell_xyz.shape[0]
+    on_boundary = np.zeros(n_cells, dtype=bool)
+    on_boundary[boundary_cells] = True
+
+    n = len(boundary_cells)
+    for k in range(n):
+        source, target = int(boundary_cells[k]), int(boundary_cells[(k + 1) % n])
+        if source == target:
+            continue
+
+        normal = np.cross(cell_xyz[source], cell_xyz[target])
+        norm = np.linalg.norm(normal)
+        if norm < 1e-9:
+            raise ValueError(
+                "gmpas prep create-region: two boundary points are "
+                "antipodal (or nearly so), which leaves the great-circle "
+                "arc between them undefined. Add an intermediate boundary "
+                "point between them."
+            )
+        normal = normal / norm
+
+        current = source
+        target_xyz = cell_xyz[target]
+        steps = 0
+        while current != target:
+            steps += 1
+            if steps > n_cells:
+                raise ValueError(
+                    "gmpas prep create-region: the boundary walk did not "
+                    "reach its target cell within the mesh size -- the "
+                    "mesh may be disconnected between these two points."
+                )
+            dist_current = great_circle_distance(cell_xyz[current], target_xyz)
+            candidates = _ragged_neighbours(cells_on_cell, n_edges_on_cell, current)
+            if candidates.size == 0:
+                raise ValueError(
+                    f"gmpas prep create-region: cell {current} has no "
+                    f"neighbours while walking the boundary."
+                )
+            dist_to_target = great_circle_distance(cell_xyz[candidates], target_xyz)
+            progressing = candidates[dist_to_target <= dist_current + 1e-12]
+            if progressing.size == 0:
+                raise ValueError(
+                    "gmpas prep create-region: the boundary walk got stuck "
+                    "with no neighbour making progress toward the next "
+                    "boundary point -- the mesh may be too coarse for "
+                    "this boundary, or the points too close together."
+                )
+            deviation = np.abs(cell_xyz[progressing] @ normal)
+            current = int(progressing[np.argmin(deviation)])
+            on_boundary[current] = True
+
+    return on_boundary
+
+
+def _flood_fill(cells_on_cell: np.ndarray, n_edges_on_cell: np.ndarray,
+                start_cell: int, on_boundary: np.ndarray) -> np.ndarray:
+    """Every cell reachable from `start_cell` without crossing `on_boundary`
+    -- the requested region's interior, plus the boundary path itself."""
+    in_region = on_boundary.copy()
+    in_region[start_cell] = True
+    stack = [start_cell]
+    while stack:
+        cell = stack.pop()
+        for neighbour in _ragged_neighbours(cells_on_cell, n_edges_on_cell, cell):
+            if not in_region[neighbour]:
+                in_region[neighbour] = True
+                stack.append(int(neighbour))
+    return in_region
+
+
+def _relaxation_zones(cells_on_cell: np.ndarray, n_edges_on_cell: np.ndarray,
+                      in_region: np.ndarray, n_layers: int) -> np.ndarray:
+    """Zone index per cell: 0 for `in_region`, 1..n_layers outward from it
+    by graph distance, -1 for cells never reached (dropped from the
+    subset). Vectorized multi-source BFS -- one array pass per layer,
+    rather than a per-cell Python loop, so this stays fast on a real
+    (possibly multi-million-cell) global mesh.
+    """
+    n_cells = in_region.shape[0]
+    max_edges = cells_on_cell.shape[1]
+    zone = np.where(in_region, 0, -1)
+
+    valid_col = np.arange(max_edges)[None, :] < n_edges_on_cell[:, None]
+    frontier = in_region.copy()
+    for layer in range(1, n_layers + 1):
+        rows = np.flatnonzero(frontier)
+        if rows.size == 0:
+            break
+        cand = cells_on_cell[rows]
+        cand_valid = valid_col[rows] & (cand > 0)
+        newly = np.unique(cand[cand_valid]) - 1
+        newly = newly[zone[newly] == -1]
+        if newly.size == 0:
+            frontier = np.zeros(n_cells, dtype=bool)
+            continue
+        zone[newly] = layer
+        frontier = np.zeros(n_cells, dtype=bool)
+        frontier[newly] = True
+
+    return zone
+
+
+def _neighbour_zone(zone: np.ndarray, cells_on: np.ndarray) -> np.ndarray:
+    """The minimum zone among a row's kept (>= 0) neighbour cells --
+    `bdyMaskEdge`/`bdyMaskVertex` take the more-interior (lower) of their
+    adjoining cells' zones, following the actual boundary inward. A side
+    with no kept cell at all (0-fill, or a neighbour this crop dropped)
+    contributes `_NO_NEIGHBOUR`, so it never wins the min unless every side
+    is like that -- which means this edge/vertex is dropped too.
+    """
+    zone_ext = np.append(zone, _NO_NEIGHBOUR)          # index n_cells == "none"
+    idx = np.where(cells_on > 0, cells_on - 1, zone_ext.shape[0] - 1)
+    per_side = np.where(zone_ext[idx] >= 0, zone_ext[idx], _NO_NEIGHBOUR)
+    return per_side.min(axis=1)
+
+
+def _spherical_centroid(lon_deg: np.ndarray, lat_deg: np.ndarray) -> tuple[float, float]:
+    """A reasonable default interior point for a polygon: the mean of its
+    vertices' unit-sphere xyz, renormalized and projected back. Exact for a
+    regular/convex polygon's centre; a caller with a concave or unusual
+    shape should pass `--point` explicitly instead."""
+    xyz = lonlat_to_xyz(np.radians(lon_deg), np.radians(lat_deg)).mean(axis=0)
+    lon, lat = xyz_to_lonlat(xyz)
+    return float(np.degrees(lon)), float(np.degrees(lat))
+
+
+# ---------------------------------------------------------- subset/remap
+
+def _build_remap(kept_0based: np.ndarray, n_total: int) -> np.ndarray:
+    """`remap[v]` for a raw 1-based-with-0-fill value `v`: 0 stays 0 (no
+    neighbour); a kept old index becomes its new 1-based position; a
+    dropped old index becomes 0 (its former neighbours now have no
+    neighbour on that side, same convention as a true mesh edge)."""
+    new_id = np.zeros(n_total, dtype=np.int64)
+    new_id[kept_0based] = np.arange(1, kept_0based.size + 1)
+    return np.concatenate([[0], new_id])
+
+
+def _subset_and_remap(ds: xr.Dataset, kept: dict[str, np.ndarray]) -> xr.Dataset:
+    """Subset every variable to `kept` indices per dimension and renumber
+    every connectivity array's values into the new index space."""
+    isel = {dim: idx for dim, idx in kept.items() if dim in ds.dims}
+    out = ds.isel(**isel)
+
+    remaps = {dim: _build_remap(idx, ds.sizes[dim]) for dim, idx in isel.items()}
+    for name, id_space in CONNECTIVITY_VARS.items():
+        if name in out.variables and id_space in remaps:
+            da = out[name]
+            remapped = remaps[id_space][da.values]
+            out[name] = (da.dims, remapped.astype(da.dtype), da.attrs)
+
+    return out
+
+
+# ---------------------------------------------------------------- orchestrator
+
+def create_region(mesh_path: str | Path, out_path: str | Path,
+                  boundary_lat_deg, boundary_lon_deg,
+                  point_lat_deg: float | None = None,
+                  point_lon_deg: float | None = None) -> Path:
+    """Crop `mesh_path` to the region bounded by the polygon
+    (`boundary_lat_deg`, `boundary_lon_deg`) -- at least 3 vertices, in
+    order (winding direction does not matter; the boundary walk and flood
+    fill do not depend on it) -- plus `N_BDY_LAYERS` rings of relaxation
+    cells beyond it, and write the result to `out_path`.
+
+    `point_lat_deg`/`point_lon_deg` name a point known to be inside the
+    boundary; left as None, the polygon's spherical centroid is used, which
+    is only reliable for a convex (or nearly so) boundary -- pass it
+    explicitly for a concave or oddly-shaped region.
+
+    Works on a global or an already-regional input mesh, at any
+    `sphere_radius` -- this never touches position, only connectivity.
+    Writes a whole new file; `mesh_path` is never touched. Call
+    `write_graph_info` afterward for the accompanying `graph.info`
+    partition file.
+    """
+    src = resolve_path(mesh_path)
+    if not src.exists():
+        raise FileNotFoundError(f"No such mesh file: {src}")
+
+    boundary_lat_deg = np.atleast_1d(np.asarray(boundary_lat_deg, dtype=np.float64))
+    boundary_lon_deg = np.atleast_1d(np.asarray(boundary_lon_deg, dtype=np.float64))
+    if boundary_lat_deg.size < 3:
+        raise ValueError(
+            f"gmpas prep create-region needs at least 3 boundary points to "
+            f"define a region, got {boundary_lat_deg.size}."
+        )
+
+    with xr.open_dataset(src, decode_timedelta=False, engine="netcdf4") as ds:
+        missing = [v for v in REQUIRED_VARS if v not in ds.variables]
+        if missing:
+            raise KeyError(f"{src.name} cannot be cropped: missing {missing}.")
+        ds = ds.load()
+
+    cell_xyz = np.stack([ds["xCell"].values, ds["yCell"].values,
+                         ds["zCell"].values], axis=-1)
+    cell_xyz = cell_xyz / np.linalg.norm(cell_xyz, axis=-1, keepdims=True)
+
+    if point_lat_deg is None or point_lon_deg is None:
+        point_lon_deg, point_lat_deg = _spherical_centroid(
+            boundary_lon_deg, boundary_lat_deg)
+
+    cells_on_cell = ds["cellsOnCell"].values.astype(np.int64)
+    n_edges_on_cell = ds["nEdgesOnCell"].values.astype(np.int64)
+
+    boundary_cells = _nearest_cells(cell_xyz, boundary_lon_deg, boundary_lat_deg)
+    on_boundary = _walk_boundary(cells_on_cell, n_edges_on_cell, cell_xyz, boundary_cells)
+
+    start_cell = int(_nearest_cells(cell_xyz, np.array([point_lon_deg]),
+                                    np.array([point_lat_deg]))[0])
+    in_region = _flood_fill(cells_on_cell, n_edges_on_cell, start_cell, on_boundary)
+    if in_region.all():
+        raise ValueError(
+            "gmpas prep create-region: the flood fill reached the whole "
+            "mesh -- either --point is outside the --polygon boundary "
+            "rather than inside it, or the polygon's vertices are too "
+            "close together to form a real wall on this mesh (each "
+            "consecutive pair should snap to a different cell)."
+        )
+
+    cell_zone = _relaxation_zones(cells_on_cell, n_edges_on_cell, in_region, N_BDY_LAYERS)
+    edge_zone = _neighbour_zone(cell_zone, ds["cellsOnEdge"].values.astype(np.int64))
+    vertex_zone = _neighbour_zone(cell_zone, ds["cellsOnVertex"].values.astype(np.int64))
+
+    kept = {
+        "nCells": np.flatnonzero(cell_zone >= 0),
+        "nEdges": np.flatnonzero(edge_zone <= N_BDY_LAYERS),
+        "nVertices": np.flatnonzero(vertex_zone <= N_BDY_LAYERS),
+    }
+
+    out = _subset_and_remap(ds, kept)
+    out["bdyMaskCell"] = ("nCells", cell_zone[kept["nCells"]].astype(np.int32))
+    out["bdyMaskEdge"] = ("nEdges", edge_zone[kept["nEdges"]].astype(np.int32))
+    out["bdyMaskVertex"] = ("nVertices", vertex_zone[kept["nVertices"]].astype(np.int32))
+
+    out_path = Path(out_path).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out.to_netcdf(out_path)
+    return out_path
+
+
+def write_graph_info(regional_mesh_path: str | Path, out_path: str | Path) -> Path:
+    """Write a METIS `graph.info` adjacency file for a mesh produced by
+    `create_region` -- there is no `mkgrid` run over a cropped subset to
+    produce one, unlike a freshly generated global mesh.
+
+    Format: a header line `nCells nInteriorEdges`, then one line per cell
+    listing its neighbour cells' (1-based) ids -- the standard METIS graph
+    format `gpmetis` reads directly.
+    """
+    with xr.open_dataset(resolve_path(regional_mesh_path), decode_timedelta=False,
+                         engine="netcdf4") as ds:
+        n_cells = ds.sizes["nCells"]
+        n_edges_on_cell = ds["nEdgesOnCell"].values
+        cells_on_cell = ds["cellsOnCell"].values
+        cells_on_edge = ds["cellsOnEdge"].values
+
+    n_interior_edges = int(((cells_on_edge[:, 0] > 0) & (cells_on_edge[:, 1] > 0)).sum())
+
+    out_path = Path(out_path).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        f.write(f"{n_cells} {n_interior_edges}\n")
+        for c in range(n_cells):
+            row = cells_on_cell[c, : n_edges_on_cell[c]]
+            f.write(" ".join(str(int(n)) for n in row if n > 0) + "\n")
+    return out_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,186 @@ def write_mesh(path, centres, *, n_verts=None, radius_deg=1.0,
     return path
 
 
+def write_grid_mesh(path, nrows, ncols, *, lon0_deg=0.0, lat0_deg=0.0,
+                    dlon_deg=2.0, dlat_deg=2.0, sphere_radius=1.0):
+    """Write a small structured lon/lat quad-lattice mesh, in MPAS's file
+    format, with *genuine* shared connectivity -- unlike `write_mesh`, whose
+    cells each own a private, unshared ring of vertices/edges and which has
+    no `cellsOnCell` at all.
+
+    `region.py`'s algorithm (flood fill, boundary walk, relaxation layers)
+    is pure graph traversal over `cellsOnCell`; a fixture with fake adjacency
+    would let a wrong traversal pass. This one is a real (if non-hexagonal)
+    mesh graph: `nrows` x `ncols` cells, each cell's 4 corners are vertices
+    shared with its diagonal/orthogonal neighbours, each edge shared by
+    exactly the 2 cells on either side of it (0 on the side beyond the
+    lattice's own edge -- there is no wraparound, so this is a regional
+    patch, not a closed global mesh).
+
+    Cell (i, j)'s corners/edges, CCW from the SW corner, in MPAS's own
+    "verticesOnCell[k]/edgesOnCell[k] straddle the edge to cellsOnCell[k]"
+    convention: south (row i-1), east (col j+1), north (row i+1), west
+    (col j-1).
+
+    Includes `indexToCellID`/`indexToEdgeID`/`indexToVertexID` and the
+    `on_a_sphere`/`sphere_radius` global attributes -- not needed by
+    `region.py` itself, but required by `MeshHandler._load_vars` in the
+    external MPAS-Limited-Area comparison harness, so the same file drives
+    both.
+    """
+    n_cells = nrows * ncols
+    n_vertices = (nrows + 1) * (ncols + 1)
+    n_hrow = (nrows + 1) * ncols          # horizontal edges (constant row)
+    n_vcol = nrows * (ncols + 1)          # vertical edges (constant column)
+    n_edges = n_hrow + n_vcol
+    max_edges = 4
+    vertex_degree = 4
+
+    def cell_id(i, j):
+        return i * ncols + j if 0 <= i < nrows and 0 <= j < ncols else -1
+
+    def vtx_id(i, j):
+        return i * (ncols + 1) + j
+
+    def hrow_id(i, j):
+        return i * ncols + j
+
+    def vcol_id(i, j):
+        return n_hrow + i * (ncols + 1) + j
+
+    def to_xyz(lon_deg, lat_deg):
+        lr, gr = np.radians(lat_deg), np.radians(lon_deg)
+        return (np.cos(lr) * np.cos(gr) * sphere_radius,
+               np.cos(lr) * np.sin(gr) * sphere_radius,
+               np.sin(lr) * sphere_radius)
+
+    # -- cells --------------------------------------------------------
+    lon_c = np.zeros(n_cells)
+    lat_c = np.zeros(n_cells)
+    n_edges_on_cell = np.full(n_cells, max_edges, dtype=np.int32)
+    coc = np.zeros((n_cells, max_edges), dtype=np.int32)   # cellsOnCell
+    voc = np.zeros((n_cells, max_edges), dtype=np.int32)   # verticesOnCell
+    eoc = np.zeros((n_cells, max_edges), dtype=np.int32)   # edgesOnCell
+
+    for i in range(nrows):
+        for j in range(ncols):
+            c = cell_id(i, j)
+            lon_c[c] = lon0_deg + j * dlon_deg
+            lat_c[c] = lat0_deg + i * dlat_deg
+            corners = [vtx_id(i, j), vtx_id(i, j + 1),
+                      vtx_id(i + 1, j + 1), vtx_id(i + 1, j)]
+            edges = [hrow_id(i, j), vcol_id(i, j + 1),
+                    hrow_id(i + 1, j), vcol_id(i, j)]
+            neighbours = [cell_id(i - 1, j), cell_id(i, j + 1),
+                         cell_id(i + 1, j), cell_id(i, j - 1)]
+            voc[c] = [v + 1 for v in corners]
+            eoc[c] = [e + 1 for e in edges]
+            coc[c] = [n + 1 if n >= 0 else 0 for n in neighbours]
+
+    # -- vertices -------------------------------------------------------
+    lon_v = np.zeros(n_vertices)
+    lat_v = np.zeros(n_vertices)
+    cov = np.zeros((n_vertices, vertex_degree), dtype=np.int32)  # cellsOnVertex
+    eov = np.zeros((n_vertices, vertex_degree), dtype=np.int32)  # edgesOnVertex
+
+    for i in range(nrows + 1):
+        for j in range(ncols + 1):
+            v = vtx_id(i, j)
+            lon_v[v] = lon0_deg + (j - 0.5) * dlon_deg
+            lat_v[v] = lat0_deg + (i - 0.5) * dlat_deg
+            around_cells = [cell_id(i, j), cell_id(i, j - 1),
+                            cell_id(i - 1, j - 1), cell_id(i - 1, j)]
+            cov[v, :] = [c + 1 if c >= 0 else 0 for c in around_cells]
+            around_edges = []
+            around_edges.append(hrow_id(i, j - 1) if j - 1 >= 0 else -1)
+            around_edges.append(hrow_id(i, j) if j < ncols else -1)
+            around_edges.append(vcol_id(i - 1, j) if i - 1 >= 0 else -1)
+            around_edges.append(vcol_id(i, j) if i < nrows else -1)
+            eov[v, :] = [e + 1 if e >= 0 else 0 for e in around_edges]
+
+    # -- edges ------------------------------------------------------------
+    lon_e = np.zeros(n_edges)
+    lat_e = np.zeros(n_edges)
+    coe = np.zeros((n_edges, 2), dtype=np.int32)   # cellsOnEdge
+    voe = np.zeros((n_edges, 2), dtype=np.int32)   # verticesOnEdge
+
+    for i in range(nrows + 1):
+        for j in range(ncols):
+            e = hrow_id(i, j)
+            lon_e[e] = lon0_deg + j * dlon_deg
+            lat_e[e] = lat0_deg + (i - 0.5) * dlat_deg
+            south, north = cell_id(i - 1, j), cell_id(i, j)
+            coe[e] = [south + 1 if south >= 0 else 0,
+                     north + 1 if north >= 0 else 0]
+            voe[e] = [vtx_id(i, j) + 1, vtx_id(i, j + 1) + 1]
+
+    for i in range(nrows):
+        for j in range(ncols + 1):
+            e = vcol_id(i, j)
+            lon_e[e] = lon0_deg + (j - 0.5) * dlon_deg
+            lat_e[e] = lat0_deg + i * dlat_deg
+            west, east = cell_id(i, j - 1), cell_id(i, j)
+            coe[e] = [west + 1 if west >= 0 else 0,
+                     east + 1 if east >= 0 else 0]
+            voe[e] = [vtx_id(i, j) + 1, vtx_id(i + 1, j) + 1]
+
+    # edgesOnEdge -- every edge adjoining either of this edge's two cells,
+    # other than itself. Order/exact membership isn't semantically load
+    # -bearing anywhere in region.py; it only needs to be a valid, ragged,
+    # 1-based-with-0-fill array of edge ids for the generic connectivity
+    # -remap path to exercise.
+    max_edges2 = 2 * max_edges
+    eoe = np.zeros((n_edges, max_edges2), dtype=np.int32)
+    for e in range(n_edges):
+        neighbours = []
+        for c0 in coe[e]:
+            if c0 == 0:
+                continue
+            neighbours.extend(int(x) for x in eoc[c0 - 1] if x != 0 and x != e + 1)
+        neighbours = neighbours[:max_edges2]
+        eoe[e, :len(neighbours)] = neighbours
+
+    xc, yc, zc = to_xyz(lon_c, lat_c)
+    xv, yv, zv = to_xyz(lon_v, lat_v)
+    xe, ye, ze = to_xyz(lon_e, lat_e)
+
+    def rad360(deg):
+        return np.radians(np.asarray(deg) % 360.0)
+
+    def rad(deg):
+        return np.radians(np.asarray(deg))
+
+    ds = xr.Dataset(
+        {
+            "latCell": ("nCells", rad(lat_c)), "lonCell": ("nCells", rad360(lon_c)),
+            "xCell": ("nCells", xc), "yCell": ("nCells", yc), "zCell": ("nCells", zc),
+            "nEdgesOnCell": ("nCells", n_edges_on_cell),
+            "cellsOnCell": (("nCells", "maxEdges"), coc),
+            "verticesOnCell": (("nCells", "maxEdges"), voc),
+            "edgesOnCell": (("nCells", "maxEdges"), eoc),
+            "indexToCellID": ("nCells", np.arange(1, n_cells + 1, dtype=np.int32)),
+            "latVertex": ("nVertices", rad(lat_v)),
+            "lonVertex": ("nVertices", rad360(lon_v)),
+            "xVertex": ("nVertices", xv), "yVertex": ("nVertices", yv),
+            "zVertex": ("nVertices", zv),
+            "cellsOnVertex": (("nVertices", "vertexDegree"), cov),
+            "edgesOnVertex": (("nVertices", "vertexDegree"), eov),
+            "indexToVertexID": ("nVertices", np.arange(1, n_vertices + 1, dtype=np.int32)),
+            "latEdge": ("nEdges", rad(lat_e)), "lonEdge": ("nEdges", rad360(lon_e)),
+            "xEdge": ("nEdges", xe), "yEdge": ("nEdges", ye), "zEdge": ("nEdges", ze),
+            "cellsOnEdge": (("nEdges", "TWO"), coe),
+            "verticesOnEdge": (("nEdges", "TWO"), voe),
+            "edgesOnEdge": (("nEdges", "maxEdges2"), eoe),
+            "indexToEdgeID": ("nEdges", np.arange(1, n_edges + 1, dtype=np.int32)),
+        },
+        attrs={"sphere_radius": float(sphere_radius), "on_a_sphere": "YES",
+              "is_periodic": "NO"},
+    )
+    ds.to_netcdf(path)
+    ds.close()
+    return path
+
+
 @pytest.fixture
 def simple_mesh_file(tmp_path):
     """Four well-separated cells over the Maritime Continent, all hexagons."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,6 +343,12 @@ def write_grid_mesh(path, nrows, ncols, *, lon0_deg=0.0, lat0_deg=0.0,
         {
             "latCell": ("nCells", rad(lat_c)), "lonCell": ("nCells", rad360(lon_c)),
             "xCell": ("nCells", xc), "yCell": ("nCells", yc), "zCell": ("nCells", zc),
+            # a uniform solid-angle-rectangle approximation is plenty for a
+            # synthetic quad lattice -- nothing here checks areaCell's exact
+            # value, only that it exists and is positive (MpasMesh._build
+            # reads it unconditionally for cell_width_km)
+            "areaCell": ("nCells", np.full(
+                n_cells, np.radians(dlon_deg) * np.radians(dlat_deg) * sphere_radius ** 2)),
             "nEdgesOnCell": ("nCells", n_edges_on_cell),
             "cellsOnCell": (("nCells", "maxEdges"), coc),
             "verticesOnCell": (("nCells", "maxEdges"), voc),
@@ -357,6 +363,10 @@ def write_grid_mesh(path, nrows, ncols, *, lon0_deg=0.0, lat0_deg=0.0,
             "indexToVertexID": ("nVertices", np.arange(1, n_vertices + 1, dtype=np.int32)),
             "latEdge": ("nEdges", rad(lat_e)), "lonEdge": ("nEdges", rad360(lon_e)),
             "xEdge": ("nEdges", xe), "yEdge": ("nEdges", ye), "zEdge": ("nEdges", ze),
+            # not meaningful for a quad lattice's Hrow/Vcol edges (nothing
+            # here checks its value) -- present only because MpasMesh._build
+            # reads it unconditionally
+            "angleEdge": ("nEdges", np.zeros(n_edges)),
             "cellsOnEdge": (("nEdges", "TWO"), coe),
             "verticesOnEdge": (("nEdges", "TWO"), voe),
             "edgesOnEdge": (("nEdges", "maxEdges2"), eoe),

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,210 @@
+"""Cropping a global mesh to a boundary-defined regional subset."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from conftest import write_grid_mesh
+from gmpas.cli import main
+from gmpas.prep.region import (
+    N_BDY_LAYERS,
+    _flood_fill,
+    _relaxation_zones,
+    _walk_boundary,
+    create_region,
+    write_graph_info,
+)
+
+#: a 20x20 patch, 2 degrees per cell, is comfortably bigger than N_BDY_LAYERS
+#: (7) in every direction from a centred boundary, so a region drawn well
+#: inside it exercises every relaxation ring without hitting the patch's own
+#: (non-global, this is a regional test fixture) edge.
+GRID = dict(nrows=20, ncols=20, lon0_deg=0.0, lat0_deg=0.0,
+           dlon_deg=2.0, dlat_deg=2.0, sphere_radius=1.0)
+
+#: a 10x10-cell box roughly in the middle of the 20x20 patch
+BOX_LAT = [10.0, 10.0, 28.0, 28.0]
+BOX_LON = [10.0, 28.0, 28.0, 10.0]
+
+
+# ------------------------------------------------------------- graph algorithms
+
+def test_flood_fill_stops_at_the_boundary_wall(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    with xr.open_dataset(path, decode_timedelta=False) as ds:
+        coc = ds.cellsOnCell.values.astype(np.int64)
+        nec = ds.nEdgesOnCell.values.astype(np.int64)
+        cell_xyz = np.stack([ds.xCell.values, ds.yCell.values, ds.zCell.values], axis=-1)
+        cell_xyz = cell_xyz / np.linalg.norm(cell_xyz, axis=-1, keepdims=True)
+
+    # a small square loop, cell ids for grid corners (5,5) (5,8) (8,8) (8,5)
+    # in a 20-wide row-major lattice (cell_id = row*20 + col)
+    loop = np.array([5 * 20 + 5, 5 * 20 + 8, 8 * 20 + 8, 8 * 20 + 5])
+    on_boundary = _walk_boundary(coc, nec, cell_xyz, loop)
+    in_region = _flood_fill(coc, nec, 0, on_boundary)   # cell 0 is far outside the loop
+    # the fill from outside the wall reaches every cell except the 2x2
+    # pocket the wall encloses -- it cannot leak through the wall to get there
+    enclosed = {6 * 20 + 6, 6 * 20 + 7, 7 * 20 + 6, 7 * 20 + 7}
+    assert set(np.flatnonzero(~in_region).tolist()) == enclosed
+
+
+def test_relaxation_zones_are_monotonic_rings_outward(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    with xr.open_dataset(path, decode_timedelta=False) as ds:
+        coc = ds.cellsOnCell.values.astype(np.int64)
+        nec = ds.nEdgesOnCell.values.astype(np.int64)
+
+    in_region = np.zeros(coc.shape[0], dtype=bool)
+    in_region[210] = True   # a single interior seed cell, row 10 col 10 of 20x20
+    zone = _relaxation_zones(coc, nec, in_region, N_BDY_LAYERS)
+
+    assert zone[210] == 0
+    # every direct neighbour of the seed is layer 1, not further out
+    for n in coc[210][coc[210] > 0]:
+        assert zone[n - 1] == 1
+    assert zone.max() == N_BDY_LAYERS
+    assert (zone == -1).any()   # cells far enough away are dropped entirely
+
+
+# --------------------------------------------------------------------- create_region
+
+def test_the_interior_is_zone_zero_and_nothing_exceeds_n_bdy_layers(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+
+    with xr.open_dataset(out, decode_timedelta=False) as ds:
+        assert ds.bdyMaskCell.values.min() == 0
+        assert ds.bdyMaskCell.values.max() <= N_BDY_LAYERS
+        assert (ds.bdyMaskCell.values == 0).sum() > 0
+
+
+def test_the_subset_is_smaller_than_the_source_mesh(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    with xr.open_dataset(path, decode_timedelta=False) as src:
+        n_cells_global = src.sizes["nCells"]
+
+    out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+    with xr.open_dataset(out, decode_timedelta=False) as ds:
+        assert 0 < ds.sizes["nCells"] < n_cells_global
+
+
+def test_connectivity_is_renumbered_with_no_dangling_or_out_of_range_ids(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+
+    with xr.open_dataset(out, decode_timedelta=False) as ds:
+        n_cells = ds.sizes["nCells"]
+        n_edges = ds.sizes["nEdges"]
+        n_vertices = ds.sizes["nVertices"]
+        assert ds.cellsOnCell.values.min() >= 0
+        assert ds.cellsOnCell.values.max() <= n_cells
+        assert ds.cellsOnEdge.values.min() >= 0
+        assert ds.cellsOnEdge.values.max() <= n_cells
+        assert ds.verticesOnCell.values.min() >= 0
+        assert ds.verticesOnCell.values.max() <= n_vertices
+        assert ds.edgesOnCell.values.min() >= 0
+        assert ds.edgesOnCell.values.max() <= n_edges
+        assert ds.cellsOnVertex.values.min() >= 0
+        assert ds.cellsOnVertex.values.max() <= n_cells
+        # every kept cell's own id, after renumbering, is exactly its new position
+        assert np.array_equal(ds.indexToCellID.values, np.arange(1, n_cells + 1))
+
+
+def test_an_edge_between_two_kept_cells_takes_the_more_interior_zone(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+
+    with xr.open_dataset(out, decode_timedelta=False) as ds:
+        coe = ds.cellsOnEdge.values
+        cell_zone = ds.bdyMaskCell.values
+        edge_zone = ds.bdyMaskEdge.values
+        both_kept = (coe[:, 0] > 0) & (coe[:, 1] > 0)
+        expected = np.minimum(cell_zone[coe[both_kept, 0] - 1],
+                              cell_zone[coe[both_kept, 1] - 1])
+        assert np.array_equal(edge_zone[both_kept], expected)
+
+
+def test_graph_info_header_matches_the_subset(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+    graph = write_graph_info(out, tmp_path / "graph.info")
+
+    with xr.open_dataset(out, decode_timedelta=False) as ds:
+        n_cells = ds.sizes["nCells"]
+        coe = ds.cellsOnEdge.values
+        expected_interior_edges = int(((coe[:, 0] > 0) & (coe[:, 1] > 0)).sum())
+
+    lines = graph.read_text().splitlines()
+    header_cells, header_edges = (int(x) for x in lines[0].split())
+    assert header_cells == n_cells
+    assert header_edges == expected_interior_edges
+    assert len(lines) == n_cells + 1
+
+
+def test_at_least_three_boundary_points_are_required(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    with pytest.raises(ValueError, match="at least 3"):
+        create_region(path, tmp_path / "region.nc", [10.0, 12.0], [10.0, 12.0])
+
+
+def test_a_degenerate_boundary_that_forms_no_wall_is_rejected(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    # three points close enough together to all snap to the same cell --
+    # no real wall, so the flood fill leaks across the entire mesh
+    with pytest.raises(ValueError, match="whole"):
+        create_region(path, tmp_path / "region.nc",
+                      [20.0, 20.001, 20.002], [20.0, 20.001, 20.002])
+
+
+def test_a_missing_variable_names_what_is_missing(tmp_path):
+    from conftest import write_mesh
+
+    path = write_mesh(tmp_path / "m.nc", [(100.0, 0.0)])   # no cellsOnCell at all
+    with pytest.raises(KeyError, match="cellsOnCell"):
+        create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+
+
+def test_a_missing_mesh_file_is_reported(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No such mesh file"):
+        create_region(tmp_path / "absent.nc", tmp_path / "region.nc", BOX_LAT, BOX_LON)
+
+
+# -------------------------------------------------------------------- CLI
+
+def test_cli_prep_create_region(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = tmp_path / "region.nc"
+
+    assert main(["prep", "create-region", str(path), "-o", str(out),
+                "--polygon", "10,10", "10,28", "28,28", "28,10"]) == 0
+    assert out.exists()
+    assert (tmp_path / "region.graph.info").exists()
+
+
+def test_cli_default_output_path_is_derived_from_the_input(tmp_path, monkeypatch):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["prep", "create-region", str(path),
+                "--polygon", "10,10", "10,28", "28,28", "28,10"]) == 0
+    assert (tmp_path / "m.region.nc").exists()
+
+
+def test_cli_rejects_a_polygon_point_that_is_not_a_lat_lon_pair(tmp_path, capsys):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+
+    assert main(["prep", "create-region", str(path),
+                "--polygon", "10,10", "not-a-point", "28,28"]) == 1
+    assert "'lat,lon' pairs" in capsys.readouterr().err
+
+
+def test_cli_accepts_an_explicit_interior_point(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = tmp_path / "region.nc"
+
+    assert main(["prep", "create-region", str(path), "-o", str(out),
+                "--polygon", "10,10", "10,28", "28,28", "28,10",
+                "--point", "19", "19"]) == 0
+    assert out.exists()

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -112,7 +112,11 @@ def test_connectivity_is_renumbered_with_no_dangling_or_out_of_range_ids(tmp_pat
         assert np.array_equal(ds.indexToCellID.values, np.arange(1, n_cells + 1))
 
 
-def test_an_edge_between_two_kept_cells_takes_the_more_interior_zone(tmp_path):
+def test_an_edge_fully_surrounded_by_kept_cells_takes_the_more_interior_zone(tmp_path):
+    """Covers only the all-neighbours-kept branch of `_neighbour_zone` -- an
+    edge always has exactly 2 sides, so it can never exercise the
+    some-neighbours-dropped branch on its own (see the vertex tests below,
+    and `_neighbour_zone`'s docstring, for why that needs 3+ sides)."""
     path = write_grid_mesh(tmp_path / "m.nc", **GRID)
     out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
 
@@ -124,6 +128,32 @@ def test_an_edge_between_two_kept_cells_takes_the_more_interior_zone(tmp_path):
         expected = np.minimum(cell_zone[coe[both_kept, 0] - 1],
                               cell_zone[coe[both_kept, 1] - 1])
         assert np.array_equal(edge_zone[both_kept], expected)
+
+
+def test_neighbour_zone_takes_the_min_when_every_side_is_kept():
+    from gmpas.prep.region import _neighbour_zone
+
+    zone = np.array([0, 3, 5, 2, -1])
+    cells_on = np.array([[1, 2, 3, 4]])   # all 4 sides kept: zones 0, 3, 5, 2
+    assert _neighbour_zone(zone, cells_on).tolist() == [0]
+
+
+def test_neighbour_zone_takes_the_max_when_a_side_is_missing_or_dropped():
+    """The case a 2-sided edge structurally cannot exercise: with at least
+    one side missing (0-fill) or dropped (beyond N_BDY_LAYERS, zone -1),
+    this element sits at the outer rim of whatever it does touch, so it
+    takes the *more boundary-like* (max) of its kept sides, not the min.
+    Kept sides here are zones {0, 5} (cell 1 and cell 3); a plain min
+    -of-kept, which is what an earlier version of this function did, would
+    wrongly give 0 instead of 5.
+    """
+    from gmpas.prep.region import _neighbour_zone
+
+    zone = np.array([0, 3, 5, 2, -1])
+    # 1-based cellsOnCell-style row: cell 1 (zone 0), cell 3 (zone 5),
+    # a 0-fill "no neighbour" slot, and cell 5 (zone -1, dropped)
+    cells_on = np.array([[1, 3, 0, 5]])
+    assert _neighbour_zone(zone, cells_on).tolist() == [5]
 
 
 def test_graph_info_header_matches_the_subset(tmp_path):

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -173,6 +173,46 @@ def test_graph_info_header_matches_the_subset(tmp_path):
     assert len(lines) == n_cells + 1
 
 
+# --------------------------------------------------------------- comparison
+
+def test_plot_region_writes_a_png(tmp_path):
+    pytest.importorskip("matplotlib", reason="needs the `plot` extra")
+    pytest.importorskip("cartopy", reason="needs the `plot` extra")
+    import matplotlib
+    matplotlib.use("Agg")
+    from gmpas.prep.region import plot_region
+
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = create_region(path, tmp_path / "region.nc", BOX_LAT, BOX_LON)
+
+    png = plot_region(out, tmp_path / "region.png")
+    assert png.exists()
+    assert png.stat().st_size > 0
+
+
+def test_cli_prep_create_region_writes_a_plot_by_default(tmp_path):
+    pytest.importorskip("matplotlib", reason="needs the `plot` extra")
+    pytest.importorskip("cartopy", reason="needs the `plot` extra")
+    import matplotlib
+    matplotlib.use("Agg")
+
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = tmp_path / "region.nc"
+
+    assert main(["prep", "create-region", str(path), "-o", str(out),
+                "--polygon", "10,10", "10,28", "28,28", "28,10"]) == 0
+    assert (tmp_path / "region.png").exists()
+
+
+def test_cli_no_plot_skips_the_png(tmp_path):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+    out = tmp_path / "region.nc"
+
+    assert main(["prep", "create-region", str(path), "-o", str(out), "--no-plot",
+                "--polygon", "10,10", "10,28", "28,28", "28,10"]) == 0
+    assert not (tmp_path / "region.png").exists()
+
+
 def test_at_least_three_boundary_points_are_required(tmp_path):
     path = write_grid_mesh(tmp_path / "m.nc", **GRID)
     with pytest.raises(ValueError, match="at least 3"):


### PR DESCRIPTION
Retargeted straight to \`main\` -- the original stacked PR (#53) merged into \`feat/prep-scale-regional-mesh\`, but that branch had already been merged into \`main\` via #51 before #53 landed, so its new commits never reached \`main\`. This branch already contains everything #53 merged, plus one more commit (the boundary-zone plot) pushed just after #53 closed. One clean PR, same content, nothing missing.

## Summary
- Adds \`gmpas prep create-region MESH --polygon lat,lon lat,lon ... [--point LAT LON] [-o OUT]\`: crops a global (or larger regional) mesh to the subset bounded by a boundary polygon, plus the relaxation-zone rings MPAS-Model requires beyond it. New module \`src/gmpas/prep/region.py\`.
- **Independent implementation, not a port** -- unlike \`prep scale\`/\`prep relocate\` (ported from MPAS-Tools, which is permissively licensed), the closest existing tool for this job, MPAS-Dev/MPAS-Limited-Area, carries no LICENSE file -- no explicit grant to adapt its source. Built instead from first principles: graph traversal over \`cellsOnCell\` (flood fill from an interior point, a geodesic boundary walk, a vectorized multi-source-BFS relaxation-zone pass), and from MPAS-Model's own public \`Registry.xml\`/Fortran source for \`bdyMaskCell\`'s zone semantics (\`nSpecZone=2\`, \`nRelaxZone=5\`, \`nBdyLayers=7\`) -- a real file-format contract with the atmosphere core, not a free implementation choice.
- Also writes the accompanying \`graph.info\` \`gpmetis\` partition file, since there's no \`mkgrid\` run over a cropped subset to produce one.
- **Writes a boundary-zone PNG by default** -- the cropped mesh coloured by \`bdyMaskCell\`, reusing \`plot.cell_field\` directly (a single mesh, single field -- exactly its shape, unlike \`scale\`'s two-mesh side-by-side comparison). Same \`--no-plot\`/\`--plot-out\` convention as \`prep scale\`.
- Filed against, and closes the gap described in, gmpas-lib#52.

## Validation
Rather than trust the independent implementation on its own, I cloned the actual MPAS-Dev/MPAS-Limited-Area tool and ran it **unmodified**, as a black-box oracle, against the same synthetic test mesh and boundary polygon (the clone/comparison never touched this package -- no code copied in). That surfaced two real bugs, both now fixed here:

1. **A bug in the reference tool itself.** Its cell/edge/vertex-marking loops never check for \`cellsOnCell == 0\` ("no neighbour") before using the value as an array index -- \`0 - 1 == -1\`, which Python/numpy silently wraps to the *last* element. This never triggers on a genuinely closed global mesh (no \`cellsOnCell\` is ever 0 there), but does on any mesh with a real "no neighbour" edge close enough to the region to matter -- which includes this repo's own non-global test fixture, and would equally affect the reference tool if fed an already-regional input mesh. Moving the test region away from the fixture's own edge makes cells and edges match the reference exactly, confirming this module's explicit \`row[row > 0]\` filtering is the correct behavior.
2. **A bug in this module**, caught by the same comparison: \`bdyMaskEdge\`/\`bdyMaskVertex\` should take the *max* (not min) of surrounding cells' zones when a neighbour is missing or dropped -- that side sits at the true outer rim, with nothing beyond it. A 2-sided edge can never expose this (one reached side makes min and max identical), which is why edges matched immediately while a few vertices (3-4 sides) didn't. Fixed, with a unit test against \`_neighbour_zone\` verified to fail under the old min-only rule.

After both fixes, \`bdyMaskCell\`/\`bdyMaskEdge\`/\`bdyMaskVertex\` match the unmodified reference tool **element-for-element** (matched by lat/lon, not just aggregate zone counts), on both a 20x20 and a 30x30 synthetic lattice.

Also adds a new test fixture, \`write_grid_mesh\` in \`conftest.py\`: a small structured quad-lattice mesh with genuine shared \`cellsOnCell\`/\`cellsOnEdge\`/\`cellsOnVertex\` connectivity. The existing \`write_mesh\` fixture has no \`cellsOnCell\` at all and gives each cell a private, unshared ring of vertices -- fine for \`scale\`/\`relocate\`'s array-indexing tests, but unusable for \`create-region\`'s graph algorithms (flood fill, boundary walk, relaxation layers), which is the first feature in this package where mesh topology itself is under test.

## Test plan
- [x] \`pytest tests/test_region.py -q\` -- 20 tests: graph-algorithm unit tests (\`_walk_boundary\`, \`_flood_fill\`, \`_relaxation_zones\`, both branches of \`_neighbour_zone\`), end-to-end \`create_region\` (interior/zone bounds, subset size, connectivity renumbering with no dangling ids, \`graph.info\` header), the boundary-zone plot (writes a PNG, \`--no-plot\` skips it), error paths (too few boundary points, a degenerate boundary that forms no wall, missing variables/file), and CLI smoke tests.
- [x] Full suite: \`pytest -q\` -- 361 passed, 5 skipped (pre-existing, ESMF-dependent), no regressions.
- [x] \`ruff check\` clean on every new/changed file.
- [x] Manual comparison against the unmodified MPAS-Limited-Area tool (see above) -- element-for-element match on all three boundary masks.
- [x] Rendered the boundary-zone plot manually and eyeballed it: a clean nested-square gradient from the interior (zone 0) out to the edge (zone 7), no smearing or gaps.

## Note
Filing the reference-tool indexing bug upstream on MPAS-Limited-Area would be a reasonable courtesy, separate from this PR -- not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)