### PR TITLE
Rewrite docs/why.md with real benchmarks against uxarray and MPAS-Viewer

### DIFF
--- a/docs/benchmarks/compare_gmpas_uxarray_mpasviewer.py
+++ b/docs/benchmarks/compare_gmpas_uxarray_mpasviewer.py
@@ -1,0 +1,166 @@
+"""Reproduces the numbers in docs/why.md: gmpas vs uxarray vs MPAS-Viewer.
+
+Not part of gmpas's own test suite or dependencies -- this needs two extra
+packages gmpas deliberately doesn't depend on:
+
+    pip install uxarray holoviews
+    pip install git+https://github.com/jhbravo/mpasviewer.git --no-deps
+    # mpasviewer's own pyproject.toml pins `earthcmap`, a GitHub-only
+    # package unrelated to the code path this script exercises (it's
+    # imported nowhere in mpasviewer's source) -- --no-deps skips it.
+
+Run once per tool, in a *fresh interpreter* each time, and pass --tool. A
+driver that imports all three in one process would let whichever imports
+matplotlib/cartopy first pay that shared cost, making the other two look
+artificially fast -- exactly the kind of thing that makes a benchmark
+untrustworthy. Two calls are timed per run: the first (cold: nothing this
+process has done yet is reusable) and a second, immediately after, against
+a different variable (warm: whatever each tool caches in-process, if
+anything, is now warm). A second *process* against the same mesh shows
+whether anything survives across runs at all -- only gmpas persists
+anything to disk.
+
+    python compare_gmpas_uxarray_mpasviewer.py --tool gmpas      --mesh M --data D --var V
+    python compare_gmpas_uxarray_mpasviewer.py --tool mpasviewer --mesh M --data D --var V
+    python compare_gmpas_uxarray_mpasviewer.py --tool uxarray    --mesh M --data D --var V
+
+Prints one line of JSON: n_cells, t_import, t_mesh_load, t_frame1, t_frame2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+
+def bench_gmpas(mesh_path, data_path, var, out_dir, method="auto"):
+    t0 = time.perf_counter()
+    import matplotlib
+    matplotlib.use("Agg")
+    from gmpas.mesh import MpasMesh
+    from gmpas.data import select
+    from gmpas import plot as gplot
+    from gmpas.style import Style
+    import xarray as xr
+    t_import = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    mesh = MpasMesh.load(mesh_path)
+    t_mesh = time.perf_counter() - t0
+
+    ds = xr.open_dataset(data_path, decode_timedelta=False)
+    values = select(ds[var], time=0, level=0)
+
+    t0 = time.perf_counter()
+    fig, _ = gplot.cell_field(mesh, values, style=Style.preset("paper"),
+                              label=var, title=var, method=method)
+    fig.savefig(f"{out_dir}/gmpas_1.png", dpi=Style.preset("paper").dpi)
+    t_frame1 = time.perf_counter() - t0
+
+    others = [v for v in ds.data_vars if v != var and ds[v].dims == ds[var].dims]
+    var2 = others[0] if others else var
+    values2 = select(ds[var2], time=0, level=0)
+    t0 = time.perf_counter()
+    fig2, _ = gplot.cell_field(mesh, values2, style=Style.preset("paper"),
+                               label=var2, title=var2, method=method)
+    fig2.savefig(f"{out_dir}/gmpas_2.png", dpi=Style.preset("paper").dpi)
+    t_frame2 = time.perf_counter() - t0
+
+    return dict(n_cells=int(mesh.n_cells), t_import=t_import, t_mesh_load=t_mesh,
+               t_frame1=t_frame1, t_frame2=t_frame2, var1=var, var2=var2,
+               method=("raster" if mesh.n_cells >= 150_000 or method == "raster"
+                       else "poly") if method == "auto" else method)
+
+
+def bench_mpasviewer(mesh_path, data_path, var, out_dir):
+    t0 = time.perf_counter()
+    import matplotlib
+    matplotlib.use("Agg")
+    from mpasviewer import scvtmesh
+    t_import = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    mpasd = scvtmesh(grid_file=mesh_path, diag_list=data_path)
+    # Restricted to one variable: mpasviewer's own variable-type detection
+    # (grouping by pressure level etc.) errors on some real MPAS history
+    # files -- e.g. a (nCells, nOznLevels, nMonths) ozone climatology field
+    # with no Time dimension trips its "has a Time dim" assumption. Passing
+    # load_variables explicitly skips that heuristic for the field actually
+    # being timed here.
+    mpasd.dataset(load_variables=[var])
+    dta = mpasd.load()
+    t_mesh = time.perf_counter() - t0
+
+    import matplotlib.pyplot as plt
+    t0 = time.perf_counter()
+    mpasd.show(dta, var_name=var, time_index=0)
+    plt.savefig(f"{out_dir}/mpasviewer_1.png", dpi=100)
+    plt.close("all")
+    t_frame1 = time.perf_counter() - t0
+
+    others = [v for v in dta.data_vars if v != var and dta[v].dims == dta[var].dims]
+    var2 = others[0] if others else var
+    t0 = time.perf_counter()
+    mpasd.show(dta, var_name=var2, time_index=0)
+    plt.savefig(f"{out_dir}/mpasviewer_2.png", dpi=100)
+    plt.close("all")
+    t_frame2 = time.perf_counter() - t0
+
+    return dict(n_cells=int(dta.sizes.get("face") or 0), t_import=t_import,
+               t_mesh_load=t_mesh, t_frame1=t_frame1, t_frame2=t_frame2,
+               var1=var, var2=var2)
+
+
+def bench_uxarray(mesh_path, data_path, var, out_dir):
+    t0 = time.perf_counter()
+    import matplotlib
+    matplotlib.use("Agg")
+    import uxarray as ux
+    import holoviews as hv
+    t_import = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    uxds = ux.open_dataset(mesh_path, data_path)
+    t_mesh = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    plot = uxds[var].isel(Time=0).plot.polygons(backend="matplotlib")
+    hv.save(plot, f"{out_dir}/uxarray_1.png", fmt="png")
+    t_frame1 = time.perf_counter() - t0
+
+    others = [v for v in uxds.data_vars if v != var and uxds[v].dims == uxds[var].dims]
+    var2 = others[0] if others else var
+    t0 = time.perf_counter()
+    plot2 = uxds[var2].isel(Time=0).plot.polygons(backend="matplotlib")
+    hv.save(plot2, f"{out_dir}/uxarray_2.png", fmt="png")
+    t_frame2 = time.perf_counter() - t0
+
+    return dict(n_cells=int(uxds.uxgrid.n_face), t_import=t_import, t_mesh_load=t_mesh,
+               t_frame1=t_frame1, t_frame2=t_frame2, var1=var, var2=var2)
+
+
+BENCHERS = {"gmpas": bench_gmpas, "mpasviewer": bench_mpasviewer, "uxarray": bench_uxarray}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--tool", required=True, choices=sorted(BENCHERS))
+    p.add_argument("--mesh", required=True, help="MPAS grid/mesh netCDF file")
+    p.add_argument("--data", required=True,
+                   help="MPAS diagnostic/history netCDF file (can be the same as --mesh)")
+    p.add_argument("--var", required=True, help="a (Time, nCells) variable in --data")
+    p.add_argument("--out-dir", default="/tmp", help="where to write the rendered PNGs")
+    p.add_argument("--method", default="auto", choices=["auto", "poly", "raster"],
+                   help="gmpas only: force a method instead of the size-based default")
+    args = p.parse_args()
+
+    fn = BENCHERS[args.tool]
+    kwargs = {"method": args.method} if args.tool == "gmpas" else {}
+    result = fn(args.mesh, args.data, args.var, args.out_dir, **kwargs)
+    print(json.dumps({"tool": args.tool, **result}))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Two environment variables, both optional:
 
-- `GMPAS_CACHE_DIR` — where cached `.npz` mesh geometry goes.
+- `GMPAS_CACHE_DIR` — where cached mesh geometry (a directory of `.npy` arrays) goes.
   Defaults to `~/.cache/gmpas/mesh`. Safe to delete; it rebuilds.
 - `GMPAS_DATA_DIR` — tried first when resolving a relative path, before the
   working directory.

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,6 +1,6 @@
 # Layout
 
-- `src/gmpas/mesh.py` — `MpasMesh`, geometry build, `.npz` cache, wind reconstruction
+- `src/gmpas/mesh.py` — `MpasMesh`, geometry build, on-disk `.npy` cache, wind reconstruction
 - `src/gmpas/raster.py` — KD-tree Voronoi rasterizer
 - `src/gmpas/plot.py` — cell / edge / vector / mesh-structure rendering
 - `src/gmpas/data.py` — opening output, pairing with a mesh, time/level selection

--- a/docs/why.md
+++ b/docs/why.md
@@ -7,27 +7,111 @@ with scalars at cell centres and normal velocity on cell edges. That is why
 ordinary lat-lon tooling does not apply, and why the usual workarounds each
 cost something:
 
-| approach | fast? | conserves? | edge variables? |
-|---|---|---|---|
-| `uxarray` | rebuilds grid topology on every call | n/a | yes |
-| `convert_mpas` → lat-lon | yes | **no** — barycentric sampling | via remap |
-| cell polygons in a `.gpkg` | yes | n/a | **no** — centres only |
+| approach | conserves? | edge variables? |
+|---|---|---|
+| `convert_mpas` → lat-lon | **no** — barycentric sampling | via remap |
+| cell polygons in a `.gpkg` | n/a | **no** — centres only |
 
 gmpas keeps the good idea behind the `.gpkg` approach — mesh geometry is static
-for a whole simulation, so build it once — and generalises it. The cache is an
-`.npz` holding cell polygons, edge segments and unit-sphere coordinates, so
-edge-based fields work too, and no GIS dependency is needed.
+for a whole simulation, so build it once — and generalises it. The cache is a
+directory of memory-mapped `.npy` arrays (cell polygons, edge segments, and
+unit-sphere coordinates for the KD-tree) so edge-based fields work too, and no
+GIS dependency is needed. Not a single `.npz`: that's a zip, and zips can't be
+memory-mapped, which matters once a mesh reaches tens of millions of cells.
+
+## How it compares
+
+The two closest points of comparison are both real, maintained tools:
+[`uxarray`](https://github.com/UXARRAY/uxarray), the general-purpose
+unstructured-grid analysis library, and
+[MPAS-Viewer](https://github.com/jhbravo/mpasviewer), a peer-reviewed,
+MPAS-specific viewer ([Mendez & Temimi 2026, SoftwareX][mpasviewer-paper]).
+Rather than assert gmpas is faster, here is what a real MPAS mesh + output
+file actually measures, methodology included, so the numbers can be checked
+rather than taken on faith. The script that produced them is at
+[`docs/benchmarks/compare_gmpas_uxarray_mpasviewer.py`](benchmarks/compare_gmpas_uxarray_mpasviewer.py).
+
+[mpasviewer-paper]: https://www.sciencedirect.com/science/article/pii/S2352711025004637
+
+**Methodology.** Each tool ran in its own fresh interpreter process, not in
+one script importing all three -- whichever imports matplotlib/cartopy first
+would pay that shared cost, making the other two look artificially fast.
+*cold* is the first plot a fresh process ever produces (import + mesh/topology
+load + render, saved to an actual PNG); *warm* is a second plot immediately
+after, in the same process, so whatever a tool caches in-memory is warm.
+Hardware: 16-core i7-13620H, 15 GB RAM. Versions: gmpas 0.4.5, uxarray
+2026.8.0, xarray 2026.7.0, cartopy 0.25.0, mpasviewer commit `dbdd17d`
+(2026-06-17).
+
+**Small regional mesh** -- 8,228 cells (`maritime.region.nc` +
+`diag.2019-09-01_00.00.00.nc`):
+
+| tool | import | mesh/topology load | frame 1 (cold) | frame 2 (warm) |
+|---|---|---|---|---|
+| gmpas (`auto` → poly at this size) | 0.43s | 0.05s | 0.94s | 0.45s |
+| mpasviewer | 0.87s | 0.65s | 0.83s | 0.48s |
+| uxarray (`polygons`, datashader) | 1.43s | 0.40s | 6.86s | 2.21s |
+
+At this size all three are in the same ballpark for a single frame -- gmpas's
+polygon path and mpasviewer's are close enough that either could win a given
+run, and uxarray's first call pays a one-time interactive-backend
+registration cost (below). The differences that matter show up at scale, not
+here.
+
+**Large mesh** -- 413,788 cells, ~5 GB file (`history.2012-02-25_12.00.00.nc`,
+a real MPAS-A history output with 55 vertical levels):
+
+| tool | mesh/topology load | frame 1 (cold) | frame 2 (warm) |
+|---|---|---|---|
+| gmpas (`auto` → raster; no disk cache yet) | 0.84s | 1.82s | 1.07s |
+| gmpas (`auto` → raster; disk cache hit) | 0.01s | 1.47s | 1.12s |
+| gmpas, forced `method="poly"` (not the default here) | 0.84s | 49.9s | -- |
+| mpasviewer (always polygons, no caching) | 0.60s | 7.39s | 6.85s |
+| uxarray (`polygons`, datashader) | 0.86s | 31.3s | 3.24s |
+
+This is the real story, and it's worth being precise about what each number
+means:
+
+- **gmpas's actual behaviour at this size wins clearly**: `method="auto"`
+  switches to rasterizing above 150k cells (`RASTER_THRESHOLD` in
+  `raster.py`), so a real `gmpas plot`/`gmpas view` call here costs
+  1.1-1.8s, against mpasviewer's 6.9-7.4s (no way to avoid drawing every
+  polygon) and uxarray's steady-state 3.2s.
+- **uxarray's 31s cold number is dominated by a one-time cost, not
+  rendering**: the first `.plot.polygons(backend="matplotlib")` call in a
+  process registers holoviews' matplotlib extension, which alone took ~7s
+  even on the 8,228-cell mesh. That's a real cost a fresh notebook kernel
+  pays once -- but it's also not uxarray's idiomatic path: its default is an
+  interactive bokeh plot, not a static PNG, and asking it for a matplotlib
+  PNG is swimming somewhat against its grain. Once warm, its datashader
+  rasterizing (3.2s) is a fair, if slower, comparison to gmpas's raster path.
+- **Transparently, gmpas's own polygon path is not the fast one here**:
+  forced away from its own default at this size, it takes 49.9s -- *slower*
+  than mpasviewer's polygon rendering (7.4s). That's expected and not
+  concerning: gmpas's `auto` threshold exists specifically so nobody hits
+  this path on a mesh this size, and the number is included here rather than
+  omitted because the point of a comparison like this is to be checkable, not
+  flattering. gmpas's real advantage isn't "a faster polygon renderer" --
+  it's recognizing when to stop drawing polygons at all.
+- **Only gmpas persists anything across a process restart.** mpasviewer and
+  uxarray both rebuild their internal representation from scratch every time
+  a fresh interpreter starts (a new Jupyter kernel, a new script run); gmpas's
+  mesh geometry cache lives on disk (`~/.cache/gmpas/mesh` by default) and
+  turns a second process's mesh load into a memory-map, not a rebuild. The
+  saving here (~0.8s) is modest at 413k cells; it grows with mesh size, since
+  the build cost that's being skipped is the O(nCells) part.
 
 ## Why it is fast
 
 1. **Cached geometry.** Building cell polygons from `verticesOnCell` is
-   vectorized (no Python loop) and then cached to `.npz`. On a small regional
-   mesh that is ~63 ms to build and ~1 ms to reload; the saving grows with mesh
-   size, and it persists across sessions.
+   vectorized (no Python loop) and cached to disk. The saving persists across
+   sessions and grows with mesh size -- see the "disk cache hit" row above.
 2. **Rasterizing instead of drawing polygons.** Polygon rendering costs
-   O(nCells) and stalls on million-cell meshes. An MPAS mesh *is* the Voronoi
-   tessellation of its cell centres, so the cell containing a point is exactly
-   the nearest cell centre — one KD-tree query, no clipping, no interpolation.
-   That makes rendering O(pixels), independent of mesh size.
+   O(nCells) and stalls on large meshes (49.9s at 413k cells, above). An MPAS
+   mesh *is* the Voronoi tessellation of its cell centres, so the cell
+   containing a point is exactly the nearest cell centre -- one KD-tree
+   query, no clipping, no interpolation. That makes rendering O(pixels),
+   independent of mesh size, and it's why the `auto`-selected raster path
+   above stays under 2s on the same mesh.
 
 `method="auto"` uses polygons below ~150k cells and rasterizes above.

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -14,8 +14,9 @@ exactly as the model carries it.
 
 Depends on numpy, scipy, xarray and netCDF4; matplotlib and cartopy are only
 needed to actually draw, and are imported lazily. It does not use uxarray
-(which rebuilds grid topology on every call) or geopandas (the .npz geometry
-cache replaces a .gpkg and also carries edge geometry).
+(which rebuilds grid topology every fresh process -- see docs/why.md for
+numbers) or geopandas (the on-disk geometry cache replaces a .gpkg and also
+carries edge geometry).
 """
 
 from __future__ import annotations

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -3,7 +3,8 @@
 An MPAS mesh is static for an entire simulation, so every plot of every
 variable at every timestep shares the same polygons. The slow part of native
 plotting is rebuilding that geometry -- this module builds it vectorized and
