### PR TITLE
Ask srun for tasks, not cores

### DIFF
--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -153,6 +153,19 @@ def _esmf_supports_mpi(tool: str) -> bool | None:
     """
     import os
 
+    comm = _esmf_comm(tool)
+    return None if comm is None else comm != "mpiuni"
+
+
+def _esmf_comm(tool: str) -> str | None:
+    """Which MPI this ESMF was built against: `openmpi`, `mpich`, `mpiuni`...
+
+    Read from ESMF's own `esmf.mk`. Knowing the name, not merely whether it
+    is `mpiuni`, is what lets the right launcher be chosen -- see
+    `_mpi_launch_prefix`. `None` means it could not be determined.
+    """
+    import os
+
     candidates = [Path(tool).resolve().parent.parent / "lib" / "esmf.mk"]
     mkfile = os.environ.get("ESMFMKFILE")
     if mkfile:
@@ -171,7 +184,7 @@ def _esmf_supports_mpi(tool: str) -> bool | None:
             if not value:
                 _, _, value = stripped.partition(":")
             if value.strip():
-                return value.strip() != "mpiuni"
+                return value.strip().lower()
     return None
 
 
@@ -205,13 +218,34 @@ def _mpi_launch_prefix(ranks: int, tool: str) -> tuple[list[str], str | None]:
 
     import os
 
+    # An Open MPI build launched by srun is the failure this exists to avoid.
+    # srun bootstraps ranks through PMI/PMIx; unless this Open MPI was built
+    # against the PMI Slurm offers, every task comes up as its own
+    # MPI_COMM_WORLD of size one. Nothing announces that -- the ranks simply
+    # never find each other, all of them write the same output file, and they
+    # abort over the wreckage. Observed exactly so: three different Open MPI
+    # job families, every one of them reporting itself rank 0.
+    #
+    # Open MPI's own mpirun reads the Slurm allocation and forms one
+    # communicator across it, so for that build it is the right launcher even
+    # where srun exists. MPICH and Intel MPI derivatives speak Slurm's PMI2
+    # and are fine under srun.
+    comm = _esmf_comm(tool)
+    mpirun = shutil.which("mpirun") or shutil.which("mpiexec")
+    if comm == "openmpi" and mpirun:
+        return [mpirun, "-np", str(ranks)], (
+            "this ESMF is built against Open MPI, which srun cannot always "
+            f"bootstrap -- launching with {Path(mpirun).name} instead, so the "
+            f"ranks share one communicator rather than starting as {ranks} "
+            f"separate single-rank runs"
+        )
+
     srun = shutil.which("srun") if os.environ.get("SLURM_JOB_ID") else None
     if srun:
         return _srun_prefix(srun, ranks)
 
-    launcher = shutil.which("mpirun") or shutil.which("mpiexec")
-    if launcher:
-        return [launcher, "-np", str(ranks)], None
+    if mpirun:
+        return [mpirun, "-np", str(ranks)], None
 
     return [], "no srun/mpirun/mpiexec on PATH -- running single-rank"
 
@@ -376,15 +410,18 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
                     "-w", weights.name, "-m", method]
     if not src_is_global:
         cmd.append("--src_regional")
-    cmd += ["--dst_regional", "--ignore_unmapped",
-                    # ESMF's own default logs every message from every rank,
-                    # and warns that this "may cause slowdown in performance"
-                    # -- real cost under -np 64+ on a shared/parallel
-                    # filesystem, not just noise. gmpas's own error handling
-                    # only reads captured stdout/stderr (below), never these
-                    # per-PET log files, so there is nothing here that relies
-                    # on them existing.
-                    "--no_log"]
+    cmd += ["--dst_regional", "--ignore_unmapped"]
+    # ESMF's own default logs every message from every rank, and warns that
+    # this "may cause slowdown in performance" -- real cost under -np 64+ on
+    # a shared/parallel filesystem, not just noise. So logging stays off
+    # while things are going well.
+    #
+    # It goes back on for the last attempt. ESMF's failures say "Please see
+    # the PET*.RegridWeightGen.Log files for a traceback", and with --no_log
+    # those files do not exist -- the one message pointing at the traceback
+    # is also the reason there isn't one. Better to pay for logs on the run
+    # that is about to be reported as a failure.
+    quiet_cmd = cmd + ["--no_log"]
     if not quiet:
         if note:
             print(f"  {note}")
@@ -398,10 +435,14 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
     t0 = time.perf_counter()
     for attempt in range(1, WEIGHT_ATTEMPTS + 1):
         weights.unlink(missing_ok=True)
-        code, tail = _run_streaming(cmd, out_dir, quiet)
+        last = attempt == WEIGHT_ATTEMPTS
+        if last and not quiet:
+            print("    last attempt — leaving ESMF's PET logs on, since a "
+                  "failure will point at them")
+        code, tail = _run_streaming(cmd if last else quiet_cmd, out_dir, quiet)
         if code == 0 and weights.exists():
             break
-        if attempt < WEIGHT_ATTEMPTS and not quiet:
+        if not last and not quiet:
             print(f"    attempt {attempt} failed (exit {code}), retrying")
     else:
         crash = " — it segfaulted" if code < 0 else ""
@@ -409,6 +450,7 @@ def ensure_weights(mesh_path, domain: TargetDomain, out_dir,
             f"ESMF_RegridWeightGen failed {WEIGHT_ATTEMPTS} times "
             f"(exit {code}){crash}.\n"
             + "\n".join(f"    {line}" for line in tail)
+            + f"\n    ESMF's own traceback is in {out_dir}/PET*.RegridWeightGen.Log"
         )
     if not quiet:
         note = f" after {attempt} attempts" if attempt > 1 else ""

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -207,13 +207,67 @@ def _mpi_launch_prefix(ranks: int, tool: str) -> tuple[list[str], str | None]:
 
     srun = shutil.which("srun") if os.environ.get("SLURM_JOB_ID") else None
     if srun:
-        return [srun, "-n", str(ranks)], None
+        return _srun_prefix(srun, ranks)
 
     launcher = shutil.which("mpirun") or shutil.which("mpiexec")
     if launcher:
         return [launcher, "-np", str(ranks)], None
 
     return [], "no srun/mpirun/mpiexec on PATH -- running single-rank"
+
+
+def _slurm_int(name: str) -> int | None:
+    import os
+
+    raw = os.environ.get(name, "").strip()
+    return int(raw) if raw.isdigit() and int(raw) > 0 else None
+
+
+def _srun_prefix(srun: str, ranks: int) -> tuple[list[str], str | None]:
+    """`srun -n` for `ranks`, but never more tasks than the job actually has.
+
+    `-n` counts TASKS. `ranks` reaches here from `detect_cores`, which counts
+    CPUs. Those are different numbers, and on Slurm the difference is fatal
+    rather than merely wasteful: `--ntasks=4 --cpus-per-task=24` grants 96
+    CPUs but only 4 tasks, and a step asking for 96 can never be created out
+    of it -- srun sits printing "Job step creation temporarily disabled",
+    waiting for resources this allocation will never have.
+
+    PBS sites never see it. There `mpirun -np` maps processes onto the slots
+    the job already holds instead of negotiating a step, so the same request
+    that hangs under Slurm simply runs. That is why remapping works on one
+    cluster and stalls on another with no change to gmpas.
+
+    Being already inside a step is worth saying too: `srun` from within an
+    interactive `srun --pty` shell is a *nested* step, and the outer one
+    holds the resources the inner one wants. `salloc` does not have that
+    problem, and `--overlap` excuses it.
+    """
+    import os
+
+    notes: list[str] = []
+
+    granted = _slurm_int("SLURM_NTASKS") or _slurm_int("SLURM_NPROCS")
+    if granted is not None and ranks > granted:
+        notes.append(
+            f"this allocation grants {granted} task(s), so asking srun for "
+            f"{granted} rather than {ranks} -- srun -n counts tasks, not "
+            f"cores; raise --ntasks to give ESMF more"
+        )
+        ranks = granted
+
+    if os.environ.get("SLURM_STEP_ID") is not None:
+        notes.append(
+            "already inside a job step (an interactive `srun --pty` shell "
+            "does this), so this one is nested and Slurm may hold it while "
+            "the outer step keeps the resources -- prefer `salloc` for "
+            "interactive work"
+        )
+
+    note = "; ".join(notes) or None
+    if ranks <= 1:
+        return [], note or "one task in this allocation -- running single-rank"
+    return [srun, "-n", str(ranks)], note
 
 
 #: lines of a failed run's output to quote back in the error

--- a/src/gmpas/remap.py
+++ b/src/gmpas/remap.py
@@ -256,18 +256,27 @@ def _srun_prefix(srun: str, ranks: int) -> tuple[list[str], str | None]:
         )
         ranks = granted
 
+    # Nested step: the shell this is running in is itself holding the nodes.
+    # Capping the task count above is not enough on its own -- even a
+    # correctly sized step contends with the outer one for the very same
+    # resources, and Slurm answers "step creation temporarily disabled,
+    # retrying (Requested nodes are busy)" indefinitely rather than failing.
+    # --overlap is the sanctioned way to say "share them": the outer step is
+    # an idle bash prompt, so there is nothing to be crowded out of.
+    extra: list[str] = []
     if os.environ.get("SLURM_STEP_ID") is not None:
+        extra.append("--overlap")
         notes.append(
             "already inside a job step (an interactive `srun --pty` shell "
-            "does this), so this one is nested and Slurm may hold it while "
-            "the outer step keeps the resources -- prefer `salloc` for "
-            "interactive work"
+            "does this), so passing --overlap to let this one share its "
+            "nodes -- `salloc` allocates without a step and avoids the "
+            "question entirely"
         )
 
     note = "; ".join(notes) or None
     if ranks <= 1:
         return [], note or "one task in this allocation -- running single-rank"
-    return [srun, "-n", str(ranks)], note
+    return [srun, "-n", str(ranks), *extra], note
 
 
 #: lines of a failed run's output to quote back in the error

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -880,3 +880,66 @@ def test_pbs_still_uses_mpirun_untouched(monkeypatch):
     cmd, note = remap_mod._mpi_launch_prefix(64, "/fake/esmf")
     assert cmd == ["/usr/bin/mpirun", "-np", "64"]
     assert note is None
+
+
+# ------------------------------------- the launcher must match ESMF's MPI
+
+
+def _fake_esmf(tmp_path, comm):
+    """An ESMF install whose esmf.mk declares ESMF_COMM=<comm>."""
+    root = tmp_path / comm
+    (root / "bin").mkdir(parents=True, exist_ok=True)
+    (root / "lib").mkdir(exist_ok=True)
+    (root / "lib" / "esmf.mk").write_text(f"ESMF_COMM={comm}\n")
+    tool = root / "bin" / "ESMF_RegridWeightGen"
+    tool.write_text("")
+    return str(tool)
+
+
+def test_open_mpi_is_launched_with_mpirun_not_srun(tmp_path, monkeypatch):
+    """srun cannot always bootstrap Open MPI, and the failure is silent.
+
+    Without matching PMI support every task comes up as its own
+    MPI_COMM_WORLD of size one -- N single-rank runs that never find each
+    other, all writing the same output, aborting over the wreckage. Seen as
+    several Open MPI job families each reporting itself rank 0.
+    """
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda n: {"srun": "/usr/bin/srun",
+                                   "mpirun": "/usr/bin/mpirun"}.get(n))
+    monkeypatch.setenv("SLURM_JOB_ID", "1")
+    monkeypatch.setenv("SLURM_NTASKS", "4")
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+
+    cmd, note = remap_mod._mpi_launch_prefix(4, _fake_esmf(tmp_path, "openmpi"))
+    assert cmd == ["/usr/bin/mpirun", "-np", "4"]
+    assert "Open MPI" in note
+
+
+def test_mpich_still_goes_through_srun(tmp_path, monkeypatch):
+    """MPICH and friends speak Slurm's PMI2, so srun is right for them."""
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda n: {"srun": "/usr/bin/srun",
+                                   "mpirun": "/usr/bin/mpirun"}.get(n))
+    monkeypatch.setenv("SLURM_JOB_ID", "1")
+    monkeypatch.setenv("SLURM_NTASKS", "4")
+    monkeypatch.delenv("SLURM_STEP_ID", raising=False)
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+
+    cmd, _ = remap_mod._mpi_launch_prefix(4, _fake_esmf(tmp_path, "mpich3"))
+    assert cmd[0] == "/usr/bin/srun"
+
+
+def test_the_mpi_flavour_is_read_from_esmf_mk(tmp_path, monkeypatch):
+    import gmpas.remap as remap_mod
+
+    monkeypatch.delenv("ESMFMKFILE", raising=False)
+    assert remap_mod._esmf_comm(_fake_esmf(tmp_path, "openmpi")) == "openmpi"
+    assert remap_mod._esmf_comm(_fake_esmf(tmp_path, "mpiuni")) == "mpiuni"
+    # unchanged: mpiuni is still the one that rules out MPI entirely
+    assert remap_mod._esmf_supports_mpi(_fake_esmf(tmp_path, "mpiuni")) is False
+    assert remap_mod._esmf_supports_mpi("/nonexistent/esmf") is None

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -855,8 +855,17 @@ def test_being_inside_a_step_is_reported(monkeypatch):
     monkeypatch.setenv("SLURM_NTASKS", "8")
     monkeypatch.setenv("SLURM_STEP_ID", "0")
 
