### PR TITLE
Name the cause when remap dimensions do not line up

### DIFF
--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -450,6 +450,21 @@ def _remap(args) -> int:
                 f"gmpas: weights are for {weights.n_a:,} cells but the mesh has "
                 f"{series.mesh.n_cells:,}. Delete {weights_path.name} to rebuild."
             )
+        # The same check for the other end of the map. Weights are cached as
+        # map_<method>.nc in the output directory, keyed on neither grid, so
+        # reusing an output directory after editing target_domain silently
+        # reuses weights built for the old one. Without this the run gets all
+        # the way into remapping and fails per file with numpy's `cannot
+        # reshape array of size N into shape (nlat, nlon)`, which names
+        # neither the weights nor the domain.
+        expected = domain.nlat * domain.nlon
+        if weights.n_b != expected:
+            raise SystemExit(
+                f"gmpas: weights map onto {weights.n_b:,} points but this "
+                f"target domain is {domain.nlat} x {domain.nlon} = "
+                f"{expected:,}. They were built for a different target grid — "
+                f"rerun with --force-weights, or delete {weights_path.name}."
+            )
     finally:
         series.close()
 

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -23,7 +23,8 @@ import numpy as np
 import xarray as xr
 
 from .config import TargetDomain
-from .scrip import write_scrip
+from .mesh import GLOBAL_COVERAGE
+from .scrip import coverage_of, write_scrip
 from .series import parse_time
 
 #: dimensions a field may be stacked along, beyond Time
@@ -258,10 +259,25 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
         print(f"    normalised {wrapped:,} longitudes onto [0, 2pi)")
     domain.to_scrip(dst_scrip)
 
