### PR TITLE
Probe find_mesh_beside candidates with netCDF4, not xarray

### DIFF
--- a/src/gmpas/data.py
+++ b/src/gmpas/data.py
@@ -47,13 +47,25 @@ def open_data(data_path: str | Path,
 
 
 def find_mesh_beside(dpath: Path, n_cells: int) -> Path | None:
-    """Look for a mesh file in the same directory with a matching cell count."""
+    """Look for a mesh file in the same directory with a matching cell count.
+
+    Probes each candidate with netCDF4 directly rather than xarray: this only
+    needs two cheap header facts -- does it carry `verticesOnCell`, does its
+    `nCells` match -- and `xr.open_dataset` would run full CF decoding
+    (attrs, masking, coordinate indexes) over every variable in every
+    candidate file just to answer them. A run directory can hold many files,
+    so that cost is paid once per file scanned, not once total; matches
+    `Series._scan`'s netCDF4-over-xarray choice for the same reason.
+    """
+    import netCDF4
+
     for cand in sorted(dpath.parent.glob("*.nc")):
         if cand == dpath:
             continue
         try:
-            with xr.open_dataset(cand, decode_timedelta=False, engine="netcdf4") as c:
-                if has_mesh(c) and int(c.sizes.get("nCells", -1)) == n_cells:
+            with netCDF4.Dataset(cand) as nc:
+                dim = nc.dimensions.get("nCells")
+                if has_mesh(nc) and dim is not None and len(dim) == n_cells:
                     return cand
         except Exception:
             continue

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -58,8 +58,14 @@ class MeshCacheError(OSError):
     """The mesh cache could not be written -- almost always out of room."""
 
 
-def has_mesh(ds: xr.Dataset) -> bool:
-    """Whether a dataset carries enough information to build mesh geometry."""
+def has_mesh(ds) -> bool:
+    """Whether a dataset carries enough information to build mesh geometry.
+
+    Accepts an xarray Dataset or a raw netCDF4 Dataset -- both expose a
+    `.variables` mapping supporting `in`, and callers use both (`data.py`'s
+    directory scan probes candidates with netCDF4 directly to skip xarray's
+    CF decoding).
+    """
     return all(v in ds.variables for v in MESH_VARS)
 
 


### PR DESCRIPTION
## Summary
- `find_mesh_beside` (data.py) runs whenever a data file doesn't self-describe its mesh — true for essentially every `diag.*.nc`, false for a self-describing `history`/`init` file. When it runs, it opened every other `.nc` file in the same directory with `xr.open_dataset`, paying full CF decoding (attrs, masking, coordinate indexes) across every variable in every candidate, just to answer two cheap header facts: does it carry `verticesOnCell`, does its `nCells` match.
- Diagnosed from a real report: a smaller diag file was consistently slower to open than a larger, self-describing init file on the same run directory — the init file skips this scan entirely (`has_mesh(ds)` true), the diag file pays to scan the whole directory, independent of its own size.
- Swapped the probe to raw `netCDF4`, which answers both facts from the header alone — same choice `series.py`'s `_scan()` already makes for the same reason (measured there at 1.6ms vs 7.3ms per file). Reuses `has_mesh()` unchanged, since both xarray and netCDF4 `Dataset` objects expose a `.variables` mapping supporting `in`.

## Test plan
- [x] `pytest -q tests/test_cli.py tests/test_config.py tests/test_style.py` — 46 passed
- [x] Manual functional test against synthetic netCDF fixtures: correctly finds a matching mesh file, skips a decoy file lacking `nCells`, returns `None` on a genuine cell-count mismatch
- [ ] Confirm on the real GLADE run directory that this actually resolves the observed diag-file slowness (immediate workaround in the meantime: pass `--mesh` explicitly, which skips this scan entirely)