### PR TITLE
Bound the values cache by bytes, not entry count

### DIFF
--- a/src/gmpas/series.py
+++ b/src/gmpas/series.py
@@ -17,6 +17,7 @@ this class deliberately does not try to replace it.
 
 from __future__ import annotations
 
+import os
 import re
 import threading
 from collections import OrderedDict
@@ -58,11 +59,32 @@ def parse_time(path: Path) -> datetime | None:
 #: open file handles to keep around while scrubbing through time
 LRU_SIZE = 4
 
-#: materialised (var, step, level) reads to keep around. Cheaper to hold
-#: more of these than open file handles -- one field's worth of float64
-#: rather than a whole file -- but still bounded: an animation loop can
-#: cycle through every step of every variable over a long session.
-VALUES_LRU_SIZE = 64
+#: how much memory materialised (var, step, level) reads may hold, in bytes.
+#:
+#: A budget in BYTES, deliberately not a count of entries. One field is ~2 MB
+#: on a small regional mesh and ~320 MB on a 41M-cell global one, so any fixed
+#: entry count is either useless at one end or an out-of-memory kill at the
+#: other: 64 entries was ~130 MB on the mesh it was tuned against and ~20 GB
+#: on a 3.75 km global mesh, which is exactly how it got a Derecho login node
+#: killed. Sizing by bytes scales itself -- dozens of small fields, or one
+#: large one, for the same footprint either way.
+VALUES_CACHE_BYTES = 512 * 1024 * 1024
+
+#: overrides the values-cache budget, in MB. Worth setting on HPC, where a
+#: login node's cgroup cap and a compute node's memory differ by orders of
+#: magnitude and the same install serves both.
+VALUES_CACHE_ENV = "GMPAS_VALUES_CACHE_MB"
+
+
+def values_budget() -> int:
+    """The values-cache budget in bytes, honouring the environment override."""
+    raw = os.environ.get(VALUES_CACHE_ENV)
+    if not raw:
+        return VALUES_CACHE_BYTES
+    try:
+        return max(0, int(float(raw) * 1024 * 1024))
+    except ValueError:                      # unparseable: keep the default
+        return VALUES_CACHE_BYTES
 
 
 def expand(paths) -> list[Path]:
@@ -124,6 +146,8 @@ class Series:
         self.files = expand(paths)
         self._open: OrderedDict[Path, xr.Dataset] = OrderedDict()
         self._values: OrderedDict[tuple, np.ndarray] = OrderedDict()
+        self._values_bytes = 0
+        self._values_budget = values_budget()
 
         # netCDF4/HDF5 is not safe for concurrent access from multiple
         # threads, and the viewer serves every HTTP request on its own
@@ -243,6 +267,10 @@ class Series:
             for ds in self._open.values():
                 ds.close()
             self._open.clear()
+            # the materialised fields are the bulk of what this holds; closing
+            # the handles but keeping them resident would free almost nothing
+            self._values.clear()
+            self._values_bytes = 0
 
     # -- access ----------------------------------------------------------
 
@@ -296,6 +324,11 @@ class Series:
         from the cache lookup, which is why they can share the lock with
         the disk read below rather than needing one of their own.
 
+        The cache is bounded by total BYTES, not entry count -- see
+        `VALUES_CACHE_BYTES`. What it holds therefore depends on the mesh:
+        many fields of a small one, or a single field of a 41M-cell global
+        one, for the same footprint either way.
+
         The actual disk read (`select` materialises `.values`) happens
         inside the lock along with the cache lookup, not after it -- the
         returned array is a plain, fully detached numpy array, so nothing
@@ -312,10 +345,30 @@ class Series:
             if var not in ds:
                 raise KeyError(f"{var!r} not in {path.name}")
             arr = select(ds[var], time=local, level=level)
-            self._values[key] = arr
-            if len(self._values) > VALUES_LRU_SIZE:
-                self._values.popitem(last=False)
+            self._remember(key, arr)
             return arr