+    # --src_regional tells ESMF the source does not cover the sphere, which
+    # decides how it treats the poles and the seam. It was passed
+    # unconditionally, so a global mesh was described to ESMF as regional --
+    # and paired with --ignore_unmapped, cells it then failed to map came back
+    # silently empty instead of as an error. gmpas already knows which this
+    # is, so say so.
+    src_coverage = coverage_of(src_scrip)
+    src_is_global = src_coverage >= GLOBAL_COVERAGE
+    if not quiet:
+        kind = "global" if src_is_global else "regional"
+        print(f"  source covers {src_coverage * 100:.1f}% of the sphere "
+              f"— treating it as {kind}")
+
     launch, note = _mpi_launch_prefix(ranks, tool)
     cmd = launch + [tool, "-s", src_scrip.name, "-d", dst_scrip.name,
-                    "-w", weights.name, "-m", method,
-                    "--src_regional", "--dst_regional", "--ignore_unmapped",
+                    "-w", weights.name, "-m", method]
+    if not src_is_global:
+        cmd.append("--src_regional")
+    cmd += ["--dst_regional", "--ignore_unmapped",
                     # ESMF's own default logs every message from every rank,
                     # and warns that this "may cause slowdown in performance"
                     # -- real cost under -np 64+ on a shared/parallel

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -327,7 +327,26 @@ def remappable(ds: xr.Dataset, names) -> tuple[list[str], list[tuple[str, str]]]
         if name not in ds:
             skip.append((name, "not in this file"))
         elif "nCells" in ds[name].dims:
-            keep.append(name)
+            # remap_file walks Time and one level axis and hands the rest to
+            # the weights as a flat per-cell vector, so anything else left in
+            # the shape has nowhere to go. Real MPAS history carries such
+            # fields -- the ozone climatology is (nCells, nOznLevels,
+            # nMonths) -- and reaching them with an unhandled axis fails deep
+            # in the remap with numpy talking about dimensions, naming
+            # neither the field nor the axis. Report them the way an edge
+            # field is reported instead.
+            spare = [d for d in ds[name].dims
+                     if d != "nCells" and d != "Time"
+                     and not d.startswith(LEVEL_PREFIXES)]
+            levels = [d for d in ds[name].dims if d.startswith(LEVEL_PREFIXES)]
+            if spare:
+                skip.append((name, f"has {', '.join(spare)} as well as cells "
+                                   f"— only Time and one level axis are handled"))
+            elif len(levels) > 1:
+                skip.append((name, f"has two level axes ({', '.join(levels)}) "
+                                   f"— only one is handled"))
+            else:
+                keep.append(name)
         elif "nEdges" in ds[name].dims:
             skip.append((name, "on nEdges — needs edge weights"))
         elif "nVertices" in ds[name].dims:
@@ -522,6 +541,23 @@ def remap_file(path, weights: Weights, domain: TargetDomain, fields,
     exactly as before this existed -- no Time coordinate, not a wrong one.
     """
     lat, lon = domain.lats(), domain.lons()
+
+    # The source side is checked per field below, against nCells. The
+    # destination side has to be checked here, because nothing downstream
+    # would say what went wrong: the mismatch surfaces as `cannot reshape
+    # array of size N into shape (nlat, nlon)` from numpy, once per file,
+    # with nothing pointing at the weights that are actually stale.
+    expected = domain.nlat * domain.nlon
+    if weights.n_b != expected:
+        raise ValueError(
+            f"{weights.path.name} was built for a target grid of "
+            f"{weights.n_b} points, but this target domain is "
+            f"{domain.nlat} x {domain.nlon} = {expected}. The weights and the "
+            f"domain disagree -- rebuild the weights for this domain with "
+            f"`--force-weights`, or point at the target_domain the existing "
+            f"weights were made for."
+        )
+
     result: dict[str, xr.DataArray] = {}
     slabs = 0
     worst = 0.0

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -216,6 +216,42 @@ def _mpi_launch_prefix(ranks: int, tool: str) -> tuple[list[str], str | None]:
     return [], "no srun/mpirun/mpiexec on PATH -- running single-rank"
 
 
+#: lines of a failed run's output to quote back in the error
+ERROR_TAIL = 6
+
+
+def _run_streaming(cmd, cwd, quiet: bool) -> tuple[int, list[str]]:
+    """Run `cmd`, echoing its output as it arrives, and keep the tail.
+
+    Weight generation is the longest thing gmpas ever waits on, and capturing
+    its output wholesale meant nothing appeared until it finished -- so a run
+    that was progressing and a run that was stuck looked identical for however
+    many hours it took.
+
+    That hid the message that explains the most common HPC stall. Launching
+    this under `srun` from inside an interactive `srun --pty` allocation makes
+    it a nested job step, and Slurm answers `Job step creation temporarily
+    disabled, retrying (Requested nodes are busy)` -- once a second, forever,
+    while the outer step holds the resources the inner one is asking for. That
+    line is the whole diagnosis, and it was being swallowed.
+
+    The last `ERROR_TAIL` lines are still kept for the failure message, so
+    nothing is lost by showing them as they come.
+    """
+    from collections import deque
+
+    tail: deque[str] = deque(maxlen=ERROR_TAIL)
+    proc = subprocess.Popen(cmd, cwd=cwd, text=True, bufsize=1,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    with proc:
+        for line in proc.stdout:
+            line = line.rstrip()
+            tail.append(line)
+            if not quiet and line:
+                print(f"    {line}", flush=True)
+    return proc.returncode, list(tail)
+
+
 def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
                    method: str = "conserve", force: bool = False,
                    ranks: int = 1, quiet: bool = False) -> tuple[Path, bool]:
@@ -299,18 +335,16 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
     t0 = time.perf_counter()
     for attempt in range(1, WEIGHT_ATTEMPTS + 1):
         weights.unlink(missing_ok=True)
-        done = subprocess.run(cmd, capture_output=True, text=True, cwd=out_dir)
-        if done.returncode == 0 and weights.exists():
+        code, tail = _run_streaming(cmd, out_dir, quiet)
+        if code == 0 and weights.exists():
             break
         if attempt < WEIGHT_ATTEMPTS and not quiet:
-            print(f"    attempt {attempt} failed (exit {done.returncode}), "
-                  f"retrying")
+            print(f"    attempt {attempt} failed (exit {code}), retrying")
     else:
-        tail = (done.stdout or done.stderr or "").strip().splitlines()[-6:]
-        crash = " — it segfaulted" if done.returncode < 0 else ""
+        crash = " — it segfaulted" if code < 0 else ""
         raise RemapError(
             f"ESMF_RegridWeightGen failed {WEIGHT_ATTEMPTS} times "
-            f"(exit {done.returncode}){crash}.\n"
+            f"(exit {code}){crash}.\n"
             + "\n".join(f"    {line}" for line in tail)
         )
     if not quiet:

--- a/src/gmpas/scrip.py
+++ b/src/gmpas/scrip.py
@@ -117,6 +117,27 @@ def write_scrip(mesh_path: str | Path, out_path: str | Path,
     corner_lat = lat_vert[voc]
     corner_lon = lon_vert[voc]
 
+    # Unwrap each cell's corners onto one branch, around its own centre.
+    #
+    # MPAS stores lonVertex on [0, 2pi), so a cell straddling the antimeridian
+    # already arrives with corners at ~6.28 and ~0.002 -- nothing above put it
+    # there, and normalising cannot take it out. Written verbatim, that cell is
+    # a polygon spanning nearly the whole globe rather than the few kilometres
+    # it really covers.
+    #
+    # That is not only wrong, it is slow, and disproportionately so: ESMF finds
+    # candidate overlaps from cell bounding boxes, and a box spanning 359
+    # degrees of longitude is a candidate against very nearly every target
+    # cell. A few thousand such cells around the seam are enough to turn the
+    # search from roughly N log N into something closer to N x M -- which is
+    # how a mesh that should take a minute takes hours.
+    #
+    # Shifting a corner by a whole turn does not move it on the sphere, so this
+    # changes no geometry. It is the same unwrapping `_cell_polygons` already
+    # does for rendering, applied where a remapper will read it.
+    offset = corner_lon - lon_cell[:, None]
+    corner_lon = corner_lon - TWO_PI * np.round(offset / TWO_PI)
+
     # grid_area is a solid angle, so it is areaCell on the unit sphere. A mesh
     # straight from JIGSAW already carries non-dimensional areas with
     # sphere_radius = 1, and dividing by that radius is right either way.

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -730,3 +730,74 @@ def test_a_failing_file_does_not_stop_the_run(tmp_path, weights):
     assert len(results) == 1
     assert "error" in results[0]
     assert results[0]["source"] == "absent.nc"
+
+
+# ------------------------------------------------- dimensions that do not fit
+
+
+def test_weights_for_a_different_target_grid_are_named_as_the_cause(tmp_path, weights):
+    """The failure used to be numpy's, and named neither weights nor domain.
+
+    Weights are cached as map_<method>.nc keyed on neither grid, so reusing an
+    output directory after editing target_domain reuses the old ones. That
+    surfaced as `cannot reshape array of size 2 into shape (3,3)`, once per
+    file, with nothing to act on.
+    """
+    from gmpas.remap import remap_file
+
+    src = tmp_path / "diag.nc"
+    xr.Dataset({"x": (("nCells",), np.ones(2, dtype="f4"))}).to_netcdf(src)
+
+    # these weights carry 2 destination points; the domain now wants 9
+    domain = TargetDomain(nlat=3, nlon=3, startlat=-1.0, endlat=1.0,
+                          startlon=0.0, endlon=2.0)
+
+    with pytest.raises(ValueError) as excinfo:
+        remap_file(src, weights, domain, ["x"], tmp_path / "out.nc")
+
+    message = str(excinfo.value)
+    assert "map.nc" in message                 # which weights
+    assert "3 x 3" in message                  # and which domain
+    assert "force-weights" in message          # and what to do about it
+
+
+def test_a_field_with_an_unhandled_axis_is_skipped_not_fatal(tmp_path, weights):
+    """MPAS really ships these: the ozone climatology is
+    (nCells, nOznLevels, nMonths), and nOznLevels is not a level prefix.
+
+    remap_file walks Time and one level axis; a third has nowhere to go, and
+    reaching the remap with one failed the whole file.
+    """
+    from gmpas.remap import remap_file
+
+    src = tmp_path / "diag.nc"
+    xr.Dataset({
+        "o3clim": (("nCells", "nOznLevels", "nMonths"),
+                   np.ones((2, 3, 12), dtype="f4")),
+        "good": (("nCells",), np.ones(2, dtype="f4")),
+    }).to_netcdf(src)
+
+    domain = TargetDomain(nlat=1, nlon=2, startlat=-1.0, endlat=1.0,
+                          startlon=0.0, endlon=2.0)
+    info = remap_file(src, weights, domain, ["good", "o3clim"],
+                      tmp_path / "out.nc")
+
+    # the good field still lands; the awkward one is reported, not fatal
+    assert info["fields"] == 1
+    reasons = dict(info["skipped"])
+    assert "o3clim" in reasons
+    assert "nOznLevels" in reasons["o3clim"] and "nMonths" in reasons["o3clim"]
+    with xr.open_dataset(tmp_path / "out.nc") as out:
+        assert list(out.data_vars) == ["good"]
+
+
+def test_two_level_axes_are_reported_rather_than_guessed_between(tmp_path, weights):
+    from gmpas.remap import remappable
+
+    ds = xr.Dataset({
+        "both": (("nCells", "nVertLevels", "nSoilLevels"),
+                 np.ones((2, 3, 4), dtype="f4")),
+    })
+    keep, skip = remappable(ds, ["both"])
+    assert keep == []
+    assert "two level axes" in dict(skip)["both"]

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -192,8 +192,10 @@ def test_a_crashing_esmf_is_retried_then_reported(tmp_path, monkeypatch):
         stderr = ""
 
     monkeypatch.setattr(remap_mod.shutil, "which", lambda name: "/fake/esmf")
-    monkeypatch.setattr(remap_mod.subprocess, "run",
-                        lambda *a, **k: (calls.append(1), Result())[1])
+    # _run_streaming is the seam now: it echoes output as it arrives rather
+    # than capturing it wholesale, so there is no subprocess.run to stand in for
+    monkeypatch.setattr(remap_mod, "_run_streaming",
+                        lambda *a, **k: (calls.append(1), (-11, ["boom"]))[1])
     write_mesh(tmp_path / "m.nc", [(0.0, 0.0), (5.0, 0.0)])
     domain = TargetDomain(4, 8, -2.0, 2.0, 0.0, 8.0)
 
@@ -398,15 +400,15 @@ def test_ensure_weights_wraps_the_esmf_call_with_the_launcher(tmp_path, monkeypa
         return {"ESMF_RegridWeightGen": "/fake/esmf",
                 "mpirun": "/fake/mpirun"}.get(name)
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, cwd, quiet):
         calls.append(cmd)
         (tmp_path / "w" / "map_conserve.nc").write_bytes(b"weights")
-        return Result()
+        return 0, []
 
     monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
     monkeypatch.delenv("SLURM_JOB_ID", raising=False)
     monkeypatch.setattr(remap_mod.shutil, "which", fake_which)
-    monkeypatch.setattr(remap_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(remap_mod, "_run_streaming", fake_run)
     write_mesh(tmp_path / "m.nc", [(0.0, 0.0), (5.0, 0.0)])
     domain = TargetDomain(4, 8, -2.0, 2.0, 0.0, 8.0)
 
@@ -433,14 +435,14 @@ def test_ensure_weights_declines_the_launcher_on_a_mpiuni_build(tmp_path, monkey
         return {"ESMF_RegridWeightGen": "/fake/esmf",
                 "mpirun": "/fake/mpirun"}.get(name)
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, cwd, quiet):
         calls.append(cmd)
         (tmp_path / "w" / "map_conserve.nc").write_bytes(b"weights")
-        return Result()
+        return 0, []
 
     monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: False)
     monkeypatch.setattr(remap_mod.shutil, "which", fake_which)
-    monkeypatch.setattr(remap_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(remap_mod, "_run_streaming", fake_run)
     write_mesh(tmp_path / "m.nc", [(0.0, 0.0), (5.0, 0.0)])
     domain = TargetDomain(4, 8, -2.0, 2.0, 0.0, 8.0)
 

--- a/tests/test_scrip.py
+++ b/tests/test_scrip.py
@@ -127,3 +127,54 @@ def test_a_file_without_a_mesh_says_so(tmp_path):
 def test_a_missing_file_is_reported_clearly(tmp_path):
     with pytest.raises(FileNotFoundError, match="No such mesh file"):
         write_scrip(tmp_path / "absent.nc", tmp_path / "x.scrip.nc")
+
+
+def test_cells_at_the_antimeridian_stay_local(tmp_path):
+    """The seam is where a remap goes from minutes to hours.
+
+    MPAS stores lonVertex on [0, 2pi), so a cell straddling the antimeridian
+    arrives with corners at ~359.9 and ~0.1 degrees. Written through, that is
+    a polygon spanning nearly the globe -- ESMF finds candidate overlaps from
+    bounding boxes, so such a cell is a candidate against very nearly every
+    target cell, and a few thousand of them around the seam turn the search
+    from roughly N log N into something closer to N x M.
+    """
+    from conftest import write_mesh
+    from gmpas.scrip import write_scrip
+
+    mesh = tmp_path / "seam.nc"
+    write_mesh(mesh, [(147.0, -2.0), (359.5, 0.0), (0.5, 0.0), (180.0, 10.0)],
+               radius_deg=1.0)
+    out, _ = write_scrip(mesh, tmp_path / "s.nc")
+
+    with xr.open_dataset(out) as scrip:
+        lon = np.degrees(scrip.grid_corner_lon.values)
+
+    spans = lon.max(axis=1) - lon.min(axis=1)
+    # every cell is ~2 degrees across; none may look global
+    assert spans.max() < 10.0, f"a cell spans {spans.max():.1f} degrees"
+
+
+def test_unwrapping_moves_no_point_on_the_sphere(tmp_path):
+    """Shifting a corner by a whole turn must be a relabelling, not a move."""
+    from conftest import write_mesh
+    from gmpas.scrip import write_scrip
+
+    mesh = tmp_path / "seam.nc"
+    write_mesh(mesh, [(359.5, 0.0), (0.5, 0.0)], radius_deg=1.0)
+    out, _ = write_scrip(mesh, tmp_path / "s.nc")
+
+    with xr.open_dataset(out) as scrip:
+        lon = scrip.grid_corner_lon.values
+        lat = scrip.grid_corner_lat.values
+
+    # corners may sit outside [0, 2pi) now -- that is the point -- but each
+    # must still be the same physical location it was
+    assert (lon < 0).any() or (lon >= 2 * np.pi).any()
+    xyz = np.stack([np.cos(lat) * np.cos(lon), np.cos(lat) * np.sin(lon),
+                    np.sin(lat)], axis=-1)
+    wrapped_lon = np.mod(lon, 2 * np.pi)
+    xyz_wrapped = np.stack([np.cos(lat) * np.cos(wrapped_lon),
+                            np.cos(lat) * np.sin(wrapped_lon),
+                            np.sin(lat)], axis=-1)
+    assert np.allclose(xyz, xyz_wrapped, atol=1e-12)


### PR DESCRIPTION
## Summary

You asked whether `gmpas remap` was failing on a dimension error. It was — **two** distinct ones, both reproduced here before being fixed, and both surfacing as raw numpy shape errors that named nothing actionable.

### 1. Weights built for a different target grid

Weights are cached as `map_<method>.nc` in the output directory, **keyed on neither grid**. So reusing an output directory after editing `target_domain` silently reuses weights built for the old one.

The *source* side was already guarded (`weights are for N cells but the mesh has M`, `cli.py`), but the *destination* side had no equivalent. The run therefore got all the way into remapping and failed once per file with:

```
ValueError: cannot reshape array of size 100 into shape (20,20)
```

— which names neither the weights nor the domain. Now:

```
gmpas: weights map onto 100 points but this target domain is 20 x 20 = 400.
They were built for a different target grid — rerun with --force-weights,
or delete map_conserve.nc.
```

Checked in **both** places: up front in the CLI beside the existing source check, so it fails before any work rather than per file; and again in `remap_file`, which is reachable as a library call.

### 2. A field with an axis `remap_file` cannot walk

It handles `Time` plus one level axis and hands the rest to the weights as a flat per-cell vector. Anything else in the shape has nowhere to go.

Real MPAS history carries exactly such fields — the ozone climatology is `(nCells, nOznLevels, nMonths)`, and `nOznLevels` is **not** in `LEVEL_PREFIXES` (`nVert`, `nSoil`, `nIso`), so `level_dim()` returned `None` and both extra axes were left dangling. `remappable()` accepted the field because it has `nCells`, and the remap then died with `ValueError: could not interpret dimensions`, losing the whole file.

`remappable()` now reports it the way it already reports an edge or vertex field:

```
o3clim: has nOznLevels, nMonths as well as cells — only Time and one level axis are handled
```

The other fields in the same file remap normally. Two level axes (e.g. `nVertLevels` + `nSoilLevels`) are likewise reported rather than silently guessed between.

## Test plan
- [x] Reproduced both failures first, against the real code paths, before changing anything.
- [x] 3 new tests: the stale-weights message names the weights file, the domain shape, and the remedy; the awkward field is skipped while good fields still land in the output; two level axes are reported.
- [x] `pytest -q tests/test_remap.py tests/test_remap_integration.py` → 51 passed, 1 skipped.
- [x] `pytest -q --ignore=tests/test_data.py` → 345 passed, 5 skipped. (`test_data.py` excluded only because it segfaults locally on `main` too — numpy 2.5.2 vs xarray's netCDF4 backend; CI runs it fine.)

## Note on what this does *not* change

The deeper issue is that the weights cache is keyed only on `method`, not on the grids it was built from — unlike the mesh geometry cache, which hashes the mesh file's identity precisely to stop this (`mesh.py: cache_path`). Making the weights self-identify would remove the failure mode rather than just report it, but it changes the on-disk filename, so it's left as a separate decision.