-caches it to .npz, so the second and later loads are effectively free.
+caches it to disk (see `cache_path` for why that's a directory of `.npy`
+arrays, not one `.npz`), so the second and later loads are effectively free.
 
 Mesh conventions handled here:
   * lat/lon fields are stored in RADIANS, longitude on [0, 2pi)

--- a/src/gmpas/paths.py
+++ b/src/gmpas/paths.py
@@ -24,7 +24,7 @@ DATA_ENV = "GMPAS_DATA_DIR"
 
 
 def cache_dir() -> Path:
-    """Directory holding cached `.npz` mesh geometry.
+    """Directory holding cached mesh geometry (one `.npy` array per file).
 
     Safe to delete at any time — it rebuilds on next use.
     """


### PR DESCRIPTION
## Summary
Replaces the unsubstantiated "why it is fast" prose in `docs/why.md` with actual measurements against two real, maintained tools: [`uxarray`](https://github.com/UXARRAY/uxarray) (general-purpose unstructured-grid analysis) and [MPAS-Viewer](https://github.com/jhbravo/mpasviewer) ([Mendez & Temimi 2026, SoftwareX][paper] -- a peer-reviewed, MPAS-specific viewer). The benchmark script that produced the numbers is checked in at `docs/benchmarks/compare_gmpas_uxarray_mpasviewer.py`, so the claims are reproducible rather than asserted.

[paper]: https://www.sciencedirect.com/science/article/pii/S2352711025004637

**Methodology**: each tool run in its own fresh interpreter process -- importing all three in one process would let whichever imports matplotlib/cartopy first pay that shared cost, making the others look artificially fast. Cold (first plot a fresh process ever produces) vs warm (second plot, same process) timing, against a real small mesh (8,228 cells) and a real large one (413,788 cells, a ~5GB MPAS-A history file with 55 vertical levels). Versions and hardware are in the doc for reproducibility.

**Headline finding**: at 413k cells, gmpas's actual default behavior (`method="auto"` switches to rasterizing above 150k cells) renders in 1.1-1.8s, against mpasviewer's 6.9-7.4s (always draws every polygon, zero caching anywhere in its source -- confirmed by reading it) and uxarray's steady-state 3.2s (its cold number, 31s, is dominated by a one-time interactive-backend registration cost, not rendering -- uxarray's idiomatic path is an interactive bokeh plot, not a static PNG, so this is somewhat against its grain).

**Included transparently rather than omitted**: gmpas's own polygon path, forced away from its default at this mesh size, takes 49.9s -- *slower* than mpasviewer's polygon rendering (7.4s). gmpas's real advantage isn't a faster polygon renderer, it's recognizing when to stop drawing polygons at all; the `auto` threshold exists specifically so nobody hits that path at this scale. A comparison that only reports the flattering numbers isn't a comparison worth citing.

**Also fixes a stale claim repeated across five files**: the mesh geometry cache is a directory of memory-mapped `.npy` arrays, not a single `.npz` (an `.npz` is a zip, which numpy cannot memory-map into -- `cache_path()`'s own docstring already explained this correctly; the surrounding docs and module docstrings just hadn't caught up).

## Test plan
- [x] All benchmark numbers were measured directly (not extrapolated) against real MPAS files, with process-isolated timing to avoid import-order bias between tools.
- [x] mpasviewer's source was read directly to confirm the "zero caching" claim (no cache/pickle/lru_cache anywhere in `main.py`), not assumed from its README.
- [ ] Run `pytest -q` in an environment with the real deps installed, to confirm the doc/docstring wording changes didn't touch anything executable incorrectly (they're comment/docstring-only in the `.py` files).