### PR TITLE
release: 0.4.4

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-As of 0.4.3, gmpas covers the pipeline from both ends.
+As of 0.4.4, gmpas covers the pipeline from both ends.
 
 **Postprocessing** — plotting, the interactive viewer, and conservative
 remapping — is implemented. `gmpas remap` writes the grid files ESMF needs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.3"
+version = "0.4.4"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 __all__ = [
     # entry points


### PR DESCRIPTION
## Summary
Bumps version to 0.4.4, matching the pattern of prior releases (pyproject.toml, src/gmpas/__init__.py, docs/status.md).

Since 0.4.3, merged in this release:
- #58 — `--cache-dir` CLI flag and cache-hit/miss notification (avoids the `$GMPAS_CACHE_DIR` shell-placement footgun)
- #59 — `find_mesh_beside` probes candidates with netCDF4 instead of xarray (large speedup when opening a file that doesn't self-describe its mesh, e.g. most `diag.*.nc`)
- #60 — `MpasMesh`'s KD-tree built with `balanced_tree=False` (faster tree construction, paid on every `gmpas view` of an already-cached mesh)
- #61 — the mesh geometry cache build (`_build_to_dir`) now chunks every remaining full-array read, cutting peak build memory roughly 75-80% on a large global mesh (~6-8GB → ~1.4-1.5GB estimated on the standard 41.9M-cell MPAS mesh)

## Test plan
- [x] `pytest -q tests/test_version.py` — 2 passed (pyproject.toml / `__version__` agreement)