### PR TITLE
Complete the tunnel command from the environment, and honour an explicit --port

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -543,9 +543,15 @@ def _dashboard(args, data_path=None, mesh_path="", hfun_path="") -> int:
 
     sources, banner = build(data_path, mesh_path, hfun_path,
                             nx=args.width, ny=args.height)
-    serve(sources, port=args.port, host=args.host,
-          open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT, banner=banner)
+    # `--port` defaults to None rather than DEFAULT_PORT so that asking for a
+    # port explicitly is distinguishable from not asking. Comparing the value
+    # to DEFAULT_PORT instead meant `--port 8765` -- the natural thing to type
+    # once an SSH tunnel is pinned to that port -- counted as "no preference"
+    # and was allowed to wander to 8766 when busy, leaving the tunnel pointing
+    # at nothing and looking, from the browser, exactly like a dead server.
+    serve(sources, port=DEFAULT_PORT if args.port is None else args.port,
+          host=args.host, open_browser=not args.no_browser,
+          strict_port=args.port is not None, banner=banner)
     return 0
 
 
@@ -579,9 +585,9 @@ def _generic_view(args) -> int:
                     f"{gv.path.name} · {gv.nx}x{gv.ny} grid · "
                     f"{gv.steps} step{'s' if gv.steps != 1 else ''}",
                     _handler(gv, PAGE))
-    serve([source], port=args.port, host=args.host,
-          open_browser=not args.no_browser,
-          strict_port=args.port != DEFAULT_PORT,
+    serve([source], port=DEFAULT_PORT if args.port is None else args.port,
+          host=args.host, open_browser=not args.no_browser,
+          strict_port=args.port is not None,          # see the note in _dashboard
           banner=f"gmpas view --generic · {gv.path.name}")
     return 0
 
@@ -815,7 +821,7 @@ def build_parser() -> argparse.ArgumentParser:
                         "-m/--mesh, --hfun and --cache-dir. Export "
                         "(figure/GIF/netCDF) isn't implemented for this mode "
                         "yet.")