+
+    def _remember(self, key: tuple, arr: np.ndarray) -> None:
+        """Cache `arr`, evicting oldest entries to stay inside the budget.
+
+        Caller must hold `self._lock`. Note this bounds only what the *cache*
+        keeps: a caller combining two fields (a derived variable, say) holds
+        its own references to both regardless, which is inherent to the
+        operation rather than something a cache can bound away.
+        """
+        nbytes = int(arr.nbytes)
+        # An array larger than the entire budget is never worth keeping: it
+        # would evict everything else and still sit there as the sole entry,
+        # so the next distinct read evicts it again. Better to not cache it
+        # and leave the budget serving reads it can actually satisfy twice.
+        if nbytes > self._values_budget:
+            return
+
+        self._values[key] = arr
+        self._values_bytes += nbytes
+        while self._values_bytes > self._values_budget and len(self._values) > 1:
+            _, old = self._values.popitem(last=False)
+            self._values_bytes -= int(old.nbytes)
 
     def __repr__(self) -> str:
         return (f"<Series {len(self.steps)} steps across {self.n_files} files"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -323,3 +323,70 @@ def test_a_series_exposes_its_times_without_reading_files(tmp_path):
         assert [t.hour for t in s.times] == [0, 1, 2]
     finally:
         s.close()
+
+
+# --------------------------------------------------- the values cache budget
+
+
+def test_the_values_cache_is_bounded_by_bytes_not_entries(tmp_path):
+    """The regression that killed a Derecho login node.
+
+    The cache was capped at 64 *entries*, which is ~130 MB of small-mesh
+    fields but ~20 GB of 41M-cell ones. Scrubbing a long series therefore
+    grew without any bound that scaled with the mesh. The budget is in bytes
+    now, so the same walk stays inside it whatever the field size.
+    """
+    from gmpas.series import Series
+
+    run = _run_dir(tmp_path, n_files=6, n_times=3)
+    s = Series(run)
+    try:
+        s._values_budget = 200            # bytes: room for a couple of fields
+        for step in range(len(s)):
+            s.values("fld", step=step)
+        assert s._values_bytes <= s._values_budget
+        assert s._values_bytes == sum(v.nbytes for v in s._values.values())
+    finally:
+        s.close()
+
+
+def test_a_field_larger_than_the_whole_budget_is_not_cached(tmp_path):
+    """Caching it would evict everything and still be evicted next read."""
+    from gmpas.series import Series
+
+    run = _run_dir(tmp_path, n_files=2, n_times=2)
+    s = Series(run)
+    try:
+        s._values_budget = 1              # smaller than any real field
+        got = s.values("fld", step=0)
+        assert got is not None            # still returned to the caller
+        assert not s._values                # but nothing retained
+        assert s._values_bytes == 0
+    finally:
+        s.close()
+
+
+def test_closing_a_series_releases_the_cached_fields(tmp_path):
+    from gmpas.series import Series
+
+    run = _run_dir(tmp_path, n_files=2, n_times=2)
+    s = Series(run)
+    s.values("fld", step=0)
+    assert s._values_bytes > 0
+    s.close()
+    assert s._values_bytes == 0
+    assert not s._values
+
+
+def test_the_values_budget_honours_its_environment_override(monkeypatch):
+    from gmpas.series import VALUES_CACHE_BYTES, VALUES_CACHE_ENV, values_budget
+
+    monkeypatch.setenv(VALUES_CACHE_ENV, "64")
+    assert values_budget() == 64 * 1024 * 1024
+
+    # an unparseable value must not take the viewer down on startup
+    monkeypatch.setenv(VALUES_CACHE_ENV, "not-a-number")
+    assert values_budget() == VALUES_CACHE_BYTES
+
+    monkeypatch.delenv(VALUES_CACHE_ENV)
+    assert values_budget() == VALUES_CACHE_BYTES


### PR DESCRIPTION
## Summary

Fixes a regression I introduced in #72, which is OOM-killing a Derecho login node on a real 3.75 km global mesh (41.9M cells, 3000+ diag files).

The cache was capped at **64 entries**, justified by a comment reasoning that one field is cheaper to hold than one open file handle. That holds on the regional mesh it was tuned against (~2 MB per field, ~130 MB total) and is badly wrong at scale: one field at 41.9M cells is **320 MB**, so the same "bound" is **~20 GB**.

It also explains the exact shape of the reported failure. A single static plot touches one entry and is fine — which is why plotting works. But:
- **animation** walks step after step, adding a 320 MB entry per frame,
- **derived variables** (`hypot(a,b)`, `diff(a)`) read 2+ fields per call, filling it twice as fast.

Those are precisely the two operations getting killed.

## The fix

Size the cache in **bytes**, not entries. That scales itself — dozens of fields on a small mesh, one on a 41M-cell one, the same footprint either way — with no constant to re-tune per mesh size. Default 512 MB, overridable with `GMPAS_VALUES_CACHE_MB`, which matters on HPC where one install serves both a cgroup-capped login node and a compute node with orders of magnitude more memory.

An array larger than the entire budget isn't cached at all: keeping it would evict everything else and still be evicted by the next distinct read.

Scope note: this bounds what the *cache* holds, not what a *caller* holds. A derived variable keeps both operands plus the result resident for the duration of the call, which is inherent to the operation rather than something a cache can bound away — ~960 MB peak at 41M cells, versus ~20 GB before.

`select()`'s unconditional upcast to float64 is a related 2x memory cost (a float32 field becomes 320 MB instead of 160 MB), but that's a precision change, so it's deliberately **not** in this PR.

## Measured

| | old (64 entries) | new (512 MB budget) |
|---|---|---|
| 3000-step animation, 41.9M cells | **20.0 GB** resident | **320 MB** resident |
| small regional mesh (8,228 cells) | 64 fields max | 200 fields in 12.6 MB |

## Test plan
- [x] 4 new regression tests in `tests/test_data.py`: budget respected while walking a whole series, oversized field returned-but-not-cached, `close()` releases the cached fields, and the env override (including that an unparseable value falls back rather than taking the viewer down at startup).
- [x] `pytest -q --ignore=tests/test_data.py` → 334 passed, 5 skipped.
- [x] Byte-accounting verified to stay exactly in sync with `sum(v.nbytes)`, so the counter can't drift from reality.
- [ ] CI is the real verdict for `tests/test_data.py`: it segfaults intermittently in my local sandbox on **both** this branch and `main`, which traces to numpy 2.5.2 + xarray's netCDF4 backend (which emits a numpy-2.5 deprecation warning there), not to this change. CI is green on `main` with its pinned versions.