### PR TITLE
Add gmpas prep create-region --pts: circle/ellipse/custom region files

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -384,7 +384,10 @@ made here — it is hardcoded in MPAS-Model's own
 at each kept cell (`0` for the untouched interior, up through `7` at the
 outer edge) is a file-format contract with those routines, not an
 implementation detail. `bdyMaskEdge`/`bdyMaskVertex` follow the more
-interior (lower) of their adjoining cells' values.
+interior (lower) of their adjoining cells' values — except where a
+neighbour is missing or fell outside the crop, where they take the more
+boundary-like (higher) of the sides they do have, since that side sits at
+the true outer rim with nothing beyond it.
 
 An independent implementation, not a port — see the module docstring in
 `gmpas/prep/region.py` for why: MPAS-Dev/MPAS-Limited-Area does the same
@@ -392,6 +395,34 @@ job but carries no LICENSE file, unlike MPAS-Tools (the source for `scale`
 and `relocate`), which is permissively licensed. Built instead from graph
 traversal over `cellsOnCell` and from MPAS-Model's own public
 Registry.xml/Fortran source for the `bdyMaskCell` semantics above.
+
+#### Circles, ellipses, and `.pts` files
+
+`--pts FILE` is an alternative to `--polygon`: a region-specification file
+in the format MPAS-Limited-Area's own `create_region` uses, so an existing
+`.pts` file written for that tool works here unchanged.
+
+```
+Name: Manus
+Type: circle
+Point: -2.0, 147.0
+radius: 3000000.0   # Meters
+```
+
+```bash
+gmpas prep create-region mesh.nc --pts manus.pts
+```
+
+`custom` (an explicit boundary polygon, one alternative to `--polygon`
+directly), `circle`, and `ellipse` are supported; `channel` (a band between
+two latitudes spanning every longitude) isn't yet — it needs multiple
+disjoint boundaries, which `create_region`'s single-polygon interface
+doesn't support (tracked in
+[gmpas-lib#56](https://github.com/nmathewa/gmpas-lib/issues/56), along with
+direct `--circle`/`--ellipse` CLI flags that skip needing a file at all).
+The file's `Point:` is used directly as the interior point (no centroid
+guessing), and its `Name:` becomes the default output stem in place of the
+mesh's own.
 
 Since there is no `mkgrid` run over a cropped subset, `create-region` also
 writes the accompanying `graph.info` `gpmetis` partition file itself, in

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -637,24 +637,35 @@ def _prep_relocate(args) -> int:
 
 
 def _prep_create_region(args) -> int:
-    from .prep.region import create_region, write_graph_info
+    from .prep.region import create_region, region_from_pts, write_graph_info
 
-    try:
-        points = [tuple(float(v) for v in token.split(",")) for token in args.polygon]
-        if any(len(p) != 2 for p in points):
-            raise ValueError
-    except ValueError:
-        print("gmpas: --polygon points must be 'lat,lon' pairs, e.g. "
-             "--polygon 40.0,-100.0 50.0,-100.0 50.0,-70.0", file=sys.stderr)
+    if bool(args.polygon) == bool(args.pts):
+        print("gmpas: give exactly one of --polygon or --pts", file=sys.stderr)
         return 1
-    boundary_lat, boundary_lon = zip(*points, strict=True)
 
-    point_lat, point_lon = args.point if args.point else (None, None)
+    if args.pts:
+        spec = region_from_pts(args.pts)
+        boundary_lat, boundary_lon = spec.boundary_lat_deg, spec.boundary_lon_deg
+        point_lat, point_lon = spec.point_lat_deg, spec.point_lon_deg
+        out_path = args.out or f"{spec.name}.region.nc"
+        boundary_desc = f"{spec.name} ({len(boundary_lat)}-point boundary)"
+    else:
+        try:
+            points = [tuple(float(v) for v in token.split(",")) for token in args.polygon]
+            if any(len(p) != 2 for p in points):
+                raise ValueError
+        except ValueError:
+            print("gmpas: --polygon points must be 'lat,lon' pairs, e.g. "
+                 "--polygon 40.0,-100.0 50.0,-100.0 50.0,-70.0", file=sys.stderr)
+            return 1
+        boundary_lat, boundary_lon = zip(*points, strict=True)
+        point_lat, point_lon = args.point if args.point else (None, None)
+        out_path = args.out or f"{Path(args.mesh_file).stem}.region.nc"
+        boundary_desc = f"{len(points)}-point boundary"
 
