### PR TITLE
Fill in the tunnel command, and honour an explicit --port

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -543,9 +543,15 @@ def _dashboard(args, data_path=None, mesh_path="", hfun_path="") -> int:
 
     sources, banner = build(data_path, mesh_path, hfun_path,
                             nx=args.width, ny=args.height)
-    serve(sources, port=args.port, host=args.host,
-          open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT, banner=banner)
+    # `--port` defaults to None rather than DEFAULT_PORT so that asking for a
+    # port explicitly is distinguishable from not asking. Comparing the value
+    # to DEFAULT_PORT instead meant `--port 8765` -- the natural thing to type
+    # once an SSH tunnel is pinned to that port -- counted as "no preference"
+    # and was allowed to wander to 8766 when busy, leaving the tunnel pointing
+    # at nothing and looking, from the browser, exactly like a dead server.
+    serve(sources, port=DEFAULT_PORT if args.port is None else args.port,
+          host=args.host, open_browser=not args.no_browser,
+          strict_port=args.port is not None, banner=banner)
     return 0
 
 
@@ -579,9 +585,9 @@ def _generic_view(args) -> int:
                     f"{gv.path.name} · {gv.nx}x{gv.ny} grid · "
                     f"{gv.steps} step{'s' if gv.steps != 1 else ''}",
                     _handler(gv, PAGE))
-    serve([source], port=args.port, host=args.host,
-          open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT,
+    serve([source], port=DEFAULT_PORT if args.port is None else args.port,
+          host=args.host, open_browser=not args.no_browser,
+          strict_port=args.port is not None,          # see the note in _dashboard
           banner=f"gmpas view --generic · {gv.path.name}")
     return 0
 
@@ -815,7 +821,7 @@ def build_parser() -> argparse.ArgumentParser:
                         "-m/--mesh, --hfun and --cache-dir. Export "
                         "(figure/GIF/netCDF) isn't implemented for this mode "
                         "yet.")