-    v.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+    v.add_argument("-p", "--port", type=int, default=None,
                    help=f"port (default {DEFAULT_PORT}; the default wanders "
                         f"if busy, an explicit one fails instead)")
     v.add_argument("--host", default="127.0.0.1",
@@ -848,7 +854,7 @@ def build_parser() -> argparse.ArgumentParser:
     pv.add_argument("--hfun", help="also serve the JIGSAW hfun.py behind this "
                                    "mesh, so intent and result are one click "
                                    "apart")
-    pv.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+    pv.add_argument("-p", "--port", type=int, default=None,
                     help=f"port (default {DEFAULT_PORT}; the default wanders "
                          f"if busy, an explicit one fails instead)")
     pv.add_argument("--host", default="127.0.0.1",
@@ -874,7 +880,7 @@ def build_parser() -> argparse.ArgumentParser:
     ph.add_argument("--mesh", help="also serve a mesh built from this hfun, "
                                    "to compare what was asked for against "
                                    "what came out")
-    ph.add_argument("-p", "--port", type=int, default=DEFAULT_PORT,
+    ph.add_argument("-p", "--port", type=int, default=None,
                     help=f"port (default {DEFAULT_PORT}; the default wanders "
                          f"if busy, an explicit one fails instead)")
     ph.add_argument("--host", default="127.0.0.1",

--- a/src/gmpas/dashboard.py
+++ b/src/gmpas/dashboard.py
@@ -154,9 +154,9 @@ def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
           open_browser: bool = True, strict_port: bool = False,
           banner: str = ""):
     """Start one server carrying every source, and block until interrupted."""
-    import socket
+    import sys
 
-    from .viewer import bind, open_in_browser
+    from .viewer import bind, open_in_browser, reach_lines
 
     server = bind(router(sources), port, host=host, strict=strict_port)
     port = server.server_address[1]
@@ -167,17 +167,13 @@ def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
     for s in sources:
         print(f"  /{s.slug:<5} {s.label} — {s.detail}")
 
-    node = socket.gethostname()
-    if host in ("127.0.0.1", "localhost"):
-        print(f"listening on 127.0.0.1:{port} — this machine only")
-        print(f"  open  http://127.0.0.1:{port}")
-        print(f"  if {node} is a remote node, this is NOT reachable through a "
-              f"tunnel to a login node; restart with --host 0.0.0.0")
-    else:
-        print(f"listening on {host}:{port} — reachable as {node}:{port}")
-        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
-        print(f"  then open           http://localhost:{port}")
+    for line in reach_lines(host, port):
+        print(line)
     print("ctrl-c to stop")
+    # stdout is block-buffered whenever it is not a terminal, so the usual
+    # `gmpas view ... > viewer.log &` on a compute node left the log empty --
+    # no URL, no tunnel command, nothing to act on until the process ended
+    sys.stdout.flush()
 
     if open_browser:
         open_in_browser(f"http://127.0.0.1:{port}")

--- a/src/gmpas/series.py
+++ b/src/gmpas/series.py
@@ -65,7 +65,7 @@ LRU_SIZE = 4
 #: on a small regional mesh and ~320 MB on a 41M-cell global one, so any fixed
 #: entry count is either useless at one end or an out-of-memory kill at the
 #: other: 64 entries was ~130 MB on the mesh it was tuned against and ~20 GB
-#: on a 3.75 km global mesh, which is exactly how it got a Derecho login node
+#: on a 3.75 km global mesh, which is exactly how it got an HPC login node
 #: killed. Sizing by bytes scales itself -- dozens of small fields, or one
 #: large one, for the same footprint either way.
 VALUES_CACHE_BYTES = 512 * 1024 * 1024

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -16,10 +16,12 @@ an SSH tunnel -- the case where ncview's X11 forwarding hurts most.
 from __future__ import annotations
 
 import errno
+import getpass
 import io
 import json
 import os
 import re
+import socket
 import sys
 import threading
 import webbrowser
@@ -622,6 +624,40 @@ def _handler(viewer: Viewer, html: str = ""):
 PORT_ATTEMPTS = 20
 
 
+def reach_lines(host: str, port: int) -> list[str]:
+    """How to actually open this server, as lines ready to print.
+
+    The tunnel command is the whole point of this banner: on anything but a
+    laptop the viewer sits on the far side of an SSH hop, and that hop is the
+    step people miss -- an editor like VS Code forwards the port silently, so
+    the first plain-terminal run looks like the server never started.
+
+    Both the host and the login name are known right here, so they are filled
+    in rather than left as <placeholders> for the reader to substitute. Only
+    the login node genuinely cannot be known from a compute node, so that one
+    stays a placeholder.
+    """
+    node = socket.gethostname()
+    user = getpass.getuser()
+
+    if host in ("127.0.0.1", "localhost"):
+        return [
+            f"listening on 127.0.0.1:{port} — this machine only",
+            f"  on this machine:  http://127.0.0.1:{port}",
+            f"  from another machine, forward the port first — run this THERE:",
+            f"      ssh -N -L {port}:localhost:{port} {user}@{node}",
+            f"    then open       http://localhost:{port}",
+            f"  (an HPC compute node is different: a tunnel lands on the login"
+            f" node and will not reach here, so restart with --host 0.0.0.0)",
+        ]
+    return [
+        f"listening on {host}:{port} — reachable as {node}:{port}",
+        f"  from your own machine, run this THERE:",
+        f"      ssh -N -L {port}:{node}:{port} {user}@<login-node>",
+        f"    then open       http://localhost:{port}",
+    ]
+
+
 def can_open_browser() -> tuple[bool, str]:
     """Whether opening a browser here is likely to work, and why not if not.
 
@@ -743,8 +779,6 @@ def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True
     so a viewer listening only on the compute node's loopback is unreachable.
     Pass host="0.0.0.0" there, exactly as one does for Jupyter.
     """
-    import socket
-
     viewer = Viewer(data_path, mesh_path, nx=nx, ny=ny)
     server = bind(_handler(viewer), port, host=host, strict=strict_port)
     port = server.server_address[1]
@@ -755,17 +789,11 @@ def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True
           f"{viewer.series.n_files} file(s), "
           f"{len(viewer.plottable_cell_vars())} plottable fields")
 
-    node = socket.gethostname()
-    if host in ("127.0.0.1", "localhost"):
-        print(f"listening on 127.0.0.1:{port} — this machine only")
-        print(f"  open  http://127.0.0.1:{port}")
-        print(f"  if {node} is a remote node, this is NOT reachable through a "
-              f"tunnel to a login node; restart with --host 0.0.0.0")
-    else:
-        print(f"listening on {host}:{port} — reachable as {node}:{port}")
-        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
-        print(f"  then open           http://localhost:{port}")
+    for line in reach_lines(host, port):
+        print(line)
     print("ctrl-c to stop")
+    # see the note in dashboard.serve: a redirected log stayed empty otherwise
+    sys.stdout.flush()
 
     if open_browser:
         open_in_browser(f"http://127.0.0.1:{port}")

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -627,10 +627,10 @@ PORT_ATTEMPTS = 20
 def ssh_target() -> str:
     """The name to SSH *to*, preferring one that resolves off this machine.
 
-    `gethostname()` alone gives the bare label -- `derecho1` -- which is not
+    `gethostname()` alone gives the bare label -- `node7` -- which is not
     something a laptop can look up. The fully qualified name usually is:
-    `derecho1.hpc.ucar.edu` can be typed straight into `ssh`, which is the
-    entire point of printing the command at all.
+    `node7.cluster.example.org` can be typed straight into `ssh`, which is
+    the entire point of printing the command at all.
 
     Only taken when it genuinely extends the short name, since `getfqdn()`
     falls back to whatever /etc/hosts says and can answer `localhost` or some
@@ -642,6 +642,34 @@ def ssh_target() -> str:
     return fqdn if fqdn.startswith(f"{node}.") else node
 
 
+#: environment a batch scheduler sets on a compute node. Both pairs are read
+#: from the environment at run time -- no site, cluster or hostname is ever
+#: baked in here, so this works on any PBS or Slurm system and knows nothing
+#: about any particular one.
+JOB_ID_VARS = ("PBS_JOBID", "SLURM_JOB_ID")
+SUBMIT_HOST_VARS = ("PBS_O_HOST", "SLURM_SUBMIT_HOST")
+
+
+def in_batch_job() -> bool:
+    """Whether this is running inside a scheduler allocation."""
+    return any(os.environ.get(v) for v in JOB_ID_VARS)
+
+
+def submit_host() -> str:
+    """The host the job was submitted from -- the login node, if known.
+
+    PBS sets `PBS_O_HOST` and Slurm `SLURM_SUBMIT_HOST` to wherever the job
+    was queued, which on a cluster is exactly the node a tunnel has to hop
+    through. Reading it beats asking the user to remember it, and beats
+    hardcoding anything: the value comes from their own session.
+    """
+    for var in SUBMIT_HOST_VARS:
+        value = os.environ.get(var)
+        if value:
+            return value
+    return "<login-node>"
+
+
 def reach_lines(host: str, port: int) -> list[str]:
     """How to actually open this server, as lines ready to print.
 
@@ -650,12 +678,13 @@ def reach_lines(host: str, port: int) -> list[str]:
     step people miss -- an editor like VS Code forwards the port silently, so
     the first plain-terminal run looks like the server never started.
 
-    Everything knowable is filled in. That includes the case this banner
-    used to get wrong: a *login* node running the viewer is directly
-    reachable, so telling its user to tunnel via "<login-node>" asks them to
-    hop through the machine they are already on. The direct command comes
-    first now, with the via-a-login-node form kept for a compute node that
-    really cannot be reached from outside.
+    Which command is right depends on where this is running, and that is
+    knowable rather than guessable. Inside a batch job the viewer is on a
+    compute node, unreachable from outside, and the hop has to go through the
+    submitting host -- which the scheduler names in the environment. Anywhere
+    else, including on a login node, the machine is reachable directly, and
+    telling the reader to go via "<login-node>" would send them hopping
+    through the box they are already on.
     """
     target = ssh_target()
     node = socket.gethostname()
@@ -671,14 +700,21 @@ def reach_lines(host: str, port: int) -> list[str]:
             f"  (an HPC compute node is different: a tunnel lands on the login"
             f" node and will not reach here, so restart with --host 0.0.0.0)",
         ]
+
+    if in_batch_job():
+        # a compute node: reachable only through whoever queued the job
+        return [
+            f"listening on {host}:{port} — reachable as {node}:{port}",
+            f"  from your own machine, run this THERE:",
+            f"      ssh -N -L {port}:{node}:{port} {user}@{submit_host()}",
+            f"    then open       http://localhost:{port}",
+        ]
+
     return [
         f"listening on {host}:{port} — reachable as {target}:{port}",
         f"  from your own machine, run this THERE:",
         f"      ssh -N -L {port}:localhost:{port} {user}@{target}",
         f"    then open       http://localhost:{port}",
-        f"  (if {node} is a compute node you cannot SSH to directly, go via"
-        f" the login node instead:)",
-        f"      ssh -N -L {port}:{node}:{port} {user}@<login-node>",
     ]
 
 

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -624,6 +624,24 @@ def _handler(viewer: Viewer, html: str = ""):
 PORT_ATTEMPTS = 20
 
 
+def ssh_target() -> str:
+    """The name to SSH *to*, preferring one that resolves off this machine.
+
+    `gethostname()` alone gives the bare label -- `derecho1` -- which is not
+    something a laptop can look up. The fully qualified name usually is:
+    `derecho1.hpc.ucar.edu` can be typed straight into `ssh`, which is the
+    entire point of printing the command at all.
+
+    Only taken when it genuinely extends the short name, since `getfqdn()`
+    falls back to whatever /etc/hosts says and can answer `localhost` or some
+    placeholder domain on a misconfigured box. In that case the short name is
+    no worse and reads less like a promise.
+    """
+    node = socket.gethostname()
+    fqdn = socket.getfqdn()
+    return fqdn if fqdn.startswith(f"{node}.") else node
+
+
 def reach_lines(host: str, port: int) -> list[str]:
     """How to actually open this server, as lines ready to print.
 
@@ -632,11 +650,14 @@ def reach_lines(host: str, port: int) -> list[str]:
     step people miss -- an editor like VS Code forwards the port silently, so
     the first plain-terminal run looks like the server never started.
 
-    Both the host and the login name are known right here, so they are filled
-    in rather than left as <placeholders> for the reader to substitute. Only
-    the login node genuinely cannot be known from a compute node, so that one
-    stays a placeholder.
+    Everything knowable is filled in. That includes the case this banner
+    used to get wrong: a *login* node running the viewer is directly
+    reachable, so telling its user to tunnel via "<login-node>" asks them to
+    hop through the machine they are already on. The direct command comes
+    first now, with the via-a-login-node form kept for a compute node that
+    really cannot be reached from outside.
     """
+    target = ssh_target()
     node = socket.gethostname()
     user = getpass.getuser()
 
@@ -645,16 +666,19 @@ def reach_lines(host: str, port: int) -> list[str]:
             f"listening on 127.0.0.1:{port} — this machine only",
             f"  on this machine:  http://127.0.0.1:{port}",
             f"  from another machine, forward the port first — run this THERE:",
-            f"      ssh -N -L {port}:localhost:{port} {user}@{node}",
+            f"      ssh -N -L {port}:localhost:{port} {user}@{target}",
             f"    then open       http://localhost:{port}",
             f"  (an HPC compute node is different: a tunnel lands on the login"
             f" node and will not reach here, so restart with --host 0.0.0.0)",
         ]
     return [
-        f"listening on {host}:{port} — reachable as {node}:{port}",
+        f"listening on {host}:{port} — reachable as {target}:{port}",
         f"  from your own machine, run this THERE:",
-        f"      ssh -N -L {port}:{node}:{port} {user}@<login-node>",
+        f"      ssh -N -L {port}:localhost:{port} {user}@{target}",
         f"    then open       http://localhost:{port}",
+        f"  (if {node} is a compute node you cannot SSH to directly, go via"
+        f" the login node instead:)",
+        f"      ssh -N -L {port}:{node}:{port} {user}@<login-node>",
     ]
 
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -518,9 +518,10 @@ def test_the_tunnel_command_is_filled_in_not_a_placeholder(monkeypatch):
 
     monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
     monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+    monkeypatch.setattr(socket, "getfqdn", lambda *a: "dec1042.hpc.example.edu")
 
     text = "\n".join(reach_lines("127.0.0.1", 8765))
-    assert "ssh -N -L 8765:localhost:8765 someone@dec1042" in text
+    assert "ssh -N -L 8765:localhost:8765 someone@dec1042.hpc.example.edu" in text
     assert "http://localhost:8765" in text
     assert "<host>" not in text and "<user>" not in text
 
@@ -534,6 +535,29 @@ def test_binding_all_interfaces_forwards_via_the_node_name(monkeypatch):
     monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
     monkeypatch.setattr(getpass, "getuser", lambda: "someone")
 
+    monkeypatch.setattr(socket, "getfqdn", lambda *a: "dec1042.hpc.example.edu")
     text = "\n".join(reach_lines("0.0.0.0", 8765))
-    # the compute node is named, but the login node genuinely cannot be known
+    # the directly-reachable form comes first, fully qualified so it can be
+    # typed straight into ssh -- a login node running the viewer is reachable
+    assert "ssh -N -L 8765:localhost:8765 someone@dec1042.hpc.example.edu" in text
+    # with the via-a-login-node form kept for a compute node that is not
     assert "ssh -N -L 8765:dec1042:8765 someone@<login-node>" in text
+
+
+def test_a_bogus_fqdn_falls_back_to_the_short_name(monkeypatch):
+    """getfqdn() answers from /etc/hosts and can be useless.
+
+    Printing `someone@localhost` as the thing to SSH to would be worse than
+    the bare hostname, which is at least honest about being incomplete.
+    """
+    import socket
+
+    from gmpas.viewer import ssh_target
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+
+    monkeypatch.setattr(socket, "getfqdn", lambda *a: "localhost")
+    assert ssh_target() == "dec1042"
+
+    monkeypatch.setattr(socket, "getfqdn", lambda *a: "dec1042.hpc.example.edu")
+    assert ssh_target() == "dec1042.hpc.example.edu"

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -526,7 +526,12 @@ def test_the_tunnel_command_is_filled_in_not_a_placeholder(monkeypatch):
     assert "<host>" not in text and "<user>" not in text
 
 
-def test_binding_all_interfaces_forwards_via_the_node_name(monkeypatch):
+def test_binding_all_interfaces_outside_a_job_is_reached_directly(monkeypatch):
+    """Not in a batch job -- a login node, say -- means no hop is needed.
+
+    The old banner sent this reader through "<login-node>", which on a login
+    node is the machine they are already on.
+    """
     import getpass
     import socket
 
@@ -534,14 +539,14 @@ def test_binding_all_interfaces_forwards_via_the_node_name(monkeypatch):
 
     monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
     monkeypatch.setattr(getpass, "getuser", lambda: "someone")
-
     monkeypatch.setattr(socket, "getfqdn", lambda *a: "dec1042.hpc.example.edu")
+    for var in ("PBS_JOBID", "SLURM_JOB_ID"):
+        monkeypatch.delenv(var, raising=False)
+
     text = "\n".join(reach_lines("0.0.0.0", 8765))
-    # the directly-reachable form comes first, fully qualified so it can be
-    # typed straight into ssh -- a login node running the viewer is reachable
+    # fully qualified, so it can be typed straight into ssh
     assert "ssh -N -L 8765:localhost:8765 someone@dec1042.hpc.example.edu" in text
-    # with the via-a-login-node form kept for a compute node that is not
-    assert "ssh -N -L 8765:dec1042:8765 someone@<login-node>" in text
+    assert "<login-node>" not in text          # nothing left to substitute
 
 
 def test_a_bogus_fqdn_falls_back_to_the_short_name(monkeypatch):
@@ -561,3 +566,59 @@ def test_a_bogus_fqdn_falls_back_to_the_short_name(monkeypatch):
 
     monkeypatch.setattr(socket, "getfqdn", lambda *a: "dec1042.hpc.example.edu")
     assert ssh_target() == "dec1042.hpc.example.edu"
+
+
+def test_a_batch_job_tunnels_via_the_submitting_host(monkeypatch):
+    """A compute node is not reachable from outside; the submit host is.
+
+    PBS and Slurm both name that host in the environment, so the command can
+    be complete without hardcoding any site's address into gmpas.
+    """
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec0965")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+    monkeypatch.setenv("PBS_JOBID", "1234567.desched1")
+    monkeypatch.setenv("PBS_O_HOST", "login.cluster.example.org")
+
+    text = "\n".join(reach_lines("0.0.0.0", 8787))
+    assert ("ssh -N -L 8787:dec0965:8787 someone@login.cluster.example.org"
+            in text)
+    assert "<login-node>" not in text          # nothing left to substitute
+
+
+def test_slurm_is_understood_as_well_as_pbs(monkeypatch):
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "nid001")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+    monkeypatch.delenv("PBS_JOBID", raising=False)
+    monkeypatch.delenv("PBS_O_HOST", raising=False)
+    monkeypatch.setenv("SLURM_JOB_ID", "99")
+    monkeypatch.setenv("SLURM_SUBMIT_HOST", "head.cluster.example.org")
+
+    text = "\n".join(reach_lines("0.0.0.0", 8787))
+    assert "ssh -N -L 8787:nid001:8787 someone@head.cluster.example.org" in text
+
+
+def test_a_job_without_a_submit_host_still_says_something_useful(monkeypatch):
+    """Some sites unset it; fall back to a placeholder rather than a wrong name."""
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec0965")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+    monkeypatch.setenv("PBS_JOBID", "1234567")
+    monkeypatch.delenv("PBS_O_HOST", raising=False)
+    monkeypatch.delenv("SLURM_SUBMIT_HOST", raising=False)
+
+    text = "\n".join(reach_lines("0.0.0.0", 8787))
+    assert "ssh -N -L 8787:dec0965:8787 someone@<login-node>" in text

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -504,3 +504,36 @@ def test_a_working_browser_is_opened_and_stays_quiet(monkeypatch, capsys):
     timer.join()
     assert opened == ["http://127.0.0.1:8765"]
     assert capsys.readouterr().err == ""        # success says nothing
+
+
+# ------------------------------------------------- how to reach the server
+
+
+def test_the_tunnel_command_is_filled_in_not_a_placeholder(monkeypatch):
+    """A command still holding <host> is one the reader has to decode."""
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+
+    text = "\n".join(reach_lines("127.0.0.1", 8765))
+    assert "ssh -N -L 8765:localhost:8765 someone@dec1042" in text
+    assert "http://localhost:8765" in text
+    assert "<host>" not in text and "<user>" not in text
+
+
+def test_binding_all_interfaces_forwards_via_the_node_name(monkeypatch):
+    import getpass
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+    monkeypatch.setattr(getpass, "getuser", lambda: "someone")
+
+    text = "\n".join(reach_lines("0.0.0.0", 8765))
+    # the compute node is named, but the login node genuinely cannot be known
+    assert "ssh -N -L 8765:dec1042:8765 someone@<login-node>" in text


### PR DESCRIPTION
> **Replaces #80.** That PR was opened stacked on `fix/browser-open-feedback` and got merged into *that branch* rather than `main`, so none of this actually reached `main` — `reach_lines` is absent there. Same work, plus two follow-up commits, retargeted at `main`. #80's branch can be deleted.

## Summary

Four things that made a remote `gmpas view` look like a dead server when it was serving fine.

**1. The tunnel command was a template.** It printed `<login-node>` and left the reader to supply the piece they were least likely to know. Worse, on a *login* node it told them to hop through the machine they were already on. Both PBS and Slurm publish the answer — `PBS_O_HOST` / `SLURM_SUBMIT_HOST` name the submitting host, and `PBS_JOBID` / `SLURM_JOB_ID` say whether this is a compute node at all — so the command completes itself:

```
listening on 0.0.0.0:8787 — reachable as dec0965:8787
  from your own machine, run this THERE:
      ssh -N -L 8787:dec0965:8787 nalex@login.example.org
    then open       http://localhost:8787
```

Outside a job the machine is directly reachable, so it prints the direct form and no placeholder appears at all. If a site unsets the submit-host variable the placeholder returns — honest, and better than naming a host that might be wrong.

**Nothing site-specific is added to the package.** These are environment variables read at run time; the values come from the user's own session. No cluster, host or domain is hardcoded (verified by grep over `src/`).

**2. The hostname wasn't resolvable.** `gethostname()` gives the bare label, which no laptop can look up. Prefers `getfqdn()` — but only when it genuinely extends the short name, since it answers from `/etc/hosts` and can return `localhost` or a placeholder domain on a misconfigured box.

**3. An explicit `--port 8765` silently wandered.** `strict_port` was `args.port != DEFAULT_PORT`, so passing the default *explicitly* — the natural thing once a tunnel is pinned to it — counted as "no preference" and moved to 8766 when busy. The tunnel then points at nothing, indistinguishable from a dead server. The flag's help already promised "an explicit one fails instead"; now it does.

**4. The banner never reached a redirected log.** stdout is block-buffered off a TTY, so `gmpas view ... > viewer.log 2>&1 &` left the log **empty** — no URL, no port, no command. Measured 0 → 713 bytes.

Also de-duplicates the banner, previously copy-pasted between `viewer.serve` and `dashboard.serve`, into one `reach_lines` helper.

## Test plan
- [x] 7 tests covering: PBS and Slurm job detection, a job with the submit-host variable unset, direct reach outside a job, FQDN preference, bogus-FQDN fallback, and full substitution (asserting no `<...>` placeholder survives).
- [x] Verified live: with 8765 occupied, `--port 8765` exits 1 with `Address already in use` instead of quietly serving on 8766.
- [x] Verified live: redirected log holds the full banner while the server runs (0 → 713 bytes).
- [x] Ran the app itself (`gmpas view --host 0.0.0.0`) and smoke-tested it: `/run/` → 200, `/run/api/meta` → real JSON.
- [x] `pytest -q --ignore=tests/test_data.py` → 345 passed, 5 skipped. (`test_data.py` excluded only because it segfaults locally on `main` too — numpy 2.5.2 vs xarray's netCDF4 backend; CI runs it fine.)