### PR TITLE
Strip control characters and quotes before a header is built

### DIFF
--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import errno
 import io
 import json
+import re
 import threading
 import webbrowser
 from collections import OrderedDict
@@ -378,6 +379,19 @@ class Viewer:
 # ----------------------------------------------------------------- serving
 
 
+def _safe_header_value(value: str) -> str:
+    """Strip control characters before a request-derived string reaches a
+    response header.
+
+    `http.server.BaseHTTPRequestHandler.send_header` does not sanitize its
+    input -- it just formats `"%s: %s\\r\\n" % (keyword, value)` and encodes
+    as latin-1, so an embedded CR/LF (e.g. from a query parameter decoded by
+    `parse_qs`, which turns `%0d%0a` into a literal newline) would split the
+    header stream and let a request inject arbitrary extra response headers.
+    """
+    return re.sub(r"[\x00-\x1f\x7f]", "", value)
+
+
 class PageHandler(BaseHTTPRequestHandler):
     """What every gmpas page handler has in common.
 
@@ -475,10 +489,15 @@ def _handler(viewer: Viewer, html: str = ""):
                             "application/x-netcdf", f"{stem}.nc")
                     else:
                         return self.send_error(404)
+                    # name is built from `var`, a raw query parameter -- strip
+                    # control characters (the CRLF-injection sink) and quotes
+                    # (which would otherwise close the filename="..." early
+                    # and let extra Content-Disposition parameters follow)
+                    safe_name = _safe_header_value(name).replace('"', "")
                     self.send_response(200)
                     self.send_header("Content-Type", ctype)
                     self.send_header("Content-Disposition",
-                                     f'attachment; filename="{name}"')
+                                     f'attachment; filename="{safe_name}"')
                     self.send_header("Content-Length", str(len(body)))
                     self.end_headers()
                     return self.wfile.write(body)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -242,6 +242,24 @@ def test_compression_level_changes_size_not_content(small_viewer):
 # ------------------------------------------------------------------- export
 
 
+def test_header_value_sanitizer_strips_crlf_and_quotes():
+    """Content-Disposition is built from a filename derived from `var` and
+    (when a file has no parseable timestamp) the file's own name -- and
+    Linux filenames can contain raw CR/LF that send_header does not filter.
+
+    Not reachable through /api/export/* itself: `var` must match a real
+    dataset variable name before that code path is reached, and no valid
+    netCDF variable name can carry a control character. This guards the
+    filename-derived route (`label_of()`'s `path.stem` fallback) instead.
+    """
+    from gmpas.viewer import _safe_header_value
+
+    assert _safe_header_value("evil\r\nX-Injected: yes\r\n") == "evilX-Injected: yes"
+    assert "\r" not in _safe_header_value("a\rb\nc\x00d")
+    assert "\n" not in _safe_header_value("a\rb\nc\x00d")
+    assert _safe_header_value("ordinary_name.nc") == "ordinary_name.nc"
+
+
 def test_figure_export_is_a_full_plot_not_the_bare_raster(small_viewer):
     """A screenshot of the viewer has no axes or colorbar; this does."""
     from PIL import Image


### PR DESCRIPTION
## Summary
From a security review of the package: \`Content-Disposition\`'s \`filename\` (in the \`/api/export/*\` handler) is built from \`var\`, a raw query parameter, and \`http.server.send_header\` does not sanitize its input at all -- it just formats \`"%s: %s\r\n" % (keyword, value)\` and encodes as latin-1. \`parse_qs\` decodes \`%0d%0a\` into a literal CRLF, which would otherwise split the header stream and let a request inject arbitrary extra response headers.

**Important correction from my own initial assessment:** this is *not* reachable through \`/api/export/*\` today the way I first thought. \`var\` must match a real dataset variable name before the vulnerable line is ever reached (\`viewer.netcdf\`/\`figure\`/\`gif\` all check \`var not in ds\` first and raise), and no valid netCDF variable name can carry a control character -- confirmed empirically, the endpoint 500s before reaching \`send_header\`. The route that *is* real: \`label_of()\` falls back to \`path.stem\` for a file with no parseable timestamp, and Linux filenames can contain raw CR/LF bytes, so a maliciously-named file sitting in the served data directory would reach the same header. Fixing at the sink (right before the header is built) closes that path and any future code path that reuses this pattern, rather than trying to sanitize every possible source separately.

Also strips \`"\` so a crafted value can't close \`filename="..."\` early and append extra \`Content-Disposition\` parameters.

## Test plan
- [x] Reproduced the raw \`parse_qs\` decode + unsanitized \`send_header\` behavior directly, confirmed the fix neutralizes both the CRLF and quote-breakout cases
- [x] Exercised the actual \`/api/export/netcdf\` endpoint with a malicious \`var\` end-to-end -- confirmed it 500s before reaching the header (the correction above)
- [x] \`pytest -q tests/test_viewer.py\` -- 21 passed (new \`test_header_value_sanitizer_strips_crlf_and_quotes\` included), 3 failed on \`ModuleNotFoundError: cartopy\` (pre-existing, missing optional dep in this sandbox, unrelated)