### PR TITLE
release: 0.4.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "gmpas - a faster native visualizer for MPAS"
+type: software
+authors:
+  - given-names: Nirmal
+    family-names: Alex
+version: 0.4.5
+date-released: "2026-08-18"
+repository-code: "https://github.com/nmathewa/gmpas-lib"
+url: "https://github.com/nmathewa/gmpas-lib"
+doi: 10.5281/zenodo.21987068
+license: MIT
+keywords:
+  - mpas
+  - unstructured mesh
+  - voronoi
+  - atmosphere
+  - visualization
+  - climate
+abstract: >-
+  Fast plotting of MPAS output on its own native, variable-resolution mesh --
+  no regridding -- plus mesh generation, an interactive viewer, and
+  conservative remapping.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-As of 0.4.4, gmpas covers the pipeline from both ends.
+As of 0.4.5, gmpas covers the pipeline from both ends.
 
 **Postprocessing** — plotting, the interactive viewer, and conservative
 remapping — is implemented. `gmpas remap` writes the grid files ESMF needs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.4"
+version = "0.4.5"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -30,7 +30,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 __all__ = [
     # entry points


### PR DESCRIPTION
## Summary
Bumps version to 0.4.5, matching the pattern of prior releases (pyproject.toml, src/gmpas/__init__.py, docs/status.md), and adds `CITATION.cff` so this repo -- and the Zenodo archive publishing a GitHub Release triggers -- carries proper citation metadata (title, author, DOI, license).

Since 0.4.4, merged in this release:
- #64 -- strip control characters/quotes before building a header (CRLF header injection fix)
- #66 -- multiple independently-loading, named animations in the viewer
- #68 -- fix the viewer's pole overshoot in `fit()` (caps width/height together to keep degrees-per-pixel scale consistent, so a global view stays unstretched instead of clamping latitude after the fact)
- #69 -- cancel a superseded viewer render instead of queuing behind it
- #70 -- narrow the viewer's cache lock to bookkeeping only, so independent renders (different variable/extent) run concurrently instead of serializing

## Test plan
- [ ] `pytest -q tests/test_version.py` -- pyproject.toml / `__version__` agreement
- [ ] Validate `CITATION.cff` (e.g. via GitHub's citation UI once merged, or `cffconvert --validate`)