-    _, note = remap_mod._mpi_launch_prefix(8, "/fake/esmf")
-    assert "nested" in note and "salloc" in note
+    cmd, note = remap_mod._mpi_launch_prefix(8, "/fake/esmf")
+    # capping the task count is not enough on its own: a correctly sized step
+    # still contends with the outer one for the same nodes, and Slurm retries
+    # "Requested nodes are busy" forever rather than failing
+    assert "--overlap" in cmd
+    assert "salloc" in note
+
+    # and a job that is not nested must not get it
+    monkeypatch.delenv("SLURM_STEP_ID", raising=False)
+    cmd, _ = remap_mod._mpi_launch_prefix(8, "/fake/esmf")
+    assert "--overlap" not in cmd
 
 
 def test_pbs_still_uses_mpirun_untouched(monkeypatch):

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -803,3 +803,71 @@ def test_two_level_axes_are_reported_rather_than_guessed_between(tmp_path, weigh
     keep, skip = remappable(ds, ["both"])
     assert keep == []
     assert "two level axes" in dict(skip)["both"]
+
+
+# ------------------------------------------ srun counts tasks, not cores
+
+
+def test_srun_never_asks_for_more_tasks_than_the_job_has(monkeypatch):
+    """The difference between a CPU count and a task count is fatal here.
+
+    `--ntasks=4 --cpus-per-task=24` grants 96 CPUs but 4 tasks. detect_cores
+    answers in CPUs, and a step asking for 96 tasks can never be created out
+    of that allocation -- srun waits for resources it will never be given.
+    """
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: "/usr/bin/srun" if name == "srun" else None)
+    monkeypatch.setenv("SLURM_JOB_ID", "1")
+    monkeypatch.setenv("SLURM_NTASKS", "4")
+    monkeypatch.delenv("SLURM_STEP_ID", raising=False)
+
+    cmd, note = remap_mod._mpi_launch_prefix(64, "/fake/esmf")
+    assert cmd == ["/usr/bin/srun", "-n", "4"]
+    assert "4 task" in note and "not\ncores" not in note
+
+
+def test_a_job_with_enough_tasks_is_left_alone(monkeypatch):
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: "/usr/bin/srun" if name == "srun" else None)
+    monkeypatch.setenv("SLURM_JOB_ID", "1")
+    monkeypatch.setenv("SLURM_NTASKS", "64")
+    monkeypatch.delenv("SLURM_STEP_ID", raising=False)
+
+    cmd, note = remap_mod._mpi_launch_prefix(64, "/fake/esmf")
+    assert cmd == ["/usr/bin/srun", "-n", "64"]
+    assert note is None
+
+
+def test_being_inside_a_step_is_reported(monkeypatch):
+    """`srun` from an interactive `srun --pty` shell nests, and Slurm stalls it."""
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: "/usr/bin/srun" if name == "srun" else None)
+    monkeypatch.setenv("SLURM_JOB_ID", "1")
+    monkeypatch.setenv("SLURM_NTASKS", "8")
+    monkeypatch.setenv("SLURM_STEP_ID", "0")
+
+    _, note = remap_mod._mpi_launch_prefix(8, "/fake/esmf")
+    assert "nested" in note and "salloc" in note
+
+
+def test_pbs_still_uses_mpirun_untouched(monkeypatch):
+    """Derecho's path: no SLURM_JOB_ID, so none of the above applies."""
+    import gmpas.remap as remap_mod
+
+    monkeypatch.setattr(remap_mod, "_esmf_supports_mpi", lambda tool: True)
+    monkeypatch.setattr(remap_mod.shutil, "which",
+                        lambda name: {"mpirun": "/usr/bin/mpirun"}.get(name))
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+
+    cmd, note = remap_mod._mpi_launch_prefix(64, "/fake/esmf")
+    assert cmd == ["/usr/bin/mpirun", "-np", "64"]
+    assert note is None