-    out_path = args.out or f"{Path(args.mesh_file).stem}.region.nc"
     out = create_region(args.mesh_file, out_path, boundary_lat, boundary_lon,
                         point_lat_deg=point_lat, point_lon_deg=point_lon)
-    print(f"{args.mesh_file} -> {out}  ({len(points)}-point boundary)")
+    print(f"{args.mesh_file} -> {out}  ({boundary_desc})")
 
     graph = write_graph_info(out, f"{out.with_suffix('')}.graph.info")
     print(f"partition file: {graph}")
@@ -901,9 +912,18 @@ def build_parser() -> argparse.ArgumentParser:
     pc.add_argument("mesh_file", metavar="MESH", help="a global or regional mesh")
     pc.add_argument("-o", "--out",
                     help="output path (default: <mesh stem>.region.nc)")
-    pc.add_argument("--polygon", nargs="+", required=True, metavar="LAT,LON",
+    pc.add_argument("--polygon", nargs="+", metavar="LAT,LON",
                     help="boundary vertices as 'lat,lon' pairs, in degrees, "
-                         "at least 3 (e.g. --polygon 40,-100 50,-100 50,-70)")
+                         "at least 3 (e.g. --polygon 40,-100 50,-100 50,-70). "
+                         "Exactly one of --polygon or --pts is required")
+    pc.add_argument("--pts", metavar="FILE",
+                    help="a .pts region-specification file (the format "
+                         "MPAS-Limited-Area's create_region uses -- Name/"
+                         "Type/Point, plus a Radius for a circle, Semi-"
+                         "major-axis/Semi-minor-axis/Orientation-angle for "
+                         "an ellipse, or boundary coordinate lines for a "
+                         "custom polygon). 'channel' regions are not "
+                         "supported. An alternative to --polygon")
     pc.add_argument("--point", type=float, nargs=2, metavar=("LAT", "LON"),
                     help="a point known to be inside the boundary (default: "
                          "the polygon's spherical centroid -- only reliable "

--- a/src/gmpas/prep/region.py
+++ b/src/gmpas/prep/region.py
@@ -49,15 +49,30 @@ A concave region (or one spanning a pole or a large longitude range on a
 downstream interpolation, not of this cropping step, but worth keeping in
 mind when drawing `--polygon`. Prefer a convex boundary, or subset a
 `static.nc` (post-interpolation) instead.
+
+`region_from_pts` reads a `.pts` region-specification file -- the format
+MPAS-Limited-Area's `create_region` script uses (see its README) -- and
+resolves it to the boundary/interior point `create_region` itself needs.
+`custom` (an explicit polygon) is a direct translation; `circle`/`ellipse`
+are generated as N-point rings via `circle_boundary`/`ellipse_boundary`
+(rotation about the region centre, a standard technique). Independent
+parser and geometry, written from the documented format, not adapted from
+the reference tool's own parser -- same licensing reason as the rest of
+this module. `channel` (a band between two latitudes spanning all
+longitudes) isn't supported -- it needs multiple disjoint boundaries, which
+`create_region`'s single-polygon interface doesn't -- see gmpas-lib#56.
 """
 
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
 import xarray as xr
 
+from ..mesh import EARTH_RADIUS
 from ..paths import resolve_path
 from .scale import great_circle_distance, lonlat_to_xyz, xyz_to_lonlat
 
@@ -445,3 +460,166 @@ def plot_region(regional_mesh_path: str | Path, out_png: str | Path) -> Path:
         title=f"{mesh.n_cells:,} cells, {N_BDY_LAYERS} relaxation rings",
     )
     return save_figure(fig, out_png)
+
+
+# ----------------------------------------------------------------- .pts specs
+
+def _local_north(center: np.ndarray) -> np.ndarray:
+    """Unit tangent vector pointing north at `center` (a unit-sphere xyz
+    point) -- the north pole direction, projected onto the tangent plane
+    there. The reference direction `circle_boundary`/`ellipse_boundary`
+    measure their angles from, so a boundary ring's first point (and an
+    ellipse's `orientation_deg = 0`) sits due north of the centre.
+    """
+    north_pole = np.array([0.0, 0.0, 1.0])
+    tangent = north_pole - center * np.dot(north_pole, center)
+    norm = np.linalg.norm(tangent)
+    if norm < 1e-9:
+        # centre is (numerically) a pole -- any tangent direction is as good
+        # as any other, so fall back to an arbitrary one
+        probe = np.array([1.0, 0.0, 0.0])
+        fallback = np.cross(center, probe)
+        return fallback / np.linalg.norm(fallback)
+    return tangent / norm
+
+
+def _rotate_about_axis(point: np.ndarray, axis: np.ndarray, theta: float) -> np.ndarray:
+    """Rotate `point` (unit-sphere xyz) by `theta` radians about `axis`
+    (xyz, need not be unit length) -- Rodrigues' rotation formula, the
+    standard closed-form rotation about an arbitrary axis."""
+    k = axis / np.linalg.norm(axis)
+    return (point * math.cos(theta) + np.cross(k, point) * math.sin(theta)
+           + k * np.dot(k, point) * (1.0 - math.cos(theta)))
+
+
+def circle_boundary(center_lat_deg: float, center_lon_deg: float,
+                    radius_m: float, n: int = 100) -> tuple[np.ndarray, np.ndarray]:
+    """`n` points around a circle of `radius_m` centred at (`center_lat_deg`,
+    `center_lon_deg`) -- a closed ring in the (`boundary_lat_deg`,
+    `boundary_lon_deg`) shape `create_region` takes directly.
+
+    Constructed in two steps: first move the centre point the circle's
+    angular radius toward north -- `center` and `_local_north(center)` are
+    orthonormal, so `cos(r)*center + sin(r)*north` is exactly the point `r`
+    radians from centre in that direction, still on the unit sphere -- then
+    sweep that point all the way around the centre's own axis. (Rotating
+    `center` *about* the north axis, instead, moves it east-west, not
+    north-south -- easy to reach for by analogy with the sweep step below,
+    but a different operation.)
+    """
+    center = lonlat_to_xyz(math.radians(center_lon_deg), math.radians(center_lat_deg))
+    angular_radius = radius_m / EARTH_RADIUS
+    north = _local_north(center)
+    start = center * math.cos(angular_radius) + north * math.sin(angular_radius)
+
+    angles = np.linspace(0.0, 2.0 * math.pi, n, endpoint=False)
+    points = np.stack([_rotate_about_axis(start, center, a) for a in angles])
+    lon, lat = xyz_to_lonlat(points)
+    return np.degrees(lat), np.degrees(lon)
+
+
+def ellipse_boundary(center_lat_deg: float, center_lon_deg: float,
+                     semi_major_m: float, semi_minor_m: float,
+                     orientation_deg: float, n: int = 100) -> tuple[np.ndarray, np.ndarray]:
+    """`n` points around an ellipse centred at (`center_lat_deg`,
+    `center_lon_deg`), with semi-major/semi-minor axes in meters and
+    `orientation_deg` the clockwise rotation of the semi-major axis from
+    due north -- same parametrization `circle_boundary` builds on, with the
+    angular radius varying per angle instead of constant.
+    """
+    center = lonlat_to_xyz(math.radians(center_lon_deg), math.radians(center_lat_deg))
+    north = _local_north(center)
+    semi_major = semi_major_m / EARTH_RADIUS
+    semi_minor = semi_minor_m / EARTH_RADIUS
+    orientation = math.radians(orientation_deg)
+
+    points = []
+    for r in np.linspace(0.0, 2.0 * math.pi, n, endpoint=False):
+        radius = math.hypot(semi_major * math.cos(r), semi_minor * math.sin(r))
+        # see circle_boundary's docstring: this is a move toward north, not
+        # a rotation about the north axis
+        p0 = center * math.cos(radius) + north * math.sin(radius)
+        bearing = math.atan2(semi_minor * math.sin(r), semi_major * math.cos(r))
+        # rotating the whole ellipse clockwise by `orientation` increases
+        # every point's compass bearing by `orientation`; and since a
+        # geographic bearing increases clockwise while _rotate_about_axis's
+        # positive angle is the standard right-hand-rule sense about
+        # `center` (counterclockwise as seen from outside the sphere), the
+        # angle that actually achieves that bearing is its negation
+        points.append(_rotate_about_axis(p0, center, -(bearing + orientation)))
+
+    lon, lat = xyz_to_lonlat(np.stack(points))
+    return np.degrees(lat), np.degrees(lon)
+
+
+@dataclass
+class PtsRegion:
+    """A resolved `.pts` region spec, ready for `create_region`."""
+
+    name: str
+    boundary_lat_deg: np.ndarray
+    boundary_lon_deg: np.ndarray
+    point_lat_deg: float
+    point_lon_deg: float
+
+
+def region_from_pts(path: str | Path) -> PtsRegion:
+    """Parse a `.pts` region-specification file and resolve it to a
+    boundary/interior point ready for `create_region`. See the module
+    docstring for the supported `Type:`s and what isn't (yet) supported.
+    """
+    text_path = Path(path)
+    fields: dict[str, str] = {}
+    coords: list[tuple[float, float]] = []
+    for raw_line in text_path.read_text().splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fields[key.strip().lower()] = value.strip()
+        elif "," in line:
+            lat_str, lon_str = line.split(",", 1)
+            coords.append((float(lat_str), float(lon_str)))
+
+    if "point" not in fields:
+        raise ValueError(f"{path}: missing a required 'Point:' field")
+    point_lat_deg, point_lon_deg = (float(v) for v in fields["point"].split(","))
+    name = fields.get("name", text_path.stem)
+    region_type = fields.get("type", "").lower()
+
+    if region_type == "custom":
+        if not coords:
+            raise ValueError(
+                f"{path}: a 'custom' region needs boundary coordinate "
+                f"lines (lat, lon) after its 'Point:' line"
+            )
+        boundary_lat_deg = np.array([c[0] for c in coords])
+        boundary_lon_deg = np.array([c[1] for c in coords])
+    elif region_type == "circle":
+        if "radius" not in fields:
+            raise ValueError(f"{path}: a 'circle' region needs a 'Radius:' field")
+        boundary_lat_deg, boundary_lon_deg = circle_boundary(
+            point_lat_deg, point_lon_deg, float(fields["radius"]))
+    elif region_type == "ellipse":
+        required = ("semi-major-axis", "semi-minor-axis", "orientation-angle")
+        missing = [k for k in required if k not in fields]
+        if missing:
+            raise ValueError(f"{path}: an 'ellipse' region needs {missing}")
+        boundary_lat_deg, boundary_lon_deg = ellipse_boundary(
+            point_lat_deg, point_lon_deg, float(fields["semi-major-axis"]),
+            float(fields["semi-minor-axis"]), float(fields["orientation-angle"]))
+    elif region_type == "channel":
+        raise ValueError(
+            f"{path}: 'channel' regions (a band between two latitudes, not "
+            f"a single closed boundary) aren't supported yet -- see "
+            f"gmpas-lib#56."
+        )
+    else:
+        raise ValueError(
+            f"{path}: unknown region Type {fields.get('type')!r}; expected "
+            f"custom, circle, or ellipse"
+        )
+
+    return PtsRegion(name, boundary_lat_deg, boundary_lon_deg,
+                     point_lat_deg, point_lon_deg)

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -8,12 +8,18 @@ import xarray as xr
 
 from conftest import write_grid_mesh
 from gmpas.cli import main
+from gmpas.mesh import EARTH_RADIUS
 from gmpas.prep.region import (
     N_BDY_LAYERS,
     _flood_fill,
     _relaxation_zones,
     _walk_boundary,
+    circle_boundary,
     create_region,
+    ellipse_boundary,
+    great_circle_distance,
+    lonlat_to_xyz,
+    region_from_pts,
     write_graph_info,
 )
 
@@ -278,3 +284,111 @@ def test_cli_accepts_an_explicit_interior_point(tmp_path):
                 "--polygon", "10,10", "10,28", "28,28", "28,10",
                 "--point", "19", "19"]) == 0
     assert out.exists()
+
+
+def test_cli_requires_exactly_one_of_polygon_or_pts(tmp_path, capsys):
+    path = write_grid_mesh(tmp_path / "m.nc", **GRID)
+
+    assert main(["prep", "create-region", str(path)]) == 1
+    assert "exactly one of --polygon or --pts" in capsys.readouterr().err
+
+
+# --------------------------------------------------------- circle/ellipse
+
+def test_circle_boundary_points_are_all_at_the_requested_radius():
+    lat, lon = circle_boundary(-2.0, 147.0, 3_000_000.0, n=100)
+    center = lonlat_to_xyz(np.radians(147.0), np.radians(-2.0))
+    pts = lonlat_to_xyz(np.radians(lon), np.radians(lat))
+    dist_m = great_circle_distance(np.broadcast_to(center, pts.shape), pts) * EARTH_RADIUS
+    assert dist_m == pytest.approx(3_000_000.0, abs=1.0)
+
+
+def test_ellipse_boundary_axis_tips_land_at_the_right_distance_and_bearing():
+    """At orientation=0: r=0 is the semi-major tip, due north; a quarter
+    turn around is the semi-minor tip, due east."""
+    lat, lon = ellipse_boundary(0.0, 0.0, 2_000_000.0, 1_000_000.0, 0.0, n=100)
+
+    assert lat[0] > 0 and lon[0] == pytest.approx(0.0, abs=1e-6)     # north
+    assert lat[25] == pytest.approx(0.0, abs=1e-6) and lon[25] > 0   # east
+
+    center = lonlat_to_xyz(0.0, 0.0)
+    major_tip = lonlat_to_xyz(np.radians(lon[0]), np.radians(lat[0]))
+    minor_tip = lonlat_to_xyz(np.radians(lon[25]), np.radians(lat[25]))
+    major_dist = great_circle_distance(center, major_tip) * EARTH_RADIUS
+    minor_dist = great_circle_distance(center, minor_tip) * EARTH_RADIUS
+    assert major_dist == pytest.approx(2_000_000.0)
+    assert minor_dist == pytest.approx(1_000_000.0)
+
+
+def test_ellipse_orientation_rotates_the_major_axis_clockwise_from_north():
+    """orientation=90 puts the semi-major tip (r=0) due east instead of north."""
+    lat, lon = ellipse_boundary(0.0, 0.0, 2_000_000.0, 1_000_000.0, 90.0, n=100)
+    assert lat[0] == pytest.approx(0.0, abs=1e-6)
+    assert lon[0] > 0
+
+
+# -------------------------------------------------------------------- .pts
+
+def test_pts_circle_matches_the_manus_example(tmp_path):
+    """The exact .pts file from the MPAS-Limited-Area README/docs."""
+    path = tmp_path / "manus.pts"
+    path.write_text(
+        "Name: Manus\n"
+        "Type: circle\n"
+        "Point: -2.0, 147.0\n"
+        "radius: 3000000.0   # Meters\n"
+    )
+    spec = region_from_pts(path)
+    assert spec.name == "Manus"
+    assert (spec.point_lat_deg, spec.point_lon_deg) == (-2.0, 147.0)
+    assert len(spec.boundary_lat_deg) == 100
+
+
+def test_pts_custom_polygon_uses_the_coordinate_lines(tmp_path):
+    path = tmp_path / "custom.pts"
+    path.write_text(
+        "Name: conus\n"
+        "Type: custom\n"
+        "Point: 40.0, -100.0\n"
+        "50.0, -129.0\n"
+        "50.0, -65.0\n"
+        "20.0, -65.0\n"
+        "20.0, -129.0\n"
+    )
+    spec = region_from_pts(path)
+    assert spec.name == "conus"
+    assert spec.boundary_lat_deg.tolist() == [50.0, 50.0, 20.0, 20.0]
+    assert spec.boundary_lon_deg.tolist() == [-129.0, -65.0, -65.0, -129.0]
+
+
+def test_pts_ellipse_requires_all_three_axis_fields(tmp_path):
+    path = tmp_path / "e.pts"
+    path.write_text("Name: e\nType: ellipse\nPoint: 0,0\nSemi-major-axis: 1000\n")
+    with pytest.raises(ValueError, match="semi-minor-axis"):
+        region_from_pts(path)
+
+
+def test_pts_channel_is_rejected(tmp_path):
+    path = tmp_path / "c.pts"
+    path.write_text("Name: c\nType: channel\nPoint: 0,0\n"
+                    "Upper-lat: 10\nLower-lat: -10\n")
+    with pytest.raises(ValueError, match="channel"):
+        region_from_pts(path)
+
+
+def test_pts_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        region_from_pts(tmp_path / "absent.pts")
+
+
+def test_cli_create_region_from_a_pts_circle_file(tmp_path, monkeypatch):
+    path = write_grid_mesh(tmp_path / "m.nc", nrows=40, ncols=40,
+                           lon0_deg=120.0, lat0_deg=-30.0,
+                           dlon_deg=1.5, dlat_deg=1.5, sphere_radius=1.0)
+    pts = tmp_path / "manus.pts"
+    pts.write_text("Name: Manus\nType: circle\nPoint: -2.0, 147.0\n"
+                   "radius: 3000000.0\n")
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["prep", "create-region", str(path), "--pts", str(pts)]) == 0
+    assert (tmp_path / "Manus.region.nc").exists()


### PR DESCRIPTION
Follow-up to #54 (merged). That PR's branch got deleted on merge, so this is opened fresh from the same branch name with just the one new commit on top of current \`main\`.

## Summary
- \`--pts FILE\` is a new alternative to \`--polygon\`: parses the region-specification format MPAS-Limited-Area's own \`create_region\` script uses (\`Name\`/\`Type\`/\`Point\`, plus \`Radius\` for a circle, \`Semi-major-axis\`/\`Semi-minor-axis\`/\`Orientation-angle\` for an ellipse, or boundary coordinate lines for a \`custom\` polygon) -- an existing \`.pts\` file works here unchanged.
- Independent parser and boundary-ring geometry (\`circle_boundary\`/\`ellipse_boundary\`, Rodrigues rotation about the region's local-north tangent), written from the documented format -- not adapted from the reference tool's own parser, same licensing reason as the rest of \`region.py\`.
- \`channel\`-type regions (a band between two latitudes, needing multiple disjoint boundaries \`create_region\`'s single-polygon interface doesn't support) are explicitly rejected with a pointer to a follow-up. Filed [gmpas-lib#56](https://github.com/nmathewa/gmpas-lib/issues/56) tracking that plus direct \`--circle\`/\`--ellipse\` CLI flags (skipping the need for a \`.pts\` file) as deliberately deferred future work.

## Two real bugs caught by direct geometric checks, not eyeballing
Building the circle/ellipse ring construction, a first version silently produced the wrong geometry in two ways -- both caught by checking actual distances/bearings from the centre, not by looking at a picture:
1. Moving the ring's start point toward north was implemented as *rotating the centre about the north axis* -- which actually moves the point east-west, not north-south (rotating about a tangent axis is a different operation from moving along a great circle in that tangent's direction). Invisible for a plain circle (rotationally symmetric, so which direction "start" points doesn't matter), only surfaced once the ellipse's asymmetric axes needed a real direction.
2. Once that was fixed, the ellipse's `orientation_deg` (documented as clockwise from north) was landing counterclockwise -- `_rotate_about_axis`'s positive angle is the standard right-hand-rule sense (counterclockwise as seen from outside the sphere), opposite of a geographic bearing.

Both fixed; added direct tests asserting exact distance and bearing (not just "looks like an ellipse") for both bugs.

## Validation
Re-ran the local comparison harness (see #54's description for the setup -- unmodified MPAS-Limited-Area, cloned and run as a black-box oracle, never merged into this repo) using the user's own Manus circle \`.pts\` example, on a mesh sized to keep the region's relaxation rings clear of the test patch's own edge (see the \`bdyMaskEdge\`/\`bdyMaskVertex\` fix in the prior PR for why that matters -- the reference tool has a bug there). \`bdyMaskCell\`/\`Edge\`/\`Vertex\` zone distributions matched almost exactly (~99% of cells identical); the small remainder traces to the two tools' circles starting from different reference directions (this module's due north vs. the reference's arbitrary perpendicular) landing on slightly different cells right along the boundary ring -- expected discretization noise between two independently-parametrized circles of the same physical region, not a disagreement in the algorithm.

## Test plan
- [x] \`pytest tests/test_region.py -q\` -- 30 tests (10 new): circle/ellipse distance and bearing checks (including the case that would have caught both bugs above), \`.pts\` parsing (custom/circle/ellipse, the exact Manus example, missing-field and unsupported-channel error paths), CLI \`--pts\` smoke test and the polygon/pts mutual-exclusivity check.
- [x] Full suite: \`pytest -q\` -- 371 passed, 5 skipped (pre-existing, ESMF-dependent), no regressions.
- [x] \`ruff check\` clean on every changed file.
- [x] Manual comparison against the unmodified MPAS-Limited-Area tool using the user's Manus example (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)