### PR TITLE
Build MpasMesh's KD-tree with balanced_tree=False

### DIFF
--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -212,7 +212,12 @@ class MpasMesh:
         if self._tree is None:
             from scipy.spatial import cKDTree
 
-            self._tree = cKDTree(self.xyz_cell)
+            # balanced_tree=False only changes the split heuristic scipy uses
+            # while building the tree (sliding midpoint vs. median-of-medians),
+            # not the branch-and-bound search query() runs afterward -- nearest
+            # cell results are identical either way, and construction is
+            # measurably faster on a large mesh.
+            self._tree = cKDTree(self.xyz_cell, balanced_tree=False)
         return self._tree
 
     def cell_of(self, lon: np.ndarray, lat: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- `MpasMesh.tree()` builds `scipy.spatial.cKDTree(self.xyz_cell)` fresh in every process that opens an already-cached mesh (`raster.py`, `viewer.py`'s `ViewIndex.__init__`, `cell_of()`) — this isn't a one-time cost like the geometry cache build, it's paid on every `gmpas view`.
- scipy's default `balanced_tree=True` is markedly slower to *construct* than `balanced_tree=False`, while query time is comparable either way. This only changes the internal split heuristic used during construction (sliding midpoint vs. median-of-medians), not the branch-and-bound search `query()` runs afterward, so nearest-cell results are unaffected.
- Part of a larger investigation into `gmpas view` load time on a 41.9M-cell global mesh (see companion work in progress on chunking the mesh cache build itself, a separate/bigger change).

## Test plan
- [x] `pytest -q tests/test_mesh.py` — 41 passed
- [x] `pytest -q tests/test_raster.py` — all passed
- [x] `pytest -q tests/test_viewer.py` — 33 passed, 3 failed on `ModuleNotFoundError: cartopy` (missing optional dep in this sandbox's throwaway venv, unrelated to this change — those tests exercise coastline overlay rendering, not tree construction)
- [x] `ruff check src/gmpas/mesh.py` — 5 pre-existing issues elsewhere in the file, none on the touched lines