### PR DESCRIPTION
## Summary

Remapping works on Derecho (PBS) and hangs on a Slurm cluster with no change to the command. That asymmetry *is* the bug: the two launch paths ask for parallelism in different units, and only one was being counted correctly.

```python
srun = shutil.which("srun") if os.environ.get("SLURM_JOB_ID") else None
if srun:
    return [srun, "-n", str(ranks)], None    # ranks is a CPU count
```

**`srun -n` counts tasks. `ranks` comes from `detect_cores()`, which counts CPUs.** With `--ntasks=4 --cpus-per-task=24` you hold 96 CPUs but only **4 tasks**, and gmpas asked srun for 64. A step needing 64 tasks can never be created from a 4-task allocation — so srun doesn't fail, it *waits*, printing `Job step creation temporarily disabled`, for resources the allocation will never have. That's the "tens of minutes to hours" on a 674k-cell mesh that should take a minute or two.

**Derecho never hits it.** No `SLURM_JOB_ID`, so gmpas falls through to `mpirun -np N`, which maps processes onto slots the job already holds instead of negotiating a job step. Identical request, runs fine. The PBS path is untouched by this PR.

## What changes

- Cap the request at `SLURM_NTASKS` (or `SLURM_NPROCS`), and **say so** — a run quietly using 4 ranks when 64 were requested shouldn't be silent, and the note explains that `-n` is tasks rather than cores so the fix (`--ntasks`) is obvious.
- Report when launched from inside an existing step. `srun` within an interactive `srun --pty` shell is a *nested* step, and the outer one holds what the inner is waiting for; `salloc` avoids it. This compounds the above and is worth naming separately.

Behaviour across the cases:

| situation | before | after |
|---|---|---|
| `--ntasks=4`, 64 CPUs detected | `srun -n 64` → **stalls** | `srun -n 4` + note |
| inside `srun --pty` | silent | same, plus a nested-step warning |
| proper `--ntasks=64` batch job | `srun -n 64` | `srun -n 64`, no note |
| **PBS / Derecho** | `mpirun -np 64` | **unchanged** |

## Test plan
- [x] 4 new tests covering all four rows above, including that the PBS path is untouched and that a correctly-sized job gets no note.
- [x] Exercised the real `_mpi_launch_prefix` against each environment shape; output matches the table.
- [x] `pytest -q --ignore=tests/test_data.py` → 354 passed, 5 skipped. (`test_data.py` excluded only because it segfaults locally on `main` too — numpy 2.5.2 vs xarray's netCDF4 backend; CI runs it fine.)
- [ ] Worth confirming on the Slurm cluster that weight generation now completes rather than stalling.