-    v.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+    v.add_argument("-p", "--port", type=int, default=None,
                    help=f"port (default {DEFAULT_PORT}; the default wanders "
                         f"if busy, an explicit one fails instead)")
     v.add_argument("--host", default="127.0.0.1",
@@ -848,7 +854,7 @@ def build_parser() -> argparse.ArgumentParser:
     pv.add_argument("--hfun", help="also serve the JIGSAW hfun.py behind this "
                                    "mesh, so intent and result are one click "
                                    "apart")
-    pv.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+    pv.add_argument("-p", "--port", type=int, default=None,
                     help=f"port (default {DEFAULT_PORT}; the default wanders "
                          f"if busy, an explicit one fails instead)")
     pv.add_argument("--host", default="127.0.0.1",
@@ -874,7 +880,7 @@ def build_parser() -> argparse.ArgumentParser:
     ph.add_argument("--mesh", help="also serve a mesh built from this hfun, "
                                    "to compare what was asked for against "
                                    "what came out")
-    ph.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+    ph.add_argument("-p", "--port", type=int, default=None,
                     help=f"port (default {DEFAULT_PORT}; the default wanders "
                          f"if busy, an explicit one fails instead)")
     ph.add_argument("--host", default="127.0.0.1",

--- a/src/gmpas/dashboard.py
+++ b/src/gmpas/dashboard.py
@@ -154,9 +154,9 @@ def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
           open_browser: bool = True, strict_port: bool = False,
           banner: str = ""):
     """Start one server carrying every source, and block until interrupted."""
-    import socket
+    import sys
 
-    from .viewer import bind, open_in_browser
+    from .viewer import bind, open_in_browser, reach_lines
 
     server = bind(router(sources), port, host=host, strict=strict_port)
     port = server.server_address[1]
@@ -167,17 +167,13 @@ def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
     for s in sources:
         print(f"  /{s.slug:<5} {s.label} — {s.detail}")
 
-    node = socket.gethostname()
-    if host in ("127.0.0.1", "localhost"):
-        print(f"listening on 127.0.0.1:{port} — this machine only")
-        print(f"  open  http://127.0.0.1:{port}")
-        print(f"  if {node} is a remote node, this is NOT reachable through a "
-              f"tunnel to a login node; restart with --host 0.0.0.0")
-    else:
-        print(f"listening on {host}:{port} — reachable as {node}:{port}")
-        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
-        print(f"  then open           http://localhost:{port}")
+    for line in reach_lines(host, port):
+        print(line)
     print("ctrl-c to stop")
+    # stdout is block-buffered whenever it is not a terminal, so the usual
+    # `gmpas view ... > viewer.log &` on a compute node left the log empty --
+    # no URL, no tunnel command, nothing to act on until the process ended
+    sys.stdout.flush()
 
     if open_browser:
         open_in_browser(f"http://127.0.0.1:{port}")

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -16,10 +16,12 @@ an SSH tunnel -- the case where ncview's X11 forwarding hurts most.
 from __future__ import annotations
 
 import errno
+import getpass
 import io
 import json
 import os
 import re
+import socket
 import sys
 import threading
 import webbrowser
@@ -622,6 +624,40 @@ def _handler(viewer: Viewer, html: str = ""):
 PORT_ATTEMPTS = 20
 
 
+def reach_lines(host: str, port: int) -> list[str]:
+    """How to actually open this server, as lines ready to print.
+
+    The tunnel command is the whole point of this banner: on anything but a
+    laptop the viewer sits on the far side of an SSH hop, and that hop is the
+    step people miss -- an editor like VS Code forwards the port silently, so
+    the first plain-terminal run looks like the server never started.
+
+    Both the host and the login name are known right here, so they are filled
+    in rather than left as <placeholders> for the reader to substitute. Only
+    the login node genuinely cannot be known from a compute node, so that one
+    stays a placeholder.
+    """
+    node = socket.gethostname()
+    user = getpass.getuser()
+
+    if host in ("127.0.0.1", "localhost"):
+        return [
+            f"listening on 127.0.0.1:{port} — this machine only",
+            f"  on this machine:  http://127.0.0.1:{port}",
+            f"  from another machine, forward the port first — run this THERE:",
+            f"      ssh -N -L {port}:localhost:{port} {user}@{node}",
+            f"    then open       http://localhost:{port}",
+            f"  (an HPC compute node is different: a tunnel lands on the login"
+            f" node and will not reach here, so restart with --host 0.0.0.0)",
+        ]
+    return [
+        f"listening on {host}:{port} — reachable as {node}:{port}",
+        f"  from your own machine, run this THERE:",
+        f"      ssh -N -L {port}:{node}:{port} {user}@<login-node>",
+        f"    then open       http://localhost:{port}",
+    ]
+
+
 def can_open_browser() -> tuple[bool, str]:
     """Whether opening a browser here is likely to work, and why not if not.
 
@@ -743,8 +779,6 @@ def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True
     so a viewer listening only on the compute node's loopback is unreachable.
     Pass host="0.0.0.0" there, exactly as one does for Jupyter.
     """
-    import socket
-
     viewer = Viewer(data_path, mesh_path, nx=nx, ny=ny)
     server = bind(_handler(viewer), port, host=host, strict=strict_port)
     port = server.server_address[1]
@@ -755,17 +789,11 @@ def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True
           f"{viewer.series.n_files} file(s), "
           f"{len(viewer.plottable_cell_vars())} plottable fields")
 
-    node = socket.gethostname()
-    if host in ("127.0.0.1", "localhost"):
-        print(f"listening on 127.0.0.1:{port} — this machine only")
-        print(f"  open  http://127.0.0.1:{port}")
-        print(f"  if {node} is a remote node, this is NOT reachable through a "
-              f"tunnel to a login node; restart with --host 0.0.0.0")
-    else:
-        print(f"listening on {host}:{port} — reachable as {node}:{port}")
-        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
-        print(f"  then open           http://localhost:{port}")
+    for line in reach_lines(host, port):
+        print(line)
     print("ctrl-c to stop")
+    # see the note in dashboard.serve: a redirected log stayed empty otherwise
+    sys.stdout.flush()
 
     if open_browser:
         open_in_browser(f"http://127.0.0.1:{port}")

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -504,3 +504,36 @@ def test_a_working_browser_is_opened_and_stays_quiet(monkeypatch, capsys):
     timer.join()
     assert opened == ["http://127.0.0.1:8765"]
     assert capsys.readouterr().err == ""        # success says nothing
+
+
+# ------------------------------------------------- how to reach the server
+
+
+def test_the_tunnel_command_is_filled_in_not_a_placeholder(monkeypatch):
+    """A command still holding <host> is one the reader has to decode."""
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+
+    text = "\n".join(reach_lines("127.0.0.1", 8765))
+    assert "ssh -N -L 8765:localhost:8765 someone@dec1042" in text
+    assert "http://localhost:8765" in text
+    assert "<host>" not in text and "<user>" not in text
+
+
+def test_binding_all_interfaces_forwards_via_the_node_name(monkeypatch):
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+
+    text = "\n".join(reach_lines("0.0.0.0", 8765))
+    # the compute node is named, but the login node genuinely cannot be known
+    assert "ssh -N -L 8765:dec1042:8765 someone@<login-node>" in text


### PR DESCRIPTION
> **Stacked on #79** — based on `fix/browser-open-feedback` because both touch `serve()`. Merge #79 first and this retargets to `main` cleanly. Happy to rebase onto `main` instead if you'd rather take this one first.

## Summary

Three things that together made a remote `gmpas view` look like a dead server when it was actually serving fine — which is the confusion we just spent a while chasing.

**1. The tunnel command was a template.** The old banner printed `ssh -N -L PORT:node:PORT <login-node>` and left you to substitute. Worse, the loopback branch offered *no* command at all — only "restart with `--host 0.0.0.0`", which isn't even necessary when you've SSHed straight into the machine running the viewer. The hostname and login name are both known right there, so they're filled in now:

```
listening on 127.0.0.1:8765 — this machine only
  on this machine:  http://127.0.0.1:8765
  from another machine, forward the port first — run this THERE:
      ssh -N -L 8765:localhost:8765 nma@nmaacer
    then open       http://localhost:8765
  (an HPC compute node is different: a tunnel lands on the login node and
   will not reach here, so restart with --host 0.0.0.0)
```

Only the login node stays a placeholder, since a compute node genuinely can't know it.

**2. An explicit `--port 8765` silently wandered.** `strict_port` was `args.port != DEFAULT_PORT`, so passing the default value explicitly — the natural thing to type once you've pinned a tunnel to it — counted as "no preference" and was free to move to 8766 when busy. Your tunnel then points at nothing, which from the browser is *identical* to a server that never started. The flag's own help already promised "an explicit one fails instead"; now it does.

**3. The banner never reached a redirected log.** stdout is block-buffered when it isn't a terminal, so the ordinary compute-node invocation:

```bash
gmpas view ... --no-browser > viewer.log 2>&1 &
```

left `viewer.log` **completely empty** — no URL, no chosen port, no tunnel command. Measured: 0 bytes before, 713 bytes after.

Also de-duplicates the banner, which was copy-pasted between `viewer.serve` and `dashboard.serve`, into one `reach_lines` helper.

## Test plan
- [x] 2 new tests asserting the command is fully substituted (no `<host>`/`<user>` left) for both loopback and `0.0.0.0`.
- [x] Verified live: with 8765 occupied, `--port 8765` now exits 1 with `cannot bind 127.0.0.1:8765 — Address already in use`, instead of quietly serving on 8766.
- [x] Verified live: redirected log contains the full banner *while the server is still running* (0 → 713 bytes).
- [x] `pytest -q --ignore=tests/test_data.py` → 341 passed, 5 skipped. (`test_data.py` excluded only because it segfaults locally on `main` too — numpy 2.5.2 vs xarray's netCDF4 backend; CI runs it fine.)