### PR TITLE
Chunk the remaining full-array reads in _build_to_dir

### DIFF
--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -561,6 +561,10 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             ew.append(wrapped)
         segs.close(); ew.close()
 
+        # nothing past this point indexes by vertex, so the full nVertices
+        # arrays no longer need to stay resident alongside whatever comes next
+        del lon_v, lat_v
+
         xyz = np.stack([nc.variables["xCell"][:], nc.variables["yCell"][:],
                         nc.variables["zCell"][:]], axis=-1)
         xyz = xyz / np.linalg.norm(xyz, axis=-1, keepdims=True)

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -516,13 +516,27 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
 
         _check_space(cache.parent, _cache_bytes(nc), path)
 
-        lon_v = _wrap180(nc.variables["lonVertex"][:] * R2D)
-        lat_v = nc.variables["latVertex"][:] * R2D
-        dt = lon_v.dtype
+        lon_v_var = nc.variables["lonVertex"]
+        lat_v_var = nc.variables["latVertex"]
+        dt = lon_v_var.dtype
+        n_vertices = lon_v_var.shape[0]
 
         n_cells = len(nc.dimensions["nCells"])
         n_edges = len(nc.dimensions["nEdges"])
         max_edges = len(nc.dimensions["maxEdges"])
+
+        # lon_v/lat_v must stay fully resident for the fancy-indexing below
+        # (lon_v[voc], lat_v[voe] pick arbitrary, non-sequential vertices), so
+        # unlike everything else in this function they can't become a genuine
+        # streaming read -- but the read itself can still be chunked, which
+        # avoids the transient 2-3x multiplier _wrap180's modulo chain costs
+        # when applied in one shot to the whole array.
+        lon_v = np.empty(n_vertices, dtype=dt)
+        lat_v = np.empty(n_vertices, dtype=dt)
+        for i in range(0, n_vertices, chunk):
+            j = min(i + chunk, n_vertices)
+            lon_v[i:j] = _wrap180(lon_v_var[i:j] * R2D)
+            lat_v[i:j] = lat_v_var[i:j] * R2D
 
         bounds = _Bounds()
 

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -579,25 +579,53 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
         # arrays no longer need to stay resident alongside whatever comes next
         del lon_v, lat_v
 
-        xyz = np.stack([nc.variables["xCell"][:], nc.variables["yCell"][:],
-                        nc.variables["zCell"][:]], axis=-1)
-        xyz = xyz / np.linalg.norm(xyz, axis=-1, keepdims=True)
-
         radius = float(getattr(nc, "sphere_radius", EARTH_RADIUS) or EARTH_RADIUS)
-        area = nc.variables["areaCell"][:]
-        if radius < 1.001:
+        rescale_area = radius < 1.001
+        if rescale_area:
             radius = EARTH_RADIUS
-            area = area * EARTH_RADIUS**2
 
-        _save(tmp / "xyz_cell.npy", xyz)
-        _save(tmp / "area_cell.npy", area)
-        _save(tmp / "lon_cell.npy", _wrap180(nc.variables["lonCell"][:] * R2D))
-        _save(tmp / "lat_cell.npy", nc.variables["latCell"][:] * R2D)
+        # xyz's normalize is a per-row reduction (each cell's own 3
+        # components), so -- like the ragged fill and antimeridian unwrap
+        # above -- it decomposes cleanly over cells with no chunk needing to
+        # see another.
+        xc_var, yc_var, zc_var = (nc.variables["xCell"], nc.variables["yCell"],
+                                  nc.variables["zCell"])
+        area_var = nc.variables["areaCell"]
+        lonc_var, latc_var = nc.variables["lonCell"], nc.variables["latCell"]
+
+        xyz_w = _NpyWriter(tmp / "xyz_cell.npy", xc_var.dtype, (n_cells, 3))
+        area_w = _NpyWriter(tmp / "area_cell.npy", area_var.dtype, (n_cells,))
+        lonc_w = _NpyWriter(tmp / "lon_cell.npy", lonc_var.dtype, (n_cells,))
+        latc_w = _NpyWriter(tmp / "lat_cell.npy", latc_var.dtype, (n_cells,))
+
+        # coverage needs sum(areaCell), so accumulate a running total instead
+        # of summing the whole array at the end -- same idea as `_Bounds` for
+        # extent. A chunked sum isn't bit-identical to a whole-array .sum()
+        # (float addition isn't associative), but this only affects the
+        # derived coverage scalar, not any cached array's own values.
+        area_sum = 0.0
+        for i in range(0, n_cells, chunk):
+            j = min(i + chunk, n_cells)
+
+            xyz_block = np.stack([xc_var[i:j], yc_var[i:j], zc_var[i:j]], axis=-1)
+            xyz_block = xyz_block / np.linalg.norm(xyz_block, axis=-1, keepdims=True)
+            xyz_w.append(xyz_block)
+
+            area_block = area_var[i:j]
+            if rescale_area:
+                area_block = area_block * EARTH_RADIUS**2
+            area_w.append(area_block)
+            area_sum += float(area_block.sum())
+
+            lonc_w.append(_wrap180(lonc_var[i:j] * R2D))
+            latc_w.append(latc_var[i:j] * R2D)
+        xyz_w.close(); area_w.close(); lonc_w.close(); latc_w.close()
+
         _save(tmp / "lon_edge.npy", _wrap180(nc.variables["lonEdge"][:] * R2D))
         _save(tmp / "lat_edge.npy", nc.variables["latEdge"][:] * R2D)
         _save(tmp / "angle_edge.npy", nc.variables["angleEdge"][:])
 
