### PR TITLE
Say why the browser did not open instead of failing silently

### DIFF
--- a/src/gmpas/dashboard.py
+++ b/src/gmpas/dashboard.py
@@ -155,10 +155,8 @@ def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
           banner: str = ""):
     """Start one server carrying every source, and block until interrupted."""
     import socket
-    import threading
-    import webbrowser
 
-    from .viewer import bind
+    from .viewer import bind, open_in_browser
 
     server = bind(router(sources), port, host=host, strict=strict_port)
     port = server.server_address[1]
@@ -182,8 +180,7 @@ def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
     print("ctrl-c to stop")
 
     if open_browser:
-        threading.Timer(0.5, webbrowser.open,
-                        args=(f"http://127.0.0.1:{port}",)).start()
+        open_in_browser(f"http://127.0.0.1:{port}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 import errno
 import io
 import json
+import os
 import re
+import sys
 import threading
 import webbrowser
 from collections import OrderedDict
@@ -620,6 +622,91 @@ def _handler(viewer: Viewer, html: str = ""):
 PORT_ATTEMPTS = 20
 
 
+def can_open_browser() -> tuple[bool, str]:
+    """Whether opening a browser here is likely to work, and why not if not.
+
+    `$BROWSER` wins outright: it is the hook VS Code sets in its integrated
+    terminal to route a URL back to the real browser at the other end of its
+    connection, which is the entire reason `gmpas view` pops a tab there and
+    not from a plain SSH session. Anyone can set it by hand to get the same.
+    """
+    if os.environ.get("BROWSER"):
+        return True, ""
+    if sys.platform == "darwin" or sys.platform.startswith("win"):
+        return True, ""                       # `open` / `start` always exist
+    if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+        return True, ""
+    return False, "no DISPLAY, no WAYLAND_DISPLAY and no $BROWSER"
+
+
+#: browsers that render *into the terminal*. Launching one would seize the
+#: very TTY the server is logging to, so they are never an acceptable answer
+#: here however far down `webbrowser`'s list they sit.
+CONSOLE_BROWSERS = frozenset(
+    {"www-browser", "links", "elinks", "lynx", "w3m"}
+)
+
+
+def _console_browser(controller) -> bool:
+    name = getattr(controller, "name", "") or ""
+    if not name:                              # MacOSX / WindowsDefault: GUI
+        return False
+    return os.path.basename(name.split()[0]) in CONSOLE_BROWSERS
+
+
+def open_in_browser(url: str, delay: float = 0.5) -> "threading.Timer | None":
+    """Open `url`, or say plainly why it could not -- but never in silence.
+
+    `webbrowser.open` returns False when it cannot launch anything and raises
+    on some platforms; both results used to be dropped inside a Timer thread,
+    so "your browser is opening" and "nothing will ever happen" printed the
+    same thing. On a compute node or over a bare SSH session that reads as the
+    viewer being broken, when in fact the server is up and only needs the URL
+    to be opened by hand -- which is what the tunnel instructions above cover.
+
+    Deliberately resolves ONE controller and uses it, rather than calling
+    `webbrowser.open`, which walks its whole list until something works. That
+    list ends in terminal browsers, so a `$BROWSER` pointing at anything
+    broken does not fail -- it cascades into elinks and takes the terminal
+    with it. Better to try the browser the environment actually nominates and
+    report honestly when that one does not work.
+
+    Returns the timer doing the work, so a caller that needs to know the
+    attempt finished (a test, mainly) can join it; `serve` does not care.
+    """
+    ok, why = can_open_browser()
+    if not ok:
+        print(f"gmpas: not opening a browser -- {why}.\n"
+              f"       open {url} yourself (see the tunnel note above if this "
+              f"is a remote node), or pass --no-browser to stop asking.",
+              file=sys.stderr)
+        return None
+
+    def _say(reason: str) -> None:
+        print(f"gmpas: could not open a browser ({reason}) -- open {url} "
+              f"yourself, or pass --no-browser to stop asking.", file=sys.stderr)
+
+    def _try() -> None:
+        try:
+            controller = webbrowser.get()
+        except Exception as exc:              # nothing registered at all
+            return _say(f"{type(exc).__name__}: {exc}")
+        if _console_browser(controller):
+            return _say(f"only a terminal browser ({controller.name}) is "
+                        f"available, which would take over this terminal")
+        try:
+            if not controller.open(url):
+                _say("the browser did not start")
+        except Exception as exc:              # a broken $BROWSER, a dead DISPLAY
+            _say(f"{type(exc).__name__}: {exc}")
+
+    # still deferred: the socket is listening already, but a browser racing the
+    # first request adds nothing, and this keeps the banner above unbroken
+    timer = threading.Timer(delay, _try)
+    timer.start()
+    return timer
+
+
 def bind(handler, port: int, host: str = "127.0.0.1",
          attempts: int = PORT_ATTEMPTS,
          strict: bool = False) -> ThreadingHTTPServer:
@@ -681,8 +768,7 @@ def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True
     print("ctrl-c to stop")
 
     if open_browser:
-        threading.Timer(0.5, webbrowser.open,
-                        args=(f"http://127.0.0.1:{port}",)).start()
+        open_in_browser(f"http://127.0.0.1:{port}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -407,3 +407,100 @@ def test_coastlines_stay_at_their_own_latitudes_past_a_pole():
     # opposite mistake -- squashed rather than stretched
     assert top > 60.0
     assert bottom < -60.0
+
+
+# ------------------------------------------------------ opening a browser
+
+
+def test_a_headless_session_is_not_offered_a_browser(monkeypatch, capsys):
+    """No DISPLAY and no $BROWSER: say so, rather than fail silently."""
+    from gmpas.viewer import can_open_browser, open_in_browser
+
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("BROWSER", raising=False)
+
+    ok, why = can_open_browser()
+    assert not ok
+    assert "DISPLAY" in why
+
+    open_in_browser("http://127.0.0.1:8765", delay=0)
+    err = capsys.readouterr().err
+    assert "not opening a browser" in err
+    assert "http://127.0.0.1:8765" in err        # the URL stays actionable
+
+
+def test_the_browser_env_var_is_enough_on_its_own(monkeypatch):
+    """$BROWSER is how VS Code routes the URL back to a real browser."""
+    from gmpas.viewer import can_open_browser
+
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv("BROWSER", "/some/helper")
+
+    ok, why = can_open_browser()
+    assert ok and why == ""
+
+
+def test_a_terminal_browser_is_refused_not_launched(monkeypatch, capsys):
+    """elinks would seize the very terminal the server logs to."""
+    import webbrowser
+
+    from gmpas.viewer import open_in_browser
+
+    class Console:
+        name = "/usr/bin/elinks"
+        def open(self, url, *a, **k):          # pragma: no cover - must not run
+            raise AssertionError("a terminal browser must never be launched")
+
+    monkeypatch.setenv("BROWSER", "/usr/bin/elinks")
+    monkeypatch.setattr(webbrowser, "get", lambda *a, **k: Console())
+
+    timer = open_in_browser("http://127.0.0.1:8765", delay=0)
+    timer.join()
+    err = capsys.readouterr().err
+    assert "terminal browser" in err
+    assert "http://127.0.0.1:8765" in err
+
+
+def test_a_browser_that_will_not_start_is_reported(monkeypatch, capsys):
+    """webbrowser.open()'s False used to be discarded inside a Timer."""
+    import webbrowser
+
+    from gmpas.viewer import open_in_browser
+
+    class Dud:
+        name = "firefox"
+        def open(self, url, *a, **k):
+            return False                       # could not launch
+
+    monkeypatch.setenv("BROWSER", "firefox")
+    monkeypatch.setattr(webbrowser, "get", lambda *a, **k: Dud())
+
+    timer = open_in_browser("http://127.0.0.1:8765", delay=0)
+    timer.join()
+    assert "did not start" in capsys.readouterr().err
+
+
+def test_a_working_browser_is_opened_and_stays_quiet(monkeypatch, capsys):
+    import webbrowser
+
+    from gmpas.viewer import open_in_browser
+
+    opened = []
+
+    class Good:
+        name = "firefox"
+        def open(self, url, *a, **k):
+            opened.append(url)
+            return True
+
+    monkeypatch.setenv("BROWSER", "firefox")
+    monkeypatch.setattr(webbrowser, "get", lambda *a, **k: Good())
+
+    timer = open_in_browser("http://127.0.0.1:8765", delay=0)
+    timer.join()
+    assert opened == ["http://127.0.0.1:8765"]
+    assert capsys.readouterr().err == ""        # success says nothing


### PR DESCRIPTION
## Summary

`gmpas view` opens a browser tab under VS Code but appears to do nothing from a plain terminal — with no indication which happened. Both `viewer.serve()` and `dashboard.serve()` had the same two lines:

```python
threading.Timer(0.5, webbrowser.open, args=(url,)).start()
```

**Two real problems there:**

1. **Silent failure.** `webbrowser.open()` returns `False` when it can't launch anything, and raises on some platforms. Both were discarded inside the Timer thread, so "a browser is opening" and "nothing will ever happen" printed identically. On a compute node or bare SSH session that reads as the viewer being broken — when in fact the server is up and just needs the URL opened by hand.

2. **A terminal-hijack cascade.** `webbrowser.open()` walks its *entire* list until something works, and that list ends in console browsers. A `$BROWSER` pointing at anything broken didn't fail — it cascaded into **elinks**, which would seize the very terminal the server is logging to. I confirmed this locally: with a broken `$BROWSER`, the old path really did launch ELinks.

**Fix:** detect a headless session up front and skip rather than attempt it; otherwise resolve *one* controller, refuse it if it renders into the terminal, use it, and report honestly when it doesn't work. Every failure path repeats the URL, since that's what the user actually needs.

## Why VS Code worked and a terminal didn't

Worth recording, since it's the root of the confusion. VS Code does two independent things, and only one is a tunnel:

- **Port forwarding** — the VS Code Server watches for newly-listening TCP ports and forwards them back over its existing connection. That's why `http://127.0.0.1:8765` resolves on the laptop at all.
- **`$BROWSER`** — VS Code sets it in its integrated terminal to a helper that RPCs the URL back to the client over `$VSCODE_IPC_HOOK_CLI`. Python's `webbrowser` honors `$BROWSER`, so gmpas got that integration for free without knowing anything about VS Code.

This PR treats `$BROWSER` as sufficient evidence of a browser on its own, so the same trick works for anyone who sets it by hand over SSH.

## Behaviour

| situation | before | after |
|---|---|---|
| desktop w/ DISPLAY | opens | opens (unchanged) |
| `$BROWSER` set (VS Code) | opens | opens (unchanged) |
| headless, no `$BROWSER` | silence | explains, prints URL |
| `$BROWSER` broken | **launches ELinks** | clean report, prints URL |
| only a console browser | **seizes the terminal** | refuses, prints URL |

## Test plan
- [x] 5 new tests in `tests/test_viewer.py` covering all five rows above, verified stable over repeated runs (`open_in_browser` now returns its Timer so tests join it rather than racing the thread).
- [x] Manually exercised each case against the real `webbrowser` module, including confirming the old code launched ELinks on a broken `$BROWSER` and the new code does not.
- [x] `pytest -q --ignore=tests/test_data.py` → 339 passed, 5 skipped. (`test_data.py` is excluded only because it segfaults in my local sandbox on `main` too — numpy 2.5.2 vs xarray's netCDF4 backend, unrelated to this change; CI runs it fine.)
- [ ] Your call on merge — worth a quick check from the terminal you originally hit this in.