### PR TITLE
Clamp the viewer's computed view box to +-90 latitude

### DIFF
--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -753,7 +753,11 @@ function aspect(){ return M.nx/M.ny; }
 // aspect so nothing is ever stretched
 function boxOf(v){
   const h=v.w/aspect();
-  return [v.clon-v.w/2, v.clon+v.w/2, v.clat-h/2, v.clat+h/2];
+  // latitude has a hard physical bound the aspect-fit math above knows
+  // nothing about: fitting a 360x180 globe into a window wider than 2:1
+  // makes h > 180 to preserve aspect, which pushes clat+-h/2 past the poles
+  return [v.clon-v.w/2, v.clon+v.w/2,
+          Math.max(-90,v.clat-h/2), Math.min(90,v.clat+h/2)];
 }
 function fit(box){
   const [a,b,c,d]=box, clon=(a+b)/2, clat=(c+d)/2;
@@ -853,7 +857,9 @@ const GUTTER_X=52, GUTTER_Y=18;
 const OUTSET=1.4;
 function outset(b, f=OUTSET){
   const cx=(b[0]+b[1])/2, cy=(b[2]+b[3])/2, w=(b[1]-b[0])*f/2, h=(b[3]-b[2])*f/2;
-  return [cx-w, cx+w, cy-h, cy+h];
+  // b's own latitude bounds are already pole-clamped (boxOf), but expanding
+  // by the margin here can push past +-90 all over again -- clamp once more
+  return [cx-w, cx+w, Math.max(-90,cy-h), Math.min(90,cy+h)];
 }
 function covers(outer, inner){
   return outer && outer[0]<=inner[0]+1e-9 && outer[1]>=inner[1]-1e-9


### PR DESCRIPTION
## Summary
For a global mesh, the interactive viewer's rendered/queried latitude bounds could run past the poles -- e.g. ±105° at the default 1200x700 window, confirmed by computing \`fit()\`/\`boxOf()\`'s math directly.

Root cause: \`boxOf(v)\` derives the displayed latitude span as \`v.w/aspect()\` so the image is never stretched -- correct in general, but \`fit(M.home)\` for a global mesh (360x180) picks \`w = max(lonSpan, latSpan*aspect())\`. Whenever the window is wider than 2:1 (e.g. the 1200x700 default, aspect ~1.71), \`w\` ends up lon-driven (360), and \`boxOf\` then computes \`h = w/aspect() ~ 210\` instead of 180 -- pushing \`clat ± h/2\` past ±90. \`outset()\`'s 1.4x panning margin can reintroduce the same overshoot even starting from an already-clamped box.

Both \`draw()\` and \`overlay()\` feed through the same \`outset(boxOf(view))\` call, so clamping there keeps the coastline layer and the data raster consistent with each other exactly as before -- this is not the misalignment \`_overlay()\`'s own comment warns about (that was specifically about the *overlay* being clamped via \`set_extent\` while the *data raster* used the raw unclamped extent; here both consumers still agree on the same box, just one now bounded to the poles instead of past them).

## Test plan
- [x] Computed the exact overshoot directly (±105° at 1200x700, ±90° after the fix)
- [x] \`pytest -q tests/test_viewer.py tests/test_dashboard.py\` -- 37 passed, 3 failed on \`ModuleNotFoundError: cartopy\` (pre-existing, missing optional dep in this sandbox, unrelated)
- [ ] Confirm visually in a browser that a global view no longer shows data/graticule past the poles