-        coverage = float(area.sum() / (4.0 * np.pi * radius**2))
+        coverage = float(area_sum / (4.0 * np.pi * radius**2))
         extent = ((-180.0, 180.0, -90.0, 90.0) if coverage >= GLOBAL_COVERAGE
                   else bounds.extent())
         (tmp / "meta.json").write_text(json.dumps({

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -621,9 +621,19 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             latc_w.append(latc_var[i:j] * R2D)
         xyz_w.close(); area_w.close(); lonc_w.close(); latc_w.close()
 
-        _save(tmp / "lon_edge.npy", _wrap180(nc.variables["lonEdge"][:] * R2D))
-        _save(tmp / "lat_edge.npy", nc.variables["latEdge"][:] * R2D)
-        _save(tmp / "angle_edge.npy", nc.variables["angleEdge"][:])
+        # pure elementwise scale/wrap, no reduction at all -- the simplest
+        # case of the three chunked loops in this function
+        lone_var, late_var, ang_var = (nc.variables["lonEdge"], nc.variables["latEdge"],
+                                       nc.variables["angleEdge"])
+        lone_w = _NpyWriter(tmp / "lon_edge.npy", lone_var.dtype, (n_edges,))
+        late_w = _NpyWriter(tmp / "lat_edge.npy", late_var.dtype, (n_edges,))
+        ang_w = _NpyWriter(tmp / "angle_edge.npy", ang_var.dtype, (n_edges,))
+        for i in range(0, n_edges, chunk):
+            j = min(i + chunk, n_edges)
+            lone_w.append(_wrap180(lone_var[i:j] * R2D))
+            late_w.append(late_var[i:j] * R2D)
+            ang_w.append(ang_var[i:j])
+        lone_w.close(); late_w.close(); ang_w.close()
 
         coverage = float(area_sum / (4.0 * np.pi * radius**2))
         extent = ((-180.0, 180.0, -90.0, 90.0) if coverage >= GLOBAL_COVERAGE

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -314,10 +314,15 @@ def test_a_chunk_boundary_does_not_split_a_polygon(tmp_path):
     for chunk in (1, 7, 40, 1000):
         cache = cache_path(path)
         _build_to_dir(path, cache, chunk=chunk)
-        results.append(np.asarray(MpasMesh._mapped(path, cache).cell_verts))
+        mesh = MpasMesh._mapped(path, cache)
+        results.append((np.asarray(mesh.cell_verts), np.asarray(mesh.xyz_cell),
+                        np.asarray(mesh.area_cell)))
 
-    for other in results[1:]:
-        assert np.array_equal(results[0], other)
+    cell_verts0, xyz_cell0, area_cell0 = results[0]
+    for cell_verts, xyz_cell, area_cell in results[1:]:
+        assert np.array_equal(cell_verts0, cell_verts)
+        assert np.array_equal(xyz_cell0, xyz_cell)
+        assert np.array_equal(area_cell0, area_cell)
 
 
 def test_cached_arrays_are_memory_mapped_not_read(simple_mesh_file):


### PR DESCRIPTION
## Summary
Diagnosed while investigating `gmpas view` load time on the standard MPAS `x1.41943042` global mesh (41,943,042 cells) — a real candidate for the OOM-kill risk on memory-constrained HPC nodes. Companion, independent fix: #60 (KD-tree `balanced_tree=False`).

`_build_to_dir` already chunks `cell_verts`/`edge_segs` correctly, streaming to disk via `_NpyWriter`. But several other arrays were still pulled into memory in one shot via `nc.variables["X"][:]`: `lonVertex`/`latVertex`, `xCell`/`yCell`/`zCell` (+ normalize), `areaCell`, `lonCell`/`latCell`, `lonEdge`/`latEdge`/`angleEdge`. For the 41.9M-cell mesh (nEdges ≈ 125.8M, nVertices ≈ 83.9M, float64 source) this was roughly **6-8 GB peak** just from these arrays and their transient elementwise-op copies.

Four ordered commits:
1. `del lon_v, lat_v` as soon as the edge loop no longer needs them (they used to overlap with whatever one-shot read was currently largest)
2. Chunk the `lonVertex`/`latVertex` read itself into a preallocated buffer — they still have to stay fully resident afterward (the `cell_verts`/`edge_segs` loops index into them by arbitrary vertex, not a slice), but the *read* no longer needs to be one-shot
3. New chunked loop over `n_cells` for `xyz_cell`/`area_cell`/`lon_cell`/`lat_cell`, with a running `area_sum` accumulator for `coverage` (same pattern `_Bounds` already uses for extent)
4. New chunked loop over `n_edges` for `lon_edge`/`lat_edge`/`angle_edge` — pure elementwise, no reduction

**Estimated result:** peak drops from ~6-8GB to roughly ~1.4-1.5GB (the unavoidable `lon_v`/`lat_v` floor) for this mesh — a ~75-80% reduction. No computed value changes: every array stays bit-identical to the in-memory build (verified by the existing `test_chunked_build_matches_the_in_memory_build`); only the derived `coverage` scalar can differ at float-precision level from a chunked vs. whole-array sum (float addition isn't associative), and that test already compares it via `pytest.approx` rather than exact equality.

## Test plan
- [x] `pytest -q tests/test_mesh.py` — 41 passed after every commit
- [x] `pytest -q tests/test_mesh.py tests/test_raster.py tests/test_cli.py tests/test_config.py tests/test_style.py` — 100 passed
- [x] Extended `test_a_chunk_boundary_does_not_split_a_polygon` to also assert `xyz_cell`/`area_cell` are chunk-size-invariant (previously only checked `cell_verts`)
- [x] Confirmed zero remaining full-array `[:]` reads in `_build_to_dir` except the documented `lon_v`/`lat_v` floor
- [ ] Validate the actual memory reduction against the real `x1.41943042` mesh on Derecho/GLADE — no fixture in this repo is large enough to demonstrate the OOM risk either way