### PR TITLE
Serve the viewer to a terminal, attribute the cold start, and release 0.4.6

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ type: software
 authors:
   - given-names: Nirmal Mathew
     family-names: Alex
-version: 0.4.5
-date-released: "2026-08-18"
+version: 0.4.6
+date-released: "2026-09-03"
 repository-code: "https://github.com/nmathewa/gmpas-lib"
 url: "https://github.com/nmathewa/gmpas-lib"
 doi: 10.5281/zenodo.21987068

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -15,13 +15,21 @@ gmpas view /scratch/run/ --no-browser --port 8765
 
 and open `http://localhost:8765` in your own browser.
 
-Two environment variables matter on a shared machine:
+Environment variables that matter on a shared machine:
 
 - `GMPAS_CACHE_DIR` — where cached mesh geometry goes. Defaults to
   `~/.cache/gmpas/mesh`; point it at scratch if your home quota is small.
   The cache is memory-mapped, so several processes reading the same mesh share
   one copy through the page cache.
 - `GMPAS_DATA_DIR` — tried first when resolving relative paths.
+- `GMPAS_VALUES_CACHE_MB` (default 512) and `GMPAS_VIEW_CACHE_MB` (default 256)
+  — memory budgets, in megabytes. Lower them on a login node with a small
+  cgroup limit; see [configuration.md](configuration.md).
+- `GMPAS_TIMING=1` with `GMPAS_TIMING_FILE=timing.log` — when something is
+  slow, this says which stage. On a run directory holding thousands of files,
+  expect `mesh.discover` and `series.scan` to dominate a cold start: both open
+  every file in the directory, and every open is a round trip to the metadata
+  server.
 
 Batch rendering scales with `-j`, but two things limit it: worker startup
 (cheap under `fork` on Linux, expensive under `spawn` on macOS), and the

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -1,19 +1,65 @@
 # On a cluster
 
-The viewer serves on `127.0.0.1`, so forward the port rather than exporting a
-display — this is the case where ncview's X11 forwarding hurts most:
+`gmpas view` never opens a browser. It prints a URL and, when that URL is on
+another machine, the exact `ssh` command that reaches it — copy both. Nothing
+here needs a display, and forwarding a port beats exporting one: this is the
+case where ncview's X11 forwarding hurts most.
+
+## On a login node
 
 ```bash
-ssh -L 8765:localhost:8765 user@cluster
+gmpas view /scratch/run/ --port 8765
 ```
 
-then on the node, inside your interactive job:
+It prints the tunnel command with your username and this node's name already
+filled in. Run that on your own machine:
 
 ```bash
-gmpas view /scratch/run/ --no-browser --port 8765
+ssh -N -L 8765:localhost:8765 you@login.cluster.edu
 ```
 
-and open `http://localhost:8765` in your own browser.
+and open `http://localhost:8765` in your own browser. `-N` means "no remote
+command" — it just forwards, and holds the terminal until you stop it.
+
+## Inside a batch job
+
+A compute node is not reachable from outside, and your tunnel lands on the
+login node — where `127.0.0.1` is a *different machine's* loopback. So the
+default bind is the one thing that cannot work there:
+
+```bash
+gmpas view /scratch/run/ --host 0.0.0.0 --port 8765
+```
+
+gmpas notices it is inside a PBS or Slurm allocation, and prints a tunnel that
+hops through the node you submitted from, naming the compute node explicitly:
+
+```bash
+ssh -N -L 8765:dec1042:8765 you@derecho7
+```
+
+Bound to `0.0.0.0` the viewer is reachable by anything that can route to the
+node, which on most clusters is everyone else logged in
+([issue 1](https://github.com/nmathewa/gmpas-lib/issues/1)). It serves your
+run read-only and holds no credentials, but pick a nonstandard `--port` and
+stop it when you are done.
+
+If you run it inside a job *without* `--host 0.0.0.0`, gmpas says so rather
+than printing a tunnel command that cannot land.
+
+## A note on ports
+
+An explicit `--port` is strict: if it is busy, gmpas fails instead of quietly
+listening somewhere else. That is deliberate — your tunnel is pinned to that
+number, and a viewer that wandered to 8766 looks exactly like a dead server
+from the browser. Without `--port` it starts at 8765 and moves on if busy.
+
+## If you want a browser opened anyway
+
+`--browser` asks for it. On a login node it usually finds no graphical browser
+and hands the URL to whatever the system default is, which is often a terminal
+browser that takes over the terminal the server is logging to — so it is off
+by default, and gmpas refuses to launch one that would do that.
 
 Environment variables that matter on a shared machine:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,41 @@
 # Configuration
 
-Two environment variables, both optional:
+Environment variables, all optional:
 
 - `GMPAS_CACHE_DIR` — where cached mesh geometry (a directory of `.npy` arrays) goes.
   Defaults to `~/.cache/gmpas/mesh`. Safe to delete; it rebuilds.
 - `GMPAS_DATA_DIR` — tried first when resolving a relative path, before the
   working directory.
+
+## Memory budgets
+
+Both are sized in **bytes, not entries**. One field is a couple of megabytes on
+a small regional mesh and 320 MB on a 3.75 km global one, so a cache bounded by
+a count of entries is a cache whose real footprint swings by a factor of a
+hundred with the mesh.
+
+- `GMPAS_VALUES_CACHE_MB` — field values held in memory per open series.
+  Defaults to 512.
+- `GMPAS_VIEW_CACHE_MB` — pixel-to-cell indices and coastline overlays held per
+  viewer. Defaults to 256. An entry costs `nx * ny * 9` bytes, so it scales with
+  the browser window rather than with the mesh.
+
+## Seeing where the time goes
+
+- `GMPAS_TIMING` — `1` reports startup-scale stages to stderr, `2` adds
+  per-frame stages and peak-memory deltas. Every run ends with a roll-up
+  totalling each stage, which is the useful thing to paste into an issue.
+- `GMPAS_TIMING_FILE` — write those lines to a file instead of stderr. Worth
+  setting for `plot --all-steps -j N`, where N workers otherwise interleave
+  their output.
+
+```
+$ GMPAS_TIMING=1 gmpas info run/
+gmpas.timing  mesh.discover      0.013s  scanned=13 opened=12
+gmpas.timing  series.scan        0.012s  files=13 opened=12
+gmpas.timing  mesh.tree_build    0.006s  cells=300
+```
+
+`opened=` is the count that matters on a parallel filesystem: each one is a
+network round trip, and both of those stages grow with the number of files in
+the run directory rather than with the size of the mesh.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -25,7 +25,7 @@ KD-tree turns each view box into a pixel-to-cell index once, and every field
 and every frame at that extent is then a gather.
 
 Same flags as `view` for tunnelling and size: `-p/--port`, `--host`,
-`--width`, `--height`, `--no-browser`. On a compute node use `--host 0.0.0.0`
+`--width`, `--height`, `--browser`. On a compute node use `--host 0.0.0.0`
 and tunnel, exactly as for `view`.
 
 Two fields are offered, both derived from geometry the mesh cache already

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-As of 0.4.5, gmpas covers the pipeline from both ends.
+As of 0.4.6, gmpas covers the pipeline from both ends.
 
 **Postprocessing** — plotting, the interactive viewer, and conservative
 remapping — is implemented. `gmpas remap` writes the grid files ESMF needs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.5"
+version = "0.4.6"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -31,7 +31,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 __all__ = [
     # entry points

--- a/src/gmpas/cache.py
+++ b/src/gmpas/cache.py
@@ -1,0 +1,136 @@
+"""A bounded, concurrent get-or-build cache for expensive per-view objects.
+
+Four viewers (`viewer`, `generic`, `prep.meshview`, `prep.hfunview`) each kept
+their own pixel-to-cell indices and coastline overlays, and only one of them
+had solved the two problems that come with it:
+
+  * **Bound it by bytes, not by entries.** A count is a proxy for memory that
+    holds only while entry size is fixed. `VIEW_LRU_SIZE = 12` is ~178 MB of
+    view indices at the 1200x700 default and ~1.1 GB at 3840x2160, and two of
+    the four viewers used plain dicts that never evicted at all. The same
+    reasoning already cost this project an OOM on a memory-capped login node
+    once, in the values cache -- see `series.values_budget`.
+
+  * **Never hold the lock across the build.** Building a view index queries a
+    KD-tree and rendering an overlay runs cartopy; both take long enough that
+    holding a shared lock over them serialises every unrelated request in the
+    process. But dropping the lock naively lets N concurrent requests for the
+    same missing key each do the whole build, so each key gets a one-shot
+    Event that latecomers wait on instead.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections import OrderedDict
+
+#: bytes of cached view indices and overlays to keep, per viewer
+VIEW_CACHE_BYTES = 256 * 1024 * 1024
+
+VIEW_CACHE_ENV = "GMPAS_VIEW_CACHE_MB"
+
+
+def view_budget() -> int:
+    """Byte budget for one viewer's caches, overridable by environment."""
+    raw = os.environ.get(VIEW_CACHE_ENV)
+    if not raw:
+        return VIEW_CACHE_BYTES
+    try:
+        return max(0, int(float(raw) * 1024 * 1024))
+    except ValueError:
+        return VIEW_CACHE_BYTES
+
+
+def sizeof(value) -> int:
+    """Bytes `value` occupies, for the things these caches actually hold.
+
+    Overlays are encoded PNG bytes and view indices expose `nbytes`; anything
+    else is charged a nominal amount rather than guessed at, since a wrong
+    guess silently breaks the budget rather than failing loudly.
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return len(value)
+    n = getattr(value, "nbytes", None)
+    return int(n) if n is not None else 1
+
+
+class BuildCache:
+    """Get-or-build, bounded by bytes, safe to share across request threads."""
+
+    def __init__(self, budget: int | None = None, measure=sizeof):
+        self.budget = view_budget() if budget is None else budget
+        self._measure = measure
+        self._items: OrderedDict = OrderedDict()
+        self._bytes = 0
+        self._pending: dict = {}
+        self._lock = threading.Lock()
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    @property
+    def nbytes(self) -> int:
+        return self._bytes
+
+    def get(self, key, build):
+        """Return `cache[key]`, calling `build()` at most once per key.
+
+        `build()` runs outside the lock, so a request for a different key never
+        waits on it. A build that raises leaves nothing cached and wakes its
+        waiters, who retry rather than silently reusing a failure.
+        """
+        with self._lock:
+            if key in self._items:
+                self._items.move_to_end(key)
+                return self._items[key]
+            ev = self._pending.get(key)
+            if ev is None:
+                self._pending[key] = ev = threading.Event()
+                mine = True
+            else:
+                mine = False
+
+        if not mine:
+            ev.wait()
+            with self._lock:
+                if key in self._items:
+                    return self._items[key]
+            return self.get(key, build)          # builder failed: retry
+
+        try:
+            value = build()
+        except BaseException:
+            with self._lock:
+                self._pending.pop(key, None)
+            ev.set()
+            raise
+
+        with self._lock:
+            self._remember(key, value)
+            self._pending.pop(key, None)
+        ev.set()
+        return value
+
+    def _remember(self, key, value) -> None:
+        """Store `value`, evicting oldest first to stay inside the budget.
+
+        Caller holds the lock. An entry bigger than the whole budget is not
+        cached at all: keeping it would evict everything else and still leave
+        it as the sole occupant, to be evicted itself by the next distinct
+        request. Same rule, and same reasoning, as `Series._remember`.
+        """
+        n = int(self._measure(value))
+        if n > self.budget:
+            return
+
+        self._items[key] = value
+        self._bytes += n
+        while self._bytes > self.budget and len(self._items) > 1:
+            _, old = self._items.popitem(last=False)
+            self._bytes -= int(self._measure(old))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+            self._bytes = 0

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 from . import __version__
+from .timing import Progress, clock
 
 #: only the default port is allowed to wander when busy
 DEFAULT_PORT = 8765
@@ -35,60 +36,6 @@ def human(n: float) -> str:
             return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
         n /= 1024
     return f"{n:.1f} GB"
-
-
-class Progress:
-    """A bar when someone is watching, periodic lines when nobody is.
-
-    Under a scheduler stdout is a log file, and a carriage-returning bar just
-    fills it with thousands of partial lines. So the same information is
-    emitted either way, in whichever shape suits the destination.
-    """
-
-    def __init__(self, total: int, width: int = 32, every: int = 10):
-        self.total = total
-        self.width = width
-        self.every = every            # percent between lines when not a tty
-        self.done = 0
-        self.t0 = time.perf_counter()
-        self.tty = sys.stdout.isatty()
-        self._last = -1
-
-    def advance(self, label: str = "") -> None:
-        self.done += 1
-        elapsed = time.perf_counter() - self.t0
-        frac = self.done / self.total if self.total else 1.0
-        eta = (elapsed / self.done) * (self.total - self.done) if self.done else 0
-
-        if self.tty:
-            filled = int(self.width * frac)
-            bar = "#" * filled + "-" * (self.width - filled)
-            sys.stdout.write(
-                f"\r  [{bar}] {self.done}/{self.total} {frac * 100:3.0f}%  "
-                f"{elapsed / self.done:.1f}s/file  eta {clock(eta)}   "
-            )
-            sys.stdout.flush()
-        else:
-            pct = int(frac * 100)
-            if pct // self.every > self._last // self.every or self.done == self.total:
-                self._last = pct
-                print(f"  {self.done}/{self.total} ({pct}%)  "
-                      f"{elapsed / self.done:.1f}s/file  eta {clock(eta)}")
-
-    def close(self) -> None:
-        if self.tty:
-            sys.stdout.write("\r" + " " * (self.width + 60) + "\r")
-            sys.stdout.flush()
-
-
-def clock(seconds: float) -> str:
-    if seconds < 60:
-        return f"{seconds:.0f}s"
-    m, sec = divmod(int(seconds), 60)
-    if m < 60:
-        return f"{m}m{sec:02d}s"
-    h, m = divmod(m, 60)
-    return f"{h}h{m:02d}m"
 
 
 EXAMPLES = """
@@ -124,6 +71,10 @@ one time series across files, which is how MPAS writes output.
 environment:
   GMPAS_CACHE_DIR   where cached mesh geometry goes (default ~/.cache/gmpas/mesh)
   GMPAS_DATA_DIR    tried first when resolving relative paths
+  GMPAS_VALUES_CACHE_MB  field values held per series (default 512)
+  GMPAS_VIEW_CACHE_MB    view indices and overlays held per viewer (default 256)
+  GMPAS_TIMING      1 reports where startup time went, 2 adds per-frame stages
+  GMPAS_TIMING_FILE write those lines to a file instead of stderr
   JIGSAWDIR         the jigsaw executable, or the directory holding it
   MKGRIDFILE        the mkgrid executable, or the directory holding it
                     both required by `gmpas prep generate`
@@ -213,10 +164,12 @@ def _render_one(job):
 def _plot_series(args) -> int:
     """Render every step, in parallel.
 
-    Each worker builds its own KD-tree and view geometry, which sounds
-    wasteful but is not: the mesh cache is memory-mapped, so every process
-    shares one copy of the geometry through the page cache rather than each
-    reading its own.
+    Each worker builds its own KD-tree and view geometry. The geometry part of
+    that is genuinely cheap -- the mesh cache is memory-mapped, so every
+    process shares one copy through the page cache rather than reading its own
+    -- but the KD-tree and the series scan are not cached anywhere, so they are
+    paid again in full by every worker. Resolving the mesh here and naming it
+    explicitly at least spares each of them the directory probe.
     """
     import os
     from multiprocessing import Pool
@@ -225,6 +178,12 @@ def _plot_series(args) -> int:
 
     series = Series(args.path, args.mesh or "")
     n = len(series)
+    # Which file the mesh came from is already known now, so hand workers the
+    # answer rather than the question: without this each job re-runs
+    # `find_mesh_beside`, which opens every .nc in the directory until it finds
+    # one carrying mesh variables. On a run of a few thousand history files,
+    # over a parallel filesystem, that is thousands of round trips per frame.
+    mesh_path = str(series.mesh.path)
     series.close()
 
     jobs = args.jobs or os.cpu_count() or 1
@@ -234,7 +193,7 @@ def _plot_series(args) -> int:
         "extent": args.extent, "symmetric": args.symmetric,
         "method": args.method, "title": args.title, "pattern": args.out,
     }
-    work = [(args.path, args.mesh or "", args.var, s, opts) for s in range(n)]
+    work = [(args.path, mesh_path, args.var, s, opts) for s in range(n)]
 
     print(f"rendering {n} steps with {jobs} worker(s)", file=sys.stderr)
     if jobs == 1:
@@ -1039,12 +998,19 @@ def main(argv=None) -> int:
     if getattr(args, "cache_dir", None):
         os.environ["GMPAS_CACHE_DIR"] = args.cache_dir
 
+    from . import timing
     from .mesh import MeshCacheError
     from .prep.generate import GenerateError
     from .remap import RemapError
 
+    # --cache-dir may have just rewritten the environment, and GMPAS_TIMING is
+    # read when `step` is bound rather than on every call, so re-resolve here
+    # to catch anything set between import and now.
+    timing.refresh()
+
     try:
-        return args.func(args)
+        with timing.step("cli.total", cmd=getattr(args, "cmd", None)):
+            return args.func(args)
     except (RemapError, MeshCacheError, GenerateError) as exc:
         print(f"\ngmpas: {exc}", file=sys.stderr)
         return 1

--- a/src/gmpas/cli.py
+++ b/src/gmpas/cli.py
@@ -52,16 +52,18 @@ examples:
   gmpas target -o dst.scrip.nc              reads target_domain from this directory
   gmpas target run/history.nc               and which fields would be remapped
 
-  gmpas view  run/                          browse interactively in a browser
-  gmpas view  run/ --host 0.0.0.0 --no-browser   on an HPC compute node
+  gmpas view  run/                          serve it, and print a URL to open
+  gmpas view  run/ --host 0.0.0.0           on an HPC compute node
 
   gmpas prep hfun     hfun.py --check     the mesh you are about to build
   gmpas prep generate hfun.py -o mesh/    run JIGSAW and build it
 
-on a cluster the job runs on a compute node but your tunnel lands on the login
-node, so bind all interfaces and tunnel to the node by name:
+`view` never opens a browser for you -- it prints the URL and, when that is on
+another machine, the exact ssh command to reach it. Copy them; nothing here
+needs a display. On a cluster the job runs on a compute node but your tunnel
+lands on the login node, so bind all interfaces and tunnel to the node by name:
 
-  compute node:  gmpas view /scratch/run/ --host 0.0.0.0 --no-browser
+  compute node:  gmpas view /scratch/run/ --host 0.0.0.0
   your machine:  ssh -N -L 8765:<compute-node>:8765 <login-node>
                  then open http://localhost:8765
 
@@ -524,7 +526,7 @@ def _dashboard(args, data_path=None, mesh_path="", hfun_path="") -> int:
     # and was allowed to wander to 8766 when busy, leaving the tunnel pointing
     # at nothing and looking, from the browser, exactly like a dead server.
     serve(sources, port=DEFAULT_PORT if args.port is None else args.port,
-          host=args.host, open_browser=not args.no_browser,
+          host=args.host, open_browser=args.browser,
           strict_port=args.port is not None, banner=banner)
     return 0
 
@@ -560,7 +562,7 @@ def _generic_view(args) -> int:
                     f"{gv.steps} step{'s' if gv.steps != 1 else ''}",
                     _handler(gv, PAGE))
     serve([source], port=DEFAULT_PORT if args.port is None else args.port,
-          host=args.host, open_browser=not args.no_browser,
+          host=args.host, open_browser=args.browser,
           strict_port=args.port is not None,          # see the note in _dashboard
           banner=f"gmpas view --generic · {gv.path.name}")
     return 0
@@ -707,6 +709,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="mesh geometry cache directory for this run, overriding "
              "$GMPAS_CACHE_DIR (default: $GMPAS_CACHE_DIR or ~/.cache/gmpas/mesh)")
 
+    def browser_opts(sp):
+        """Opting *in* to a browser, and keeping the old opt-out accepted.
+
+        Not opening one is now the default, so `--no-browser` asks for what
+        already happens. It stays accepted and hidden rather than removed:
+        it is in every existing job script, every note someone wrote down and
+        this project's own older docs, and failing those runs with "unrecognized
+        argument" to make a point about a flag that is now a no-op would be
+        pure cost to the user.
+        """
+        sp.add_argument("--browser", action="store_true",
+                        help="also try to open a browser here (off by "
+                             "default: on a login or compute node this "
+                             "usually lands in a terminal browser)")
+        sp.add_argument("--no-browser", action="store_true",
+                        help=argparse.SUPPRESS)
+
     def common(sp):
         # nargs="+" so an unquoted glob works too: the shell expands it into
         # many arguments, and Series.expand already accepts a list
@@ -803,8 +822,7 @@ def build_parser() -> argparse.ArgumentParser:
                         "node so a tunnel from the login node can reach it")
     v.add_argument("--width", type=int, default=1200, help="raster width in pixels")
     v.add_argument("--height", type=int, default=700)
-    v.add_argument("--no-browser", action="store_true",
-                   help="do not open a browser (useful over an SSH tunnel)")
+    browser_opts(v)
     v.set_defaults(func=_view)
 
     # -- preprocessing ---------------------------------------------------
@@ -837,8 +855,7 @@ def build_parser() -> argparse.ArgumentParser:
     pv.add_argument("--width", type=int, default=1200,
                     help="raster width in pixels")
     pv.add_argument("--height", type=int, default=700)
-    pv.add_argument("--no-browser", action="store_true",
-                    help="do not open a browser (useful over an SSH tunnel)")
+    browser_opts(pv)
     pv.add_argument("--cache-dir", **_cache_dir_opt)
     pv.set_defaults(func=_prep_view)
 
@@ -863,8 +880,7 @@ def build_parser() -> argparse.ArgumentParser:
     ph.add_argument("--width", type=int, default=1200,
                     help="raster width in pixels")
     ph.add_argument("--height", type=int, default=700)
-    ph.add_argument("--no-browser", action="store_true",
-                    help="do not open a browser (useful over an SSH tunnel)")
+    browser_opts(ph)
     ph.add_argument("--cache-dir", **_cache_dir_opt)
     ph.set_defaults(func=_prep_hfun)
 
@@ -1014,7 +1030,12 @@ def main(argv=None) -> int:
     except (RemapError, MeshCacheError, GenerateError) as exc:
         print(f"\ngmpas: {exc}", file=sys.stderr)
         return 1
-    except (FileNotFoundError, KeyError, ValueError) as exc:
+    except (OSError, KeyError, ValueError) as exc:
+        # OSError rather than FileNotFoundError alone: a file that is present
+        # but unreadable -- truncated mid-transfer, still being written by a
+        # running model, no permission on a shared scratch directory -- is
+        # exactly as much a user's problem to fix and as little a bug, and it
+        # used to come out as a netCDF traceback.
         print(f"gmpas: {exc}", file=sys.stderr)
         return 1
     except ModuleNotFoundError as exc:

--- a/src/gmpas/dashboard.py
+++ b/src/gmpas/dashboard.py
@@ -151,9 +151,13 @@ def router(sources: list[Source]):
 
 
 def serve(sources: list[Source], port: int = 8765, host: str = "127.0.0.1",
-          open_browser: bool = True, strict_port: bool = False,
+          open_browser: bool = False, strict_port: bool = False,
           banner: str = ""):
-    """Start one server carrying every source, and block until interrupted."""
+    """Start one server carrying every source, and block until interrupted.
+
+    `open_browser` is off by default: see `viewer.open_in_browser` for why
+    launching one unasked is the wrong default where gmpas actually runs.
+    """
     import sys
 
     from .viewer import bind, open_in_browser, reach_lines

--- a/src/gmpas/dashboard.py
+++ b/src/gmpas/dashboard.py
@@ -214,7 +214,7 @@ def build(data_path=None, mesh_path: str = "", hfun_path: str = "",
                       f"{len(run.series)} steps · {n_vars} cell variables", run))
         built.append(("mesh", "mesh",
                       f"{run.mesh.path.name} · {run.mesh.n_cells:,} cells",
-                      MeshViewer(run.mesh.path, nx=nx, ny=ny)))
+                      MeshViewer(run.mesh, nx=nx, ny=ny)))
     elif mesh_path:
         mv = MeshViewer(mesh_path, nx=nx, ny=ny)
         built.append(("mesh", "mesh",

--- a/src/gmpas/data.py
+++ b/src/gmpas/data.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
-from . import timing
+from . import netcdf, timing
 from .mesh import MpasMesh, has_mesh
 from .paths import resolve_path
 
@@ -30,7 +30,8 @@ def open_data(data_path: str | Path,
     dpath = resolve_path(data_path)
     if not dpath.exists():
         raise FileNotFoundError(f"No such data file: {dpath}")
-    ds = xr.open_dataset(dpath, decode_timedelta=False, engine="netcdf4")
+    with netcdf.LOCK:                     # see netcdf.LOCK: HDF5 is not thread-safe
+        ds = xr.open_dataset(dpath, decode_timedelta=False, engine="netcdf4")
 
     if mesh_path:
         return ds, MpasMesh.load(resolve_path(mesh_path))
@@ -61,7 +62,13 @@ def find_mesh_beside(dpath: Path, n_cells: int) -> Path | None:
     import netCDF4
 
     with timing.step("mesh.discover") as t:
-        candidates = sorted(dpath.parent.glob("*.nc"))
+        # AppleDouble sidecars are `.nc` by name only -- see series.is_sidecar.
+        # Skipping them here is not just tidiness: on a parallel filesystem
+        # every candidate opened is a metadata round trip, and a Mac-copied
+        # run directory doubles the number of them.
+        from .series import is_sidecar
+        candidates = sorted(f for f in dpath.parent.glob("*.nc")
+                            if not is_sidecar(f))
         opened = 0
         try:
             for cand in candidates:
@@ -69,7 +76,11 @@ def find_mesh_beside(dpath: Path, n_cells: int) -> Path | None:
                     continue
                 try:
                     opened += 1
-                    with netCDF4.Dataset(cand) as nc:
+                    # netcdf.LOCK per candidate rather than around the whole
+                    # scan: this runs while a Series may be scanning the same
+                    # directory on another thread, and holding it for every
+                    # file would stall that for the entire probe.
+                    with netcdf.LOCK, netCDF4.Dataset(cand) as nc:
                         dim = nc.dimensions.get("nCells")
                         if has_mesh(nc) and dim is not None and len(dim) == n_cells:
                             return cand

--- a/src/gmpas/data.py
+++ b/src/gmpas/data.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
+from . import timing
 from .mesh import MpasMesh, has_mesh
 from .paths import resolve_path
 
@@ -59,17 +60,24 @@ def find_mesh_beside(dpath: Path, n_cells: int) -> Path | None:
     """
     import netCDF4
 
-    for cand in sorted(dpath.parent.glob("*.nc")):
-        if cand == dpath:
-            continue
+    with timing.step("mesh.discover") as t:
+        candidates = sorted(dpath.parent.glob("*.nc"))
+        opened = 0
         try:
-            with netCDF4.Dataset(cand) as nc:
-                dim = nc.dimensions.get("nCells")
-                if has_mesh(nc) and dim is not None and len(dim) == n_cells:
-                    return cand
-        except Exception:
-            continue
-    return None
+            for cand in candidates:
+                if cand == dpath:
+                    continue
+                try:
+                    opened += 1
+                    with netCDF4.Dataset(cand) as nc:
+                        dim = nc.dimensions.get("nCells")
+                        if has_mesh(nc) and dim is not None and len(dim) == n_cells:
+                            return cand
+                except Exception:
+                    continue
+            return None
+        finally:
+            t.note(scanned=len(candidates), opened=opened)
 
 
 def spatial_dim(da: xr.DataArray) -> str:

--- a/src/gmpas/generic.py
+++ b/src/gmpas/generic.py
@@ -100,7 +100,10 @@ class GenericViewer:
         import xarray as xr
 
         self.path = Path(path)
-        self.ds = xr.open_dataset(self.path, decode_timedelta=False, engine="netcdf4")
+        from . import netcdf
+        with netcdf.LOCK:                 # see netcdf.LOCK: HDF5 is not thread-safe
+            self.ds = xr.open_dataset(self.path, decode_timedelta=False,
+                                      engine="netcdf4")
         self.lat_name, self.lon_name = _find_latlon(self.ds)
         self.time_name = _find_time(self.ds, self.lat_name, self.lon_name)
 

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
+from . import timing
 from .paths import cache_dir, resolve_path
 
 R2D = 180.0 / np.pi
@@ -98,11 +99,12 @@ def _signature(path: Path) -> str:
     nCells/nEdges come from the header, which netCDF reads without touching any
     data, so this stays cheap enough to run on every load.
     """
-    st = path.stat()
-    n_cells, n_edges = _header_dims(path)
-    raw = (f"{path.resolve()}|{st.st_size}|{st.st_mtime_ns}"
-           f"|{n_cells}|{n_edges}")
-    return hashlib.sha1(raw.encode()).hexdigest()[:16]
+    with timing.step("mesh.signature"):
+        st = path.stat()
+        n_cells, n_edges = _header_dims(path)
+        raw = (f"{path.resolve()}|{st.st_size}|{st.st_mtime_ns}"
+               f"|{n_cells}|{n_edges}")
+        return hashlib.sha1(raw.encode()).hexdigest()[:16]
 
 
 def cache_path(path: Path) -> Path:
@@ -225,7 +227,8 @@ class MpasMesh:
             # not the branch-and-bound search query() runs afterward -- nearest
             # cell results are identical either way, and construction is
             # measurably faster on a large mesh.
-            self._tree = cKDTree(self.xyz_cell, balanced_tree=False)
+            with timing.step("mesh.tree_build", cells=self.n_cells):
+                self._tree = cKDTree(self.xyz_cell, balanced_tree=False)
         return self._tree
 
     def cell_of(self, lon: np.ndarray, lat: np.ndarray) -> np.ndarray:
@@ -261,8 +264,10 @@ class MpasMesh:
             print(f"gmpas: no cache for {path.name} yet — building geometry at "
                   f"{cache} (first use of this mesh; large global meshes can "
                   f"take a while and real memory)", file=sys.stderr)
-            _build_to_dir(path, cache)
-        return cls._mapped(path, cache)
+            with timing.step("mesh.build"):
+                _build_to_dir(path, cache)
+        with timing.step("mesh.cache_load"):
+            return cls._mapped(path, cache)
 
     @classmethod
     def _mapped(cls, path: Path, cache: Path) -> "MpasMesh":
@@ -524,6 +529,10 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
 
     nc = netCDF4.Dataset(path)
     nc.set_auto_mask(False)
+    # bound before the try: the cleanup handler touches it, and the earliest
+    # failures in here (missing mesh variables, no room to build) happen well
+    # before the loop sizes are known
+    bar = None
     try:
         missing = [v for v in MESH_VARS if v not in nc.variables]
         if missing:
@@ -543,6 +552,22 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
         n_edges = len(nc.dimensions["nEdges"])
         max_edges = len(nc.dimensions["maxEdges"])
 
+        # Five chunked passes follow (vertices, cells, edges, cell scalars,
+        # edge scalars). Total blocks is what makes an ETA meaningful; below
+        # one block per pass the mesh is small enough that the whole build is
+        # over before a bar would render, so say nothing.
+        def _blocks(n):
+            return (n + chunk - 1) // chunk
+
+        total_blocks = (_blocks(n_vertices) + 2 * _blocks(n_cells)
+                        + 2 * _blocks(n_edges))
+        if total_blocks > 5:
+            bar = timing.Progress(total_blocks, unit="block")
+
+        def tick():
+            if bar is not None:
+                bar.advance()
+
         # lon_v/lat_v must stay fully resident for the fancy-indexing below
         # (lon_v[voc], lat_v[voe] pick arbitrary, non-sequential vertices), so
         # unlike everything else in this function they can't become a genuine
@@ -555,6 +580,7 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             j = min(i + chunk, n_vertices)
             lon_v[i:j] = _wrap180(lon_v_var[i:j] * R2D)
             lat_v[i:j] = lat_v_var[i:j] * R2D
+            tick()
 
         bounds = _Bounds()
 
@@ -577,6 +603,7 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             verts.append(block)
             cw.append(wrapped)
             bounds.update(block)
+            tick()
         verts.close(); cw.close()
 
         segs = _NpyWriter(tmp / "edge_segs.npy", dt, (n_edges, 2, 2))
@@ -591,6 +618,7 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             block, wrapped = _unwrap_polygons(block)
             segs.append(block)
             ew.append(wrapped)
+            tick()
         segs.close(); ew.close()
 
         # nothing past this point indexes by vertex, so the full nVertices
@@ -637,6 +665,7 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
 
             lonc_w.append(_wrap180(lonc_var[i:j] * R2D))
             latc_w.append(latc_var[i:j] * R2D)
+            tick()
         xyz_w.close(); area_w.close(); lonc_w.close(); latc_w.close()
 
         # pure elementwise scale/wrap, no reduction at all -- the simplest
@@ -651,7 +680,11 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
             lone_w.append(_wrap180(lone_var[i:j] * R2D))
             late_w.append(late_var[i:j] * R2D)
             ang_w.append(ang_var[i:j])
+            tick()
         lone_w.close(); late_w.close(); ang_w.close()
+
+        if bar is not None:
+            bar.close()
 
         coverage = float(area_sum / (4.0 * np.pi * radius**2))
         extent = ((-180.0, 180.0, -90.0, 90.0) if coverage >= GLOBAL_COVERAGE
@@ -667,6 +700,8 @@ def _build_to_dir(path: Path, cache: Path, chunk: int = BUILD_CHUNK) -> None:
     except BaseException:
         # a build that died because the filesystem was full must not leave its
         # partial output sitting on that filesystem
+        if bar is not None:
+            bar.close()
         shutil.rmtree(tmp, ignore_errors=True)
         raise
     finally:

--- a/src/gmpas/mesh.py
+++ b/src/gmpas/mesh.py
@@ -27,7 +27,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
-from . import timing
+from . import netcdf, timing
 from .paths import cache_dir, resolve_path
 
 R2D = 180.0 / np.pi
@@ -254,20 +254,25 @@ class MpasMesh:
         if not path.exists():
             raise FileNotFoundError(f"No such mesh file: {path}")
 
-        if not use_cache:
-            return cls._build(path)
+        # Every path below reaches netCDF -- the signature's header probe, a
+        # cache build, or a full read -- and a dashboard calls this while a
+        # Series is scanning a run directory on its own thread. See netcdf.LOCK
+        # for why sharing HDF5 between two threads ends the process outright.
+        with netcdf.LOCK:
+            if not use_cache:
+                return cls._build(path)
 
-        cache = cache_path(path)
-        if (cache / "meta.json").exists():
-            print(f"gmpas: using cached mesh geometry ({cache})", file=sys.stderr)
-        else:
-            print(f"gmpas: no cache for {path.name} yet — building geometry at "
-                  f"{cache} (first use of this mesh; large global meshes can "
-                  f"take a while and real memory)", file=sys.stderr)
-            with timing.step("mesh.build"):
-                _build_to_dir(path, cache)
-        with timing.step("mesh.cache_load"):
-            return cls._mapped(path, cache)
+            cache = cache_path(path)
+            if (cache / "meta.json").exists():
+                print(f"gmpas: using cached mesh geometry ({cache})", file=sys.stderr)
+            else:
+                print(f"gmpas: no cache for {path.name} yet — building geometry at "
+                      f"{cache} (first use of this mesh; large global meshes can "
+                      f"take a while and real memory)", file=sys.stderr)
+                with timing.step("mesh.build"):
+                    _build_to_dir(path, cache)
+            with timing.step("mesh.cache_load"):
+                return cls._mapped(path, cache)
 
     @classmethod
     def _mapped(cls, path: Path, cache: Path) -> "MpasMesh":

--- a/src/gmpas/netcdf.py
+++ b/src/gmpas/netcdf.py
@@ -1,0 +1,40 @@
+"""One lock for every netCDF read in this process.
+
+netCDF4 is a wrapper around HDF5, and unless HDF5 was built `--enable-threadsafe`
+-- which the conda-forge and wheel builds are not -- its global state is not
+safe under concurrent access. Not "may return stale data": the C library walks
+its own structures while another thread is rearranging them, and the process
+dies with SIGSEGV and no Python traceback.
+
+That is easy to hit here, because two things run at once by design:
+
+* `Series` counts timesteps on a background thread, so the viewer can serve a
+  provisional time axis rather than blocking on a directory of thousands of
+  files.
+* the viewer serves every HTTP request on its own thread, and a dashboard
+  holds several sources -- a run, the mesh under it, an hfun -- each reading
+  its own files.
+
+`Series` already had a lock, but one *per instance*, which is the wrong scope:
+two `Series` objects, or a `Series` and an `MpasMesh.load` on the mesh page,
+take different locks and enter HDF5 together anyway. The hazard belongs to the
+library, not to any object, so the lock has to be process-wide too.
+
+Reentrant because the read paths nest: `Series.values` holds it across a read
+that goes through `_dataset`, which documents needing it held.
+
+The cost is that netCDF reads in one process serialise. That is what safety
+costs here, and it is not the bottleneck: reads are dominated by filesystem
+round trips a lock does not add to, and every parallel path that matters --
+`plot --all-steps`, `remap -j` -- is multi-*process*, where this lock does not
+apply at all.
+"""
+
+from __future__ import annotations
+
+import threading
+
+#: held for the whole duration of any netCDF open or read, not just around
+#: bookkeeping: releasing early would let one thread close a dataset another
+#: is mid-read on.
+LOCK = threading.RLock()

--- a/src/gmpas/prep/hfunview.py
+++ b/src/gmpas/prep/hfunview.py
@@ -21,16 +21,14 @@ arrays -- so frames are computed per view box and kept.
 from __future__ import annotations
 
 import json
-import socket
-import threading
-import webbrowser
+import sys
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 
 from ..cache import BuildCache
 from ..raster import target_grid
-from ..viewer import PageHandler, _overlay, _png, bind, ramp
+from ..viewer import PageHandler, _overlay, _png, bind, ramp, reach_lines
 from .hfun import GRADIENT_GUIDELINE, Hfun, diagnose
 from .layout import page
 
@@ -226,7 +224,7 @@ def report(viewer: HfunViewer) -> str:
 
 
 def serve(hfun_path, port: int = 8765, nx: int = 1200, ny: int = 700,
-          open_browser: bool = True, host: str = "127.0.0.1",
+          host: str = "127.0.0.1",
           strict_port: bool = False):
     """Start the distance-function viewer and block until interrupted.
 
@@ -240,21 +238,14 @@ def serve(hfun_path, port: int = 8765, nx: int = 1200, ny: int = 700,
 
     print(report(viewer))
 
-    node = socket.gethostname()
-    if host in ("127.0.0.1", "localhost"):
-        print(f"listening on 127.0.0.1:{port} — this machine only")
-        print(f"  open  http://127.0.0.1:{port}")
-        print(f"  if {node} is a remote node, this is NOT reachable through a "
-              f"tunnel to a login node; restart with --host 0.0.0.0")
-    else:
-        print(f"listening on {host}:{port} — reachable as {node}:{port}")
-        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
-        print(f"  then open           http://localhost:{port}")
+    # reach_lines rather than a hand-rolled banner: this one still printed
+    # "<login-node>" for the reader to substitute, and could not tell a login
+    # node from a compute node. The shared one reads the scheduler's own
+    # environment and prints a command with nothing left to fill in.
+    for line in reach_lines(host, port):
+        print(line)
     print("ctrl-c to stop")
-
-    if open_browser:
-        threading.Timer(0.5, webbrowser.open,
-                        args=(f"http://127.0.0.1:{port}",)).start()
+    sys.stdout.flush()
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/gmpas/prep/hfunview.py
+++ b/src/gmpas/prep/hfunview.py
@@ -28,6 +28,7 @@ from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 
+from ..cache import BuildCache
 from ..raster import target_grid
 from ..viewer import PageHandler, _overlay, _png, bind, ramp
 from .hfun import GRADIENT_GUIDELINE, Hfun, diagnose
@@ -56,9 +57,8 @@ class HfunViewer:
         # a distance function is defined over the whole sphere, so there is no
         # domain to fit to -- the home view is the world
         self.home = (-180.0, 180.0, -90.0, 90.0)
-        self._frames: dict[tuple, np.ndarray] = {}
-        self._overlays: dict[tuple, bytes] = {}
-        self._lock = threading.Lock()
+        self._frames = BuildCache()
+        self._overlays = BuildCache()
 
     # -- fields ----------------------------------------------------------
 
@@ -115,20 +115,23 @@ class HfunViewer:
     def values(self, field: str, extent, nx: int, ny: int) -> np.ndarray:
         """The field on this view's pixel centres, from one `get_hfun` call."""
         key = (*(round(float(v), 6) for v in extent), nx, ny)
-        with self._lock:
-            if key not in self._frames:
-                lon, lat = target_grid(tuple(extent), nx, ny)
-                lon2, lat2 = np.meshgrid(lon, lat)
-                h = self.hfun.sample_degrees(lon2, lat2)
+        def build():
+            lon, lat = target_grid(tuple(extent), nx, ny)
+            lon2, lat2 = np.meshgrid(lon, lat)
+            h = self.hfun.sample_degrees(lon2, lat2)
 
-                # Past a pole there is no sphere left to have a grid distance.
-                # get_hfun answers anyway -- sin and cos are periodic, so it
-                # folds back and returns a mirror image of the other side --
-                # and that fabricated band has no coastline to sit under.
-                # Frames are rendered 1.4x wider than the window, so a global
-                # view always asks for some of it. Blank it instead.
-                self._frames[key] = np.where(np.abs(lat2) > 90.0, np.nan, h)
-            h = self._frames[key]
+            # Past a pole there is no sphere left to have a grid distance.
+            # get_hfun answers anyway -- sin and cos are periodic, so it
+            # folds back and returns a mirror image of the other side --
+            # and that fabricated band has no coastline to sit under.
+            # Frames are rendered 1.4x wider than the window, so a global
+            # view always asks for some of it. Blank it instead.
+            return np.where(np.abs(lat2) > 90.0, np.nan, h)
+
+        # A user's get_hfun is arbitrary code and can be slow, which is the
+        # whole complaint in issue 25 -- so it must not run under a lock that
+        # every other request in the process is waiting on.
+        h = self._frames.get(key, build)
 
         if field == "cell_width_km":
             return h
@@ -140,10 +143,7 @@ class HfunViewer:
     def overlay(self, extent, nx=None, ny=None) -> bytes:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
-        with self._lock:
-            if key not in self._overlays:
-                self._overlays[key] = _overlay(extent, nx, ny)
-            return self._overlays[key]
+        return self._overlays.get(key, lambda: _overlay(extent, nx, ny))
 
     def frame(self, field: str, extent, nx=None, ny=None,
               compress: int = 1) -> tuple[bytes, float, float]:

--- a/src/gmpas/prep/meshview.py
+++ b/src/gmpas/prep/meshview.py
@@ -23,16 +23,15 @@ none of it is modified.
 from __future__ import annotations
 
 import json
-import socket
-import threading
-import webbrowser
+import sys
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 
 from ..cache import BuildCache
 from ..mesh import MpasMesh
-from ..viewer import PageHandler, ViewIndex, _overlay, _png, bind, ramp
+from ..viewer import (PageHandler, ViewIndex, _overlay, _png, bind,
+                      ramp, reach_lines)
 from .layout import page
 
 #: the one colormap this section uses. Sequential and perceptually uniform,
@@ -204,7 +203,7 @@ def _handler(viewer: MeshViewer, html: str):
 
 
 def serve(mesh_path, port: int = 8765, nx: int = 1200, ny: int = 700,
-          open_browser: bool = True, host: str = "127.0.0.1",
+          host: str = "127.0.0.1",
           strict_port: bool = False):
     """Start the mesh viewer and block until interrupted.
 
@@ -221,21 +220,14 @@ def serve(mesh_path, port: int = 8765, nx: int = 1200, ny: int = 700,
     print(f"{viewer.mesh.n_cells:,} cells, {viewer.mesh.n_edges:,} edges, {kind} — "
           f"cell width {width.min():.3g} to {width.max():.3g} km")
 
-    node = socket.gethostname()
-    if host in ("127.0.0.1", "localhost"):
-        print(f"listening on 127.0.0.1:{port} — this machine only")
-        print(f"  open  http://127.0.0.1:{port}")
-        print(f"  if {node} is a remote node, this is NOT reachable through a "
-              f"tunnel to a login node; restart with --host 0.0.0.0")
-    else:
-        print(f"listening on {host}:{port} — reachable as {node}:{port}")
-        print(f"  from your machine:  ssh -N -L {port}:{node}:{port} <login-node>")
-        print(f"  then open           http://localhost:{port}")
+    # reach_lines rather than a hand-rolled banner: this one still printed
+    # "<login-node>" for the reader to substitute, and could not tell a login
+    # node from a compute node. The shared one reads the scheduler's own
+    # environment and prints a command with nothing left to fill in.
+    for line in reach_lines(host, port):
+        print(line)
     print("ctrl-c to stop")
-
-    if open_browser:
-        threading.Timer(0.5, webbrowser.open,
-                        args=(f"http://127.0.0.1:{port}",)).start()
+    sys.stdout.flush()
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/gmpas/prep/meshview.py
+++ b/src/gmpas/prep/meshview.py
@@ -30,6 +30,7 @@ from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 
+from ..cache import BuildCache
 from ..mesh import MpasMesh
 from ..viewer import PageHandler, ViewIndex, _overlay, _png, bind, ramp
 from .layout import page
@@ -50,13 +51,19 @@ class MeshViewer:
     """Everything the mesh-only routes need, built once at startup."""
 
     def __init__(self, mesh_path, nx: int = 1200, ny: int = 700):
-        self.mesh = MpasMesh.load(mesh_path)
+        # Accepts an already-loaded mesh as well as a path. The dashboard shows
+        # a run's data page and its mesh page side by side, and both are the
+        # same mesh -- loading it twice meant two of every derived structure,
+        # including two KD-trees, which on a large mesh is the single most
+        # expensive thing either page does.
+        self.mesh = (mesh_path if isinstance(mesh_path, MpasMesh)
+                     else MpasMesh.load(mesh_path))
         self.nx, self.ny = nx, ny
         self.home = self.mesh.extent
-        self._views: dict[tuple, ViewIndex] = {}
-        self._overlays: dict[tuple, bytes] = {}
+        self._views = BuildCache()
+        self._overlays = BuildCache()
         self._values: dict[str, np.ndarray] = {}
-        self._lock = threading.Lock()
+        self._limits: dict[str, tuple[float, float]] = {}
 
     # -- fields ----------------------------------------------------------
 
@@ -69,17 +76,33 @@ class MeshViewer:
             self._values[field] = np.asarray(FIELDS[field][1](self.mesh))
         return self._values[field]
 
+    def limits(self, field: str) -> tuple[float, float]:
+        """(min, max) over the whole mesh for one field, without keeping it.
+
+        `describe()` needs these for every field at once, but the page only
+        ever renders one at a time. Going through `values()` would leave every
+        field's full-length array resident for the life of the process -- two
+        of them, and each is 8 bytes per cell, which on a 41M-cell mesh is most
+        of a gigabyte to populate a sidebar. So the array is built, reduced,
+        and dropped, unless something else already had a reason to keep it.
+        """
+        if field not in self._limits:
+            v = (self._values[field] if field in self._values
+                 else np.asarray(FIELDS[field][1](self.mesh)))
+            self._limits[field] = (float(np.nanmin(v)), float(np.nanmax(v)))
+        return self._limits[field]
+
     def describe(self) -> dict:
         fields = []
         for name, (label, _) in FIELDS.items():
-            v = self.values(name)
+            vmin, vmax = self.limits(name)
             fields.append({
                 "name": name,
                 "label": label,
                 # fixed, whole-mesh limits: the front end has no vmin/vmax box
                 # because there is nothing view-dependent to tune
-                "vmin": float(np.nanmin(v)),
-                "vmax": float(np.nanmax(v)),
+                "vmin": vmin,
+                "vmax": vmax,
             })
         cells, edges = int(self.mesh.n_cells), int(self.mesh.n_edges)
         coverage = round(self.mesh.coverage * 100, 1)
@@ -116,24 +139,21 @@ class MeshViewer:
     def view(self, extent, nx=None, ny=None) -> ViewIndex:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
-        with self._lock:
-            if key not in self._views:
-                self._views[key] = ViewIndex(self.mesh, extent, nx, ny)
-            return self._views[key]
+        return self._views.get(key, lambda: ViewIndex(self.mesh, extent, nx, ny))
 
     def overlay(self, extent, nx=None, ny=None) -> bytes:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
-        with self._lock:
-            if key not in self._overlays:
-                self._overlays[key] = _overlay(extent, nx, ny)
-            return self._overlays[key]
+        return self._overlays.get(key, lambda: _overlay(extent, nx, ny))
 
     def frame(self, field: str, extent, nx=None, ny=None,
               compress: int = 1) -> tuple[bytes, float, float]:
         v = self.values(field)
         img = self.view(extent, nx, ny).frame(v)
-        lo, hi = float(np.nanmin(v)), float(np.nanmax(v))
+        # whole-mesh limits, so they are the same for every view of this field
+        # -- reducing over the full cell array again on each frame is a pass
+        # over every cell in the mesh to re-derive two constants
+        lo, hi = self.limits(field)
         return _png(img, CMAP, lo, hi, compress), lo, hi
 
 

--- a/src/gmpas/raster.py
+++ b/src/gmpas/raster.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from . import timing
 from .mesh import MpasMesh
 
 #: above this many cells, polygon rendering stops being the faster option
@@ -49,6 +50,11 @@ def rasterize(mesh: MpasMesh, values: np.ndarray,
     the nearest boundary cell and smear it across the whole frame; mask_outside
     blanks anything further from a cell centre than that cell's own radius.
     """
+    with timing.step("raster.rasterize", px=nx * ny):
+        return _rasterize(mesh, values, extent, nx, ny, mask_outside)
+
+
+def _rasterize(mesh, values, extent, nx, ny, mask_outside):
     extent = extent or mesh.extent
     lon, lat = target_grid(extent, nx, ny)
     lon2, lat2 = np.meshgrid(lon, lat)

--- a/src/gmpas/series.py
+++ b/src/gmpas/series.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
+from . import timing
 from .data import find_mesh_beside, plottable, select
 from .mesh import MpasMesh, has_mesh
 from .paths import resolve_path
@@ -110,7 +111,8 @@ def expand(paths) -> list[Path]:
             unique.append(p)
     if not unique:
         raise FileNotFoundError(f"no files matched {paths!r}")
-    return order(unique)
+    with timing.step("series.expand", files=len(unique)):
+        return order(unique)
 
 
 def label_of(path: Path) -> str:
@@ -233,15 +235,19 @@ class Series:
         import netCDF4
 
         counts = dict(self._counts)
-        for path in self.files:
-            if path in counts:
-                continue
-            try:
-                with self._lock, netCDF4.Dataset(path) as nc:
-                    dim = nc.dimensions.get("Time")
-                    counts[path] = len(dim) if dim is not None else 1
-            except Exception:
-                counts[path] = 1          # unreadable: leave it as one step
+        opened = 0
+        with timing.step("series.scan", files=len(self.files)) as t:
+            for path in self.files:
+                if path in counts:
+                    continue
+                try:
+                    opened += 1
+                    with self._lock, netCDF4.Dataset(path) as nc:
+                        dim = nc.dimensions.get("Time")
+                        counts[path] = len(dim) if dim is not None else 1
+                except Exception:
+                    counts[path] = 1      # unreadable: leave it as one step
+            t.note(opened=opened)
         self._counts = counts
         # plain assignment, so a reader mid-request keeps a consistent list
         self.steps, self.labels = self._axis()

--- a/src/gmpas/series.py
+++ b/src/gmpas/series.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 import threading
 from collections import OrderedDict
 from datetime import datetime
@@ -27,7 +28,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
-from . import timing
+from . import netcdf, timing
 from .data import find_mesh_beside, plottable, select
 from .mesh import MpasMesh, has_mesh
 from .paths import resolve_path
@@ -88,6 +89,29 @@ def values_budget() -> int:
         return VALUES_CACHE_BYTES
 
 
+def is_sidecar(path: Path) -> bool:
+    """Whether this is a metadata shadow of a real file rather than data.
+
+    macOS writes an AppleDouble sidecar next to every file it copies onto a
+    filesystem that cannot hold a resource fork -- `._history.....nc`, four
+    kilobytes carrying the same `.nc` suffix as the file it shadows. Any run
+    directory that has been through a Mac, a USB stick, or an rsync from one
+    holds a shadow copy of itself, and this is common on HPC precisely because
+    that is how data arrives there.
+
+    They matter more than their size suggests: `order()` sorts on the
+    timestamp in the name, which a sidecar copies verbatim, and ties break on
+    the name, where `._x.nc` sorts before `x.nc`. So the sidecar became
+    `files[0]` -- the one file `Series.__init__` opens eagerly -- and the
+    viewer died with `NetCDF: Unknown file format` before serving a frame.
+
+    Only ever applied to names *found by globbing*: a path given explicitly is
+    always honoured, since guessing that a user did not mean the file they
+    named is worse than any error it produces.
+    """
+    return path.name.startswith("._")
+
+
 def expand(paths) -> list[Path]:
     """Turn a path, glob, directory or list into a sorted list of files."""
     if isinstance(paths, (str, Path)):
@@ -97,10 +121,11 @@ def expand(paths) -> list[Path]:
     for item in paths:
         p = resolve_path(item)
         if p.is_dir():
-            out.extend(p.glob("*.nc"))
+            out.extend(f for f in p.glob("*.nc") if not is_sidecar(f))
         elif any(ch in str(item) for ch in "*?["):
             base = p.parent
-            out.extend(sorted(base.glob(Path(str(item)).name)))
+            out.extend(sorted(f for f in base.glob(Path(str(item)).name)
+                              if not is_sidecar(f)))
         else:
             out.append(p)
 
@@ -164,10 +189,16 @@ class Series:
         # frame rather than raising. `_scan`'s own handles are included, even
         # though they never touch this cache, because the race is in the
         # underlying C library, not just this dict.
-        self._lock = threading.Lock()
+        #
+        # And for that same reason it is the *process-wide* lock rather than
+        # one per Series: a per-instance lock cannot exclude the other Series
+        # a dashboard holds, nor the `MpasMesh.load` on its mesh page, and
+        # those enter HDF5 concurrently with this one's background scan. See
+        # netcdf.LOCK.
+        self._lock = netcdf.LOCK
 
         with self._lock:
-            first = self._dataset(self.files[0])
+            first = self._open_first()
 
         if mesh_path:
             self.mesh = MpasMesh.load(resolve_path(mesh_path))
@@ -218,6 +249,53 @@ class Series:
                 steps.append((path, i))
                 labels.append(base if n == 1 else f"{base} +{i}")
         return steps, labels
+
+    def _open_first(self) -> xr.Dataset:
+        """The first file that actually opens, dropping any that do not.
+
+        Caller must hold `self._lock`.
+
+        One unreadable file used to end the run: `__init__` opened `files[0]`
+        eagerly and let the netCDF error out of the constructor, so `gmpas
+        view` on a directory exited with a traceback instead of serving the
+        other thousand files. On HPC that is a normal state, not a corrupt
+        one -- a model still running leaves its newest history file half
+        written, and a transfer still in flight leaves a truncated one.
+
+        A file that cannot be opened is dropped from the axis rather than
+        held with a placeholder: its timestep count is unknown, so any
+        placeholder would put a step on the slider that renders nothing. It
+        is reported by name on stderr, never skipped in silence -- if the
+        file was supposed to be readable, that is the only clue the user
+        gets, and the alternative reads as gmpas quietly losing data.
+        """
+        problems: list[str] = []
+        failures: list[Exception] = []
+        while self.files:
+            try:
+                ds = self._dataset(self.files[0])
+            except Exception as exc:
+                bad = self.files.pop(0)
+                problems.append(f"  {bad.name}: {exc}")
+                failures.append(exc)
+                continue
+            if problems:
+                print(f"gmpas: skipped {len(problems)} unreadable file(s):\n"
+                      + "\n".join(problems), file=sys.stderr)
+            return ds
+
+        # A path that simply is not there stays a FileNotFoundError. It is the
+        # overwhelmingly common way to get here -- a typo in an argument -- and
+        # the CLI turns that one into a plain message rather than a traceback.
+        # Widening it to OSError would have made `gmpas info typo.nc` traceback.
+        kind = (FileNotFoundError
+                if failures and all(isinstance(e, FileNotFoundError)
+                                    for e in failures)
+                else OSError)
+        raise kind(
+            "no readable file among those matched — every candidate failed "
+            "to open:\n" + "\n".join(problems)
+        )
 
     def _scan(self) -> None:
         """Count timesteps in every file, then swap the axis in.

--- a/src/gmpas/timing.py
+++ b/src/gmpas/timing.py
@@ -1,0 +1,256 @@
+"""Where the time went, when someone asks.
+
+Nothing in this package was instrumented, which made "it takes one to two
+minutes to open a 41M-cell run" an unattributable number -- and it is not even
+one number, because `info` never builds a KD-tree, `view` builds it inside the
+first frame request, and `plot` builds it inside `rasterize`. So the answer
+depends on the subcommand, and guessing which stage dominates has been wrong
+before.
+
+Off by default and free when off: `step()` is rebound at import to a function
+returning a stateless singleton, so a disabled call allocates nothing. That
+matters because some of the call sites run per animation frame, where a
+`@contextmanager` checking a flag would still build a generator every time.
+
+    GMPAS_TIMING=1      startup-scale stages
+    GMPAS_TIMING=2      adds per-frame stages and peak-RSS deltas
+    GMPAS_TIMING_FILE   write here instead of stderr
+
+Import this as a module (`from . import timing`) and call `timing.step(...)`,
+not `from .timing import step` -- the name is rebound when the environment
+changes, which is what lets the tests turn it on.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import sys
+import threading
+import time
+
+#: prefix every line carries, so a Derecho batch log greps cleanly
+PREFIX = "gmpas.timing"
+
+#: set when GMPAS_TIMING parses as an integer > 0
+LEVEL = 0
+
+_MAIN_PID = os.getpid()
+_lock = threading.Lock()
+
+#: label -> [count, total seconds, slowest single occurrence]
+_totals: dict[str, list] = {}
+
+
+class _Null:
+    """What `step()` returns when timing is off: no allocation, no state.
+
+    A single shared instance is safe to enter from several threads at once
+    precisely because it holds nothing -- the viewer serves every request on
+    its own thread, and per-frame call sites must not pay for a lock.
+    """
+
+    __slots__ = ()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def note(self, **fields):
+        pass
+
+
+_NULL = _Null()
+
+
+def _stream():
+    path = os.environ.get("GMPAS_TIMING_FILE")
+    if not path:
+        return sys.stderr
+    try:
+        # line-buffered and append-mode: a -j 32 pool has 32 writers, and
+        # short line-sized appends to one file interleave without tearing
+        # where a buffered write would
+        return open(path, "a", buffering=1)
+    except OSError:
+        return sys.stderr
+
+
+def _rss_kb() -> int:
+    try:
+        import resource
+
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except Exception:            # not POSIX, or resource unavailable
+        return 0
+
+
+def _fmt(n: float) -> str:
+    """Bytes as a short human string. Local to keep this module dependency-free."""
+    for unit in ("KB", "MB", "GB"):
+        if abs(n) < 1024 or unit == "GB":
+            return f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{n:.1f}GB"
+
+
+class _Step:
+    """One timed stage. Fields set with `note()` land on the same line."""
+
+    __slots__ = ("label", "fields", "_t0", "_rss0")
+
+    def __init__(self, label: str, fields: dict):
+        self.label = label
+        self.fields = fields
+        self._t0 = time.perf_counter()
+        self._rss0 = _rss_kb() if LEVEL >= 2 else 0
+
+    def note(self, **fields):
+        self.fields.update(fields)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        elapsed = time.perf_counter() - self._t0
+
+        with _lock:
+            slot = _totals.get(self.label)
+            if slot is None:
+                _totals[self.label] = [1, elapsed, elapsed]
+            else:
+                slot[0] += 1
+                slot[1] += elapsed
+                slot[2] = max(slot[2], elapsed)
+
+        parts = [f"{k}={v}" for k, v in self.fields.items() if v is not None]
+        if LEVEL >= 2:
+            grew = _rss_kb() - self._rss0
+            if grew > 0:
+                parts.append(f"rss+={_fmt(grew * 1024)}")
+        if os.getpid() != _MAIN_PID:
+            parts.append(f"pid={os.getpid()}")
+
+        print(f"{PREFIX}  {self.label:<20} {elapsed:8.3f}s  {' '.join(parts)}".rstrip(),
+              file=_stream())
+        return False
+
+
+def _step_null(label: str, **fields):
+    return _NULL
+
+
+def _step_real(label: str, **fields):
+    return _Step(label, fields)
+
+
+#: rebound by `refresh()`; see the module docstring for why call sites must
+#: reach it through the module rather than importing the name
+step = _step_null
+
+
+def enabled(level: int = 1) -> bool:
+    """Whether timing is on at or above `level`. For guarding costly fields."""
+    return LEVEL >= level
+
+
+def _report() -> None:
+    if not _totals:
+        return
+    out = _stream()
+    print(f"{PREFIX}  ---- roll-up " + "-" * 44, file=out)
+    for label, (n, total, worst) in sorted(
+            _totals.items(), key=lambda kv: -kv[1][1]):
+        print(f"{PREFIX}  {label:<20} {total:8.3f}s  n={n} max={worst:.3f}s",
+              file=out)
+
+
+def refresh() -> None:
+    """Re-read the environment and rebind `step`.
+
+    Called once at import. Tests call it again after monkeypatching the
+    environment, since the level is resolved at bind time rather than on every
+    call -- that is the whole point of the disabled path being free.
+    """
+    global LEVEL, step
+    try:
+        LEVEL = int(os.environ.get("GMPAS_TIMING") or 0)
+    except ValueError:
+        LEVEL = 0
+    step = _step_real if LEVEL > 0 else _step_null
+
+
+def reset() -> None:
+    """Drop accumulated totals. For tests that assert on a single run."""
+    with _lock:
+        _totals.clear()
+
+
+# ------------------------------------------------------- progress reporting
+#
+# Unlike everything above, this is always on: it exists so a long operation
+# says it is still working. It lives here rather than in `cli` so that library
+# modules can reach it -- `cli` imports the package, so the package importing
+# `cli` back would be a cycle.
+
+
+class Progress:
+    """A bar when someone is watching, periodic lines when nobody is.
+
+    Under a scheduler stdout is a log file, and a carriage-returning bar just
+    fills it with thousands of partial lines. So the same information is
+    emitted either way, in whichever shape suits the destination.
+    """
+
+    def __init__(self, total: int, width: int = 32, every: int = 10,
+                 unit: str = "file"):
+        self.total = total
+        self.width = width
+        self.every = every            # percent between lines when not a tty
+        self.unit = unit
+        self.done = 0
+        self.t0 = time.perf_counter()
+        self.tty = sys.stdout.isatty()
+        self._last = -1
+
+    def advance(self, label: str = "") -> None:
+        self.done += 1
+        elapsed = time.perf_counter() - self.t0
+        frac = self.done / self.total if self.total else 1.0
+        eta = (elapsed / self.done) * (self.total - self.done) if self.done else 0
+
+        if self.tty:
+            filled = int(self.width * frac)
+            bar = "#" * filled + "-" * (self.width - filled)
+            sys.stdout.write(
+                f"\r  [{bar}] {self.done}/{self.total} {frac * 100:3.0f}%  "
+                f"{elapsed / self.done:.1f}s/{self.unit}  eta {clock(eta)}   "
+            )
+            sys.stdout.flush()
+        else:
+            pct = int(frac * 100)
+            if pct // self.every > self._last // self.every or self.done == self.total:
+                self._last = pct
+                print(f"  {self.done}/{self.total} ({pct}%)  "
+                      f"{elapsed / self.done:.1f}s/{self.unit}  eta {clock(eta)}")
+
+    def close(self) -> None:
+        if self.tty:
+            sys.stdout.write("\r" + " " * (self.width + 60) + "\r")
+            sys.stdout.flush()
+
+
+def clock(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    m, sec = divmod(int(seconds), 60)
+    if m < 60:
+        return f"{m}m{sec:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m"
+
+
+refresh()
+atexit.register(_report)

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -616,6 +616,43 @@ def _handler(viewer: Viewer, html: str = ""):
 PORT_ATTEMPTS = 20
 
 
+def _loopback_only(name: str, timeout: float = 1.0) -> bool:
+    """Whether `name` is known to point at this machine and nowhere else.
+
+    A name that resolves purely to 127.0.0.0/8 or ::1 cannot be what somebody
+    else's laptop connects to, whatever it looks like. That is not a rare
+    misconfiguration: the stock Debian/Ubuntu `/etc/hosts` maps the machine's
+    own fully qualified name to 127.0.1.1, so `getfqdn()` hands back something
+    plausible -- `box.example.dom` -- that is a loopback alias and nothing more.
+
+    Only *proves* the negative. A name that fails to resolve here is left
+    alone rather than rejected: a cluster login node commonly resolves from
+    the outside world and not from inside its own network namespace, and
+    discarding a correct name is the worse error -- the reader can see whether
+    a hostname looks right, but cannot recover one gmpas silently dropped.
+
+    Resolution runs on a thread and is abandoned after `timeout`, because this
+    is on the path to printing a banner: a wedged resolver is common on a busy
+    login node, and waiting on it would stall a viewer that is already serving.
+    """
+    import ipaddress
+
+    result: list[bool] = []
+
+    def _look() -> None:
+        try:
+            infos = socket.getaddrinfo(name, None)
+        except OSError:
+            return                            # unresolvable: prove nothing
+        addrs = [ipaddress.ip_address(i[4][0]) for i in infos]
+        result.append(bool(addrs) and all(a.is_loopback for a in addrs))
+
+    worker = threading.Thread(target=_look, daemon=True)
+    worker.start()
+    worker.join(timeout)
+    return result[0] if result else False
+
+
 def ssh_target() -> str:
     """The name to SSH *to*, preferring one that resolves off this machine.
 
@@ -626,12 +663,16 @@ def ssh_target() -> str:
 
     Only taken when it genuinely extends the short name, since `getfqdn()`
     falls back to whatever /etc/hosts says and can answer `localhost` or some
-    placeholder domain on a misconfigured box. In that case the short name is
-    no worse and reads less like a promise.
+    placeholder domain on a misconfigured box, and only when it is not a
+    loopback alias -- see `_loopback_only`, which is what a stock Linux
+    /etc/hosts turns the machine's own FQDN into. In either case the short
+    name is no worse and reads less like a promise.
     """
     node = socket.gethostname()
     fqdn = socket.getfqdn()
-    return fqdn if fqdn.startswith(f"{node}.") else node
+    if not fqdn.startswith(f"{node}."):
+        return node
+    return node if _loopback_only(fqdn) else fqdn
 
 
 #: environment a batch scheduler sets on a compute node. Both pairs are read
@@ -683,6 +724,20 @@ def reach_lines(host: str, port: int) -> list[str]:
     user = getpass.getuser()
 
     if host in ("127.0.0.1", "localhost"):
+        if in_batch_job():
+            # The one case where the printed tunnel would not work: a tunnel
+            # from a laptop lands on the login node, and from there the
+            # compute node's own loopback is a different machine's loopback.
+            # There is no command to give that fixes it, so say the one thing
+            # that does rather than offering a tunnel that cannot land.
+            return [
+                f"listening on 127.0.0.1:{port} — this compute node only, and "
+                f"nothing outside {node} can reach that",
+                f"  you are inside a batch job, so a tunnel from your machine "
+                f"lands on {submit_host()} and stops there.",
+                f"  restart with --host 0.0.0.0 to be reachable, and gmpas "
+                f"will print the tunnel command for it.",
+            ]
         return [
             f"listening on 127.0.0.1:{port} — this machine only",
             f"  on this machine:  http://127.0.0.1:{port}",
@@ -736,14 +791,45 @@ CONSOLE_BROWSERS = frozenset(
 
 
 def _console_browser(controller) -> bool:
+    """Whether launching this would take over the terminal rather than open a window.
+
+    A delegator counts as one when nothing graphical is running: it will pass
+    the URL to the system default, and on a node with no display the system
+    default is a text browser. That is the case `CONSOLE_BROWSERS` alone
+    cannot see, because the name gmpas is handed is `xdg-open`.
+    """
     name = getattr(controller, "name", "") or ""
     if not name:                              # MacOSX / WindowsDefault: GUI
         return False
-    return os.path.basename(name.split()[0]) in CONSOLE_BROWSERS
+    exe = os.path.basename(name.split()[0])
+    if exe in CONSOLE_BROWSERS:
+        return True
+    headless = not (os.environ.get("DISPLAY") or
+                    os.environ.get("WAYLAND_DISPLAY"))
+    return exe in DELEGATING_BROWSERS and headless
+
+
+#: openers that do not render anything themselves but hand the URL to
+#: whatever the system considers the default. On a desktop that is a GUI
+#: browser; on a headless node it resolves to w3m or elinks, which is how a
+#: text browser ends up seizing the terminal even though `CONSOLE_BROWSERS`
+#: names every one of them -- the name gmpas sees is the delegator's.
+DELEGATING_BROWSERS = frozenset({"xdg-open", "gio", "gvfs-open",
+                                 "x-www-browser", "sensible-browser"})
 
 
 def open_in_browser(url: str, delay: float = 0.5) -> "threading.Timer | None":
     """Open `url`, or say plainly why it could not -- but never in silence.
+
+    Only ever called when asked for (`gmpas view --browser`). It used to be
+    the default, which is backwards for a tool whose main home is an HPC
+    login or compute node: there the best case is a browser that cannot open,
+    and the realistic case is that `webbrowser` resolves a *delegating*
+    opener like `xdg-open`, which then launches elinks or w3m straight into
+    the terminal running the server. What that renders is the viewer's
+    JavaScript shell with no JavaScript -- an unusable page, on top of the
+    log the user was reading. The URL and the tunnel command printed above
+    are what is actually wanted there, and they are printed either way.
 
     `webbrowser.open` returns False when it cannot launch anything and raises
     on some platforms; both results used to be dropped inside a Timer thread,
@@ -764,15 +850,14 @@ def open_in_browser(url: str, delay: float = 0.5) -> "threading.Timer | None":
     """
     ok, why = can_open_browser()
     if not ok:
-        print(f"gmpas: not opening a browser -- {why}.\n"
+        print(f"gmpas: --browser asked for, but not opening a browser -- {why}.\n"
               f"       open {url} yourself (see the tunnel note above if this "
-              f"is a remote node), or pass --no-browser to stop asking.",
-              file=sys.stderr)
+              f"is a remote node).", file=sys.stderr)
         return None
 
     def _say(reason: str) -> None:
         print(f"gmpas: could not open a browser ({reason}) -- open {url} "
-              f"yourself, or pass --no-browser to stop asking.", file=sys.stderr)
+              f"yourself. The server is up either way.", file=sys.stderr)
 
     def _try() -> None:
         try:
@@ -822,7 +907,7 @@ def bind(handler, port: int, host: str = "127.0.0.1",
     return ThreadingHTTPServer((host, 0), handler)      # 0 = any free port
 
 
-def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True,
+def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=False,
           host="127.0.0.1", strict_port=False):
     """Start the viewer and block until interrupted.
 
@@ -830,6 +915,9 @@ def serve(data_path, mesh_path="", port=8765, nx=1200, ny=700, open_browser=True
     compute node: an SSH tunnel from your machine lands on the *login* node,
     so a viewer listening only on the compute node's loopback is unreachable.
     Pass host="0.0.0.0" there, exactly as one does for Jupyter.
+
+    `open_browser` is off by default: see `open_in_browser` for why launching
+    one unasked is the wrong default where gmpas actually runs.
     """
     viewer = Viewer(data_path, mesh_path, nx=nx, ny=ny)
     server = bind(_handler(viewer), port, host=host, strict=strict_port)

--- a/src/gmpas/viewer.py
+++ b/src/gmpas/viewer.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import errno
 import getpass
+import functools
 import io
 import json
 import os
@@ -25,7 +26,6 @@ import socket
 import sys
 import threading
 import webbrowser
-from collections import OrderedDict
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -33,6 +33,8 @@ from urllib.parse import parse_qs, urlparse
 import numpy as np
 
 from . import data as _data
+from . import timing
+from .cache import BuildCache
 from .mesh import MpasMesh
 from .raster import target_grid
 from .series import Series
@@ -41,11 +43,11 @@ from .series import Series
 CMAPS = ["viridis", "plasma", "magma", "cividis", "turbo",
          "RdBu_r", "coolwarm", "BrBG", "Blues", "Spectral_r"]
 
-#: distinct view boxes to keep a ViewIndex/overlay cached for. Each entry is
-#: an nx*ny array pair (~7.5 MB at the 1200x700 default), and nothing evicted
-#: this before -- panning and zooming around over a long session, which is
-#: exactly what building up several animations for different variables looks
-#: like, grew both dicts without bound for the life of the server process.
+#: Deprecated: view caches are bounded by bytes now, not by entry count -- see
+#: `cache.view_budget` and GMPAS_VIEW_CACHE_MB. A count only bounds memory
+#: while entry size is fixed, and these entries scale with the browser window:
+#: twelve of them is ~178 MB at 1200x700 and ~1.1 GB at 3840x2160. Kept as a
+#: name so anything importing it still resolves.
 VIEW_LRU_SIZE = 12
 
 #: derived-variable grammar: a fixed, small set of patterns, each mapped to
@@ -77,22 +79,29 @@ class ViewIndex:
     def __init__(self, mesh: MpasMesh, extent, nx: int, ny: int):
         self.extent, self.nx, self.ny = tuple(extent), nx, ny
 
-        lon, lat = target_grid(self.extent, nx, ny)
-        lon2, lat2 = np.meshgrid(lon, lat)
-        lon_r, lat_r = np.radians(lon2), np.radians(lat2)
-        pts = np.stack([np.cos(lat_r) * np.cos(lon_r),
-                        np.cos(lat_r) * np.sin(lon_r),
-                        np.sin(lat_r)], axis=-1).reshape(-1, 3)
+        with timing.step("view.build", px=nx * ny):
+            lon, lat = target_grid(self.extent, nx, ny)
+            lon2, lat2 = np.meshgrid(lon, lat)
+            lon_r, lat_r = np.radians(lon2), np.radians(lat2)
+            pts = np.stack([np.cos(lat_r) * np.cos(lon_r),
+                            np.cos(lat_r) * np.sin(lon_r),
+                            np.sin(lat_r)], axis=-1).reshape(-1, 3)
 
-        radius = np.sqrt(np.asarray(mesh.area_cell) / np.pi) / mesh.sphere_radius
-        dist, idx = mesh.tree().query(
-            pts, workers=-1, distance_upper_bound=2.0 * float(radius.max())
-        )
-        missing = idx >= mesh.n_cells
-        idx = np.where(missing, 0, idx)
+            radius = np.sqrt(np.asarray(mesh.area_cell) / np.pi) / mesh.sphere_radius
+            with timing.step("view.query", px=nx * ny):
+                dist, idx = mesh.tree().query(
+                    pts, workers=-1, distance_upper_bound=2.0 * float(radius.max())
+                )
+            missing = idx >= mesh.n_cells
+            idx = np.where(missing, 0, idx)
 
-        self.idx = idx
-        self.blank = (missing | (dist > 2.0 * radius[idx])).reshape(ny, nx)
+            self.idx = idx
+            self.blank = (missing | (dist > 2.0 * radius[idx])).reshape(ny, nx)
+
+    @property
+    def nbytes(self) -> int:
+        """What this index costs to keep, so a cache can budget for it."""
+        return int(self.idx.nbytes + self.blank.nbytes)
 
     def frame(self, values: np.ndarray) -> np.ndarray:
         """One field, sampled onto this view. A gather, nothing more."""
@@ -114,22 +123,53 @@ def _png(img: np.ndarray, cmap: str, vmin: float, vmax: float,
     Going through a matplotlib Figure would cost tens of milliseconds more and
     undo the point of reusing the view index.
     """
-    from matplotlib import colormaps
     from PIL import Image
 
+    with timing.step("png.encode", px=img.size):
+        im = Image.fromarray(_quantize(img, vmin, vmax)[::-1], mode="P")
+        im.putpalette(_palette(cmap))                  # imshow origin=lower
+
+        buf = io.BytesIO()
+        im.save(buf, format="PNG", transparency=255, compress_level=compress)
+        return buf.getvalue()
+
+
+@functools.lru_cache(maxsize=32)
+def _palette(cmap: str) -> list:
+    """The flat 768-entry palette PIL wants, built once per colormap.
+
+    Rebuilding this per frame meant a colormap call, a round, a cast, a vstack
+    and a 768-element `.tolist()` on every frame of every animation, to produce
+    a value that depends on nothing but the colormap name.
+    """
+    from matplotlib import colormaps
+
     lut = (np.asarray(colormaps[cmap](np.linspace(0, 1, 255)))[:, :3] * 255)
-    lut = lut.round().astype(np.uint8)
+    return np.vstack([lut.round().astype(np.uint8), [[0, 0, 0]]]).ravel().tolist()
 
+
+def _quantize(img: np.ndarray, vmin: float, vmax: float) -> np.ndarray:
+    """Scale a frame to palette indices, with 255 reserved for "no data".
+
+    Done in place through one scratch buffer. The arithmetic version of this
+    allocated a fresh full-frame float64 array per step -- five of them, 13 MB
+    each at the browser's 1680x980 -- which at 3000 animation frames is a great
+    deal of allocator traffic for a result that is written straight to a PNG.
+
+    The non-finite mask is recomputed rather than taken from `ViewIndex.blank`,
+    which looks redundant but is not: `blank` marks pixels that fall outside
+    the mesh, while a field can also carry NaN at cells inside it. `blank` is a
+    subset of what has to be masked here, not the whole of it.
+    """
     span = (vmax - vmin) or 1.0
-    idx = np.clip(np.rint((img - vmin) / span * 254.0), 0, 254)
-    idx = np.where(np.isfinite(img), idx, 255).astype(np.uint8)
-
-    im = Image.fromarray(idx[::-1], mode="P")          # imshow origin=lower
-    im.putpalette(np.vstack([lut, [[0, 0, 0]]]).ravel().tolist())
-
-    buf = io.BytesIO()
-    im.save(buf, format="PNG", transparency=255, compress_level=compress)
-    return buf.getvalue()
+    buf = np.subtract(img, vmin, dtype=np.float64)
+    np.multiply(buf, 254.0 / span, out=buf)
+    np.rint(buf, out=buf)
+    np.clip(buf, 0, 254, out=buf)
+    # must land before the cast, not after: casting NaN to uint8 is undefined
+    # and numpy warns on it, which this package turns into an error
+    np.copyto(buf, 255.0, where=~np.isfinite(img))
+    return buf.astype(np.uint8)
 
 
 def _overlay(extent, nx: int, ny: int) -> bytes:
@@ -191,17 +231,13 @@ class Viewer:
         self.mesh = self.series.mesh
         self.nx, self.ny = nx, ny
         self.home = self.mesh.extent
-        self._views: OrderedDict[tuple, ViewIndex] = OrderedDict()
-        self._overlays: OrderedDict[tuple, bytes] = OrderedDict()
-        # Guards only the dict bookkeeping below, never the build itself --
-        # see _cached(). A KD-tree query or a cartopy render can take a
-        # couple hundred ms, and holding this for that long serialized every
-        # render in the process onto one thread at a time regardless of
-        # whether they shared a key, even though ThreadingHTTPServer already
-        # gives each request its own thread.
-        self._lock = threading.Lock()
-        self._view_pending: dict[tuple, threading.Event] = {}
-        self._overlay_pending: dict[tuple, threading.Event] = {}
+        # Each holds its own lock, and neither is held across a build -- a
+        # KD-tree query or a cartopy render takes long enough that holding a
+        # shared lock over it serialized every render in the process onto one
+        # thread at a time regardless of whether they shared a key, even
+        # though ThreadingHTTPServer already gives each request its own.
+        self._views = BuildCache()
+        self._overlays = BuildCache()
 
     # -- variables -------------------------------------------------------
 
@@ -248,59 +284,15 @@ class Viewer:
 
     # -- frames ----------------------------------------------------------
 
-    def _cached(self, cache: OrderedDict, pending: dict, key, build):
-        """Get-or-build `key` in `cache`, computing `build()` at most once
-        per key even under concurrent requests -- but never while holding
-        `self._lock`, so a request for a different key never waits on it.
-
-        Concurrent requests for the *same* uncached key share one build via
-        `pending`'s per-key Event rather than duplicating the work; a build
-        that raises leaves nothing cached, so any waiters just retry it
-        themselves instead of silently reusing a failure.
-        """
-        with self._lock:
-            if key in cache:
-                cache.move_to_end(key)
-                return cache[key]
-            ev = pending.get(key)
-            if ev is None:
-                pending[key] = ev = threading.Event()
-                mine = True
-            else:
-                mine = False
-        if not mine:
-            ev.wait()
-            with self._lock:
-                if key in cache:
-                    return cache[key]
-            return self._cached(cache, pending, key, build)      # builder failed: retry
-
-        try:
-            value = build()
-        except Exception:
-            with self._lock:
-                del pending[key]
-            ev.set()
-            raise
-        with self._lock:
-            cache[key] = value
-            if len(cache) > VIEW_LRU_SIZE:
-                cache.popitem(last=False)
-            del pending[key]
-        ev.set()
-        return value
-
     def view(self, extent, nx=None, ny=None) -> ViewIndex:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
-        return self._cached(self._views, self._view_pending, key,
-                             lambda: ViewIndex(self.mesh, extent, nx, ny))
+        return self._views.get(key, lambda: ViewIndex(self.mesh, extent, nx, ny))
 
     def overlay(self, extent, nx=None, ny=None) -> bytes:
         nx, ny = nx or self.nx, ny or self.ny
         key = (*(round(float(v), 6) for v in extent), nx, ny)
-        return self._cached(self._overlays, self._overlay_pending, key,
-                             lambda: _overlay(extent, nx, ny))
+        return self._overlays.get(key, lambda: _overlay(extent, nx, ny))
 
     def values(self, var: str, time: int, level: int) -> np.ndarray:
         """`time` indexes the whole series, across files, not one file.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,139 @@
+"""The shared view cache: bounded by bytes, and never locked across a build.
+
+Both properties only show themselves at production scale -- a 41M-cell mesh
+and a 4K browser window -- so they are forced here with tiny budgets and
+deliberately slow builds instead.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from gmpas.cache import VIEW_CACHE_BYTES, BuildCache, sizeof, view_budget
+
+
+def test_the_budget_is_bytes_and_overridable(monkeypatch):
+    monkeypatch.delenv("GMPAS_VIEW_CACHE_MB", raising=False)
+    assert view_budget() == VIEW_CACHE_BYTES
+
+    monkeypatch.setenv("GMPAS_VIEW_CACHE_MB", "8")
+    assert view_budget() == 8 * 1024 * 1024
+
+    # a knob nobody can read the units of is worse than no knob
+    monkeypatch.setenv("GMPAS_VIEW_CACHE_MB", "0.5")
+    assert view_budget() == 512 * 1024
+
+
+def test_an_unparseable_budget_falls_back_rather_than_crashing(monkeypatch):
+    monkeypatch.setenv("GMPAS_VIEW_CACHE_MB", "lots")
+    assert view_budget() == VIEW_CACHE_BYTES
+
+
+def test_sizeof_measures_what_these_caches_actually_hold():
+    """Overlays are encoded PNG bytes; view indices expose nbytes."""
+    assert sizeof(b"1234") == 4
+    assert sizeof(np.zeros(10, dtype=np.int64)) == 80
+
+    class Index:
+        nbytes = 4096
+
+    assert sizeof(Index()) == 4096
+
+
+def test_a_value_is_built_once_per_key():
+    calls = []
+    cache = BuildCache(budget=1_000_000)
+
+    for _ in range(5):
+        cache.get("k", lambda: calls.append(1) or "value")
+
+    assert calls == [1]
+
+
+def test_eviction_is_oldest_first_and_stops_at_the_budget():
+    cache = BuildCache(budget=300)
+    for i in range(10):
+        cache.get(i, lambda: b"x" * 100)
+
+    assert cache.nbytes <= 300
+    assert len(cache) == 3
+    assert 0 not in cache._items          # the oldest went first
+    assert 9 in cache._items
+
+
+def test_an_entry_larger_than_the_budget_is_returned_but_not_kept():
+    """Keeping it would evict everything else and still leave it as the sole
+    occupant, to be evicted itself by the next request. Same rule as
+    Series._remember."""
+    cache = BuildCache(budget=50)
+    value = cache.get("big", lambda: b"x" * 500)
+
+    assert value == b"x" * 500
+    assert len(cache) == 0
+    assert cache.nbytes == 0
+
+
+def test_a_failed_build_caches_nothing_and_is_retried():
+    attempts = []
+
+    def flaky():
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("cartopy had a bad day")
+        return "second time lucky"
+
+    cache = BuildCache(budget=1_000_000)
+    with pytest.raises(RuntimeError):
+        cache.get("k", flaky)
+    assert len(cache) == 0
+
+    assert cache.get("k", flaky) == "second time lucky"
+    assert len(attempts) == 2
+
+
+def test_the_lock_is_not_held_across_a_build():
+    """The bug this class exists to prevent: a KD-tree query or a cartopy
+    render takes long enough that holding a shared lock over it serialises
+    every unrelated request in the process."""
+    cache = BuildCache(budget=1_000_000)
+    started = threading.Event()
+
+    def slow():
+        started.set()
+        time.sleep(0.5)
+        return b"slow"
+
+    t = threading.Thread(target=lambda: cache.get("slow", slow))
+    t.start()
+    assert started.wait(2.0)
+
+    # a different key must not wait behind the slow build
+    began = time.perf_counter()
+    cache.get("other", lambda: b"fast")
+    assert time.perf_counter() - began < 0.25
+
+    t.join()
+
+
+def test_concurrent_requests_for_one_key_share_a_single_build():
+    """Dropping the lock naively lets N threads each do the whole build."""
+    builds = []
+    cache = BuildCache(budget=1_000_000)
+
+    def slow():
+        builds.append(1)
+        time.sleep(0.2)
+        return b"once"
+
+    threads = [threading.Thread(target=lambda: cache.get("k", slow))
+               for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert builds == [1]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -390,3 +390,102 @@ def test_the_values_budget_honours_its_environment_override(monkeypatch):
 
     monkeypatch.delenv(VALUES_CACHE_ENV)
     assert values_budget() == VALUES_CACHE_BYTES
+
+
+# --------------------------------------------- files that are not really data
+
+
+def test_an_applestore_sidecar_is_not_mistaken_for_output(tmp_path):
+    """`._history....nc` is a resource fork, and it sorted first.
+
+    A run directory that has been through a Mac carries one of these beside
+    every real file. They share the timestamp `order()` sorts on, and break
+    the tie in their own favour, so the sidecar became `files[0]` -- the one
+    file the constructor opens -- and the viewer died on it before serving
+    anything.
+    """
+    from gmpas.series import Series
+
+    run = _run_dir(tmp_path, n_files=2)
+    real = sorted(run.glob("history.*.nc"))
+    for path in real:
+        (path.parent / f"._{path.name}").write_bytes(b"Mac OS X\x00\x02" * 8)
+
+    s = Series(run)
+    try:
+        assert [p.name for p in s.files] == [p.name for p in real]
+    finally:
+        s.close()
+
+
+def test_an_explicitly_named_sidecar_is_still_honoured(tmp_path):
+    """Filtering applies to globbing, not to a path somebody typed.
+
+    Deciding that a named file was not meant is worse than any error opening
+    it produces -- the user can see the name they gave.
+    """
+    from gmpas.series import expand
+
+    run = _run_dir(tmp_path, n_files=1)
+    sidecar = run / "._history.2012-02-25_00.00.00.nc"
+    sidecar.write_bytes(b"Mac OS X\x00\x02")
+
+    assert expand(sidecar) == [sidecar]
+
+
+def test_an_unreadable_file_is_skipped_rather_than_fatal(tmp_path, capsys):
+    """A half-written file is a normal state on HPC, not a corrupt run.
+
+    A model still writing its newest history file, or a transfer still in
+    flight, used to take the whole viewer down with a netCDF traceback
+    instead of serving the files that were fine.
+    """
+    from gmpas.series import Series
+
+    run = _run_dir(tmp_path, n_files=3)
+    truncated = sorted(run.glob("*.nc"))[0]
+    truncated.write_bytes(b"CDF\x01 truncated")   # right suffix, no contents
+
+    s = Series(run)
+    try:
+        assert truncated not in s.files
+        assert len(s.files) == 2
+    finally:
+        s.close()
+
+    err = capsys.readouterr().err
+    assert truncated.name in err                  # never dropped in silence
+
+
+def test_a_directory_of_nothing_readable_still_says_so(tmp_path):
+    """Skipping the unreadable is not the same as pretending it worked."""
+    import pytest
+
+    from gmpas.series import Series
+
+    run = tmp_path / "run"
+    run.mkdir()
+    for i in range(2):
+        (run / f"history.2012-02-25_{i:02d}.00.00.nc").write_bytes(b"not netcdf")
+
+    with pytest.raises(OSError, match="no readable file"):
+        Series(run)
+
+
+def test_every_series_shares_one_netcdf_lock(tmp_path):
+    """The hazard is HDF5's, not any object's, so the lock cannot be per-object.
+
+    Two Series in one process -- which is what a dashboard holds -- used to
+    take different locks and enter the C library together. That does not
+    corrupt a frame, it kills the process with SIGSEGV and no traceback.
+    """
+    from gmpas import netcdf
+    from gmpas.series import Series
+
+    run = _run_dir(tmp_path, n_files=2)
+    a, b = Series(run), Series(run)
+    try:
+        assert a._lock is b._lock is netcdf.LOCK
+    finally:
+        a.close()
+        b.close()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,153 @@
+"""The timing facility must cost nothing when nobody asked for it.
+
+These assert on the *shape* of the instrumentation rather than on durations:
+a duration test at fixture scale measures the clock, not the code. The label
+set is asserted so that deleting an instrumentation point fails loudly --
+these labels are how a run on a real mesh gets attributed, and the whole point
+of adding them was that guessing which stage dominates has been wrong before.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gmpas import timing
+
+
+@pytest.fixture(autouse=True)
+def _clean_timing(monkeypatch):
+    """Leave the module exactly as it was found, however the test exits."""
+    monkeypatch.delenv("GMPAS_TIMING", raising=False)
+    monkeypatch.delenv("GMPAS_TIMING_FILE", raising=False)
+    timing.refresh()
+    timing.reset()
+    yield
+    monkeypatch.delenv("GMPAS_TIMING", raising=False)
+    timing.refresh()
+    timing.reset()
+
+
+def test_disabled_timing_allocates_nothing(capsys):
+    """The guarantee that lets this be called per animation frame: with
+    timing off, `step` hands back one shared do-nothing object rather than
+    building a context manager."""
+    assert timing.LEVEL == 0
+    assert timing.step("anything") is timing._NULL
+    assert timing.step("a") is timing.step("b")
+
+    with timing.step("mesh.tree_build", cells=41_902_592) as t:
+        t.note(opened=3)
+
+    assert capsys.readouterr().err == ""
+
+
+def test_enabling_timing_reports_the_label_and_its_fields(capsys):
+    import os
+
+    os.environ["GMPAS_TIMING"] = "1"
+    timing.refresh()
+
+    with timing.step("mesh.discover", scanned=3000) as t:
+        t.note(opened=1)
+
+    err = capsys.readouterr().err
+    assert "gmpas.timing" in err
+    assert "mesh.discover" in err
+    assert "scanned=3000" in err
+    assert "opened=1" in err
+
+
+def test_a_junk_level_disables_rather_than_crashing(monkeypatch):
+    """GMPAS_TIMING=yes is a plausible thing to type, and instrumentation is
+    the last thing that should take a run down."""
+    monkeypatch.setenv("GMPAS_TIMING", "yes")
+    timing.refresh()
+
+    assert timing.LEVEL == 0
+    assert timing.step("x") is timing._NULL
+
+
+def test_the_roll_up_totals_repeated_labels(capsys):
+    import os
+
+    os.environ["GMPAS_TIMING"] = "1"
+    timing.refresh()
+    timing.reset()
+
+    for _ in range(3):
+        with timing.step("view.query", px=4000):
+            pass
+    capsys.readouterr()
+
+    timing._report()
+    err = capsys.readouterr().err
+    assert "roll-up" in err
+    assert "view.query" in err
+    assert "n=3" in err
+
+
+def test_an_exception_still_reports_the_step(capsys):
+    """A stage that died is exactly the one worth knowing the duration of."""
+    import os
+
+    os.environ["GMPAS_TIMING"] = "1"
+    timing.refresh()
+
+    with pytest.raises(ValueError):
+        with timing.step("mesh.build"):
+            raise ValueError("no room")
+
+    assert "mesh.build" in capsys.readouterr().err
+
+
+def test_timing_can_be_sent_to_a_file(tmp_path, monkeypatch):
+    """A -j 32 pool interleaves stderr into mush, so it has somewhere to go."""
+    out = tmp_path / "timing.log"
+    monkeypatch.setenv("GMPAS_TIMING", "1")
+    monkeypatch.setenv("GMPAS_TIMING_FILE", str(out))
+    timing.refresh()
+
+    with timing.step("series.scan", files=3000):
+        pass
+
+    assert "series.scan" in out.read_text()
+
+
+def test_the_load_path_reports_the_stages_it_was_added_for(tmp_path, capsys,
+                                                           monkeypatch):
+    """The label set is the deliverable: these are the stages that have to be
+    attributable on a real run, so losing one should fail here."""
+    from conftest import write_mesh
+    from gmpas.mesh import MpasMesh
+
+    path = tmp_path / "mesh.nc"
+    write_mesh(path, [(0.0, 0.0), (10.0, 0.0)])
+
+    monkeypatch.setenv("GMPAS_TIMING", "1")
+    timing.refresh()
+
+    mesh = MpasMesh.load(path)
+    mesh.tree()
+
+    err = capsys.readouterr().err
+    for label in ("mesh.signature", "mesh.build", "mesh.cache_load",
+                  "mesh.tree_build"):
+        assert label in err, f"lost the {label} timing point"
+
+
+def test_progress_is_quiet_about_nothing_and_loud_about_something(capsys):
+    """Under a scheduler stdout is a log file, so the bar becomes lines."""
+    bar = timing.Progress(4, unit="block")
+    for _ in range(4):
+        bar.advance()
+    bar.close()
+
+    out = capsys.readouterr().out
+    assert "4/4" in out
+    assert "s/block" in out
+
+
+def test_clock_reads_as_time_not_as_a_float():
+    assert timing.clock(45) == "45s"
+    assert timing.clock(90) == "1m30s"
+    assert timing.clock(3700) == "1h01m"

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -157,16 +157,55 @@ def test_the_view_cache_does_not_grow_without_bound(small_viewer):
     """Nothing evicted this before: panning and zooming around over a long
     session -- exactly what setting up several animations for different
     variables looks like -- grew _views/_overlays forever, for the life of
-    the server process."""
-    from gmpas.viewer import VIEW_LRU_SIZE
+    the server process.
 
+    The bound is bytes, not entries. An entry is nx*ny*(8+1) bytes, so a count
+    only bounds memory while the window size is fixed: twelve entries is
+    ~178 MB at 1200x700 and ~1.1 GB at 3840x2160.
+    """
     box = small_viewer.home
-    for i in range(VIEW_LRU_SIZE + 8):
+    budget = small_viewer._views.budget
+    for i in range(40):
         small_viewer.view(box, 80 + i, 50)
         small_viewer.overlay(box, 80 + i, 50)
 
-    assert len(small_viewer._views) == VIEW_LRU_SIZE
-    assert len(small_viewer._overlays) == VIEW_LRU_SIZE
+    assert small_viewer._views.nbytes <= budget
+    assert small_viewer._overlays.nbytes <= budget
+    # these entries are tiny, so nothing should have been evicted to hold 40
+    assert len(small_viewer._views) == 40
+
+
+def test_the_view_cache_evicts_once_the_budget_is_reached(small_viewer, monkeypatch):
+    """The property that matters at scale, forced at fixture scale.
+
+    A budget of a few kilobytes against 80x50 indices (~36 KB each) means the
+    cache can hold one, which is exactly what a 4K browser window does to a
+    256 MB budget.
+    """
+    from gmpas.cache import BuildCache
+
+    small_viewer._views = BuildCache(budget=50_000)
+    box = small_viewer.home
+    for i in range(6):
+        small_viewer.view(box, 80 + i, 50)
+
+    assert small_viewer._views.nbytes <= 50_000
+    assert len(small_viewer._views) < 6
+
+
+def test_an_entry_larger_than_the_whole_budget_is_not_cached(small_viewer):
+    """Caching it would evict everything else and still leave it as the sole
+    occupant, to be evicted itself by the next distinct request. Same rule,
+    and same reasoning, as Series._remember."""
+    from gmpas.cache import BuildCache
+
+    small_viewer._views = BuildCache(budget=100)
+    view = small_viewer.view(small_viewer.home, 80, 50)
+
+    assert view.nbytes > 100
+    assert len(small_viewer._views) == 0
+    # and it still returns a working index rather than failing
+    assert view.idx.size == 80 * 50
 
 
 def test_a_frame_can_be_asked_for_at_a_larger_size(small_viewer):

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -661,3 +661,141 @@ def test_a_job_without_a_submit_host_still_says_something_useful(monkeypatch):
 
     text = "\n".join(reach_lines("0.0.0.0", 8787))
     assert "ssh -N -L 8787:dec0965:8787 someone@<login-node>" in text
+
+
+# ------------------------------------------- not opening a browser by default
+
+
+def test_a_delegating_opener_counts_as_a_terminal_browser_when_headless():
+    """`xdg-open` is the name gmpas sees; w3m is what it launches.
+
+    CONSOLE_BROWSERS names every terminal browser, and caught none of this:
+    the controller reports itself as the delegator. With nothing graphical
+    running, whatever it hands the URL to renders into this terminal.
+    """
+    import os
+
+    from gmpas.viewer import _console_browser
+
+    class Ctl:
+        name = "/usr/bin/xdg-open"
+
+    seen = {k: os.environ.pop(k, None) for k in ("DISPLAY", "WAYLAND_DISPLAY")}
+    try:
+        assert _console_browser(Ctl()) is True
+        os.environ["DISPLAY"] = ":0"
+        assert _console_browser(Ctl()) is False    # a desktop: it opens a window
+    finally:
+        os.environ.pop("DISPLAY", None)
+        for k, v in seen.items():
+            if v is not None:
+                os.environ[k] = v
+
+
+def test_view_does_not_open_a_browser_unless_asked(monkeypatch):
+    """The default is to print the URL, not to launch anything.
+
+    On a login node the realistic outcome of launching was a text browser
+    rendering the viewer's JavaScript shell over the log the user was reading.
+    """
+    from gmpas import cli
+
+    opened = []
+    monkeypatch.setattr("gmpas.dashboard.build",
+                        lambda *a, **k: ([], "banner"))
+    monkeypatch.setattr("gmpas.dashboard.serve",
+                        lambda *a, **k: opened.append(k["open_browser"]))
+
+    args = cli.build_parser().parse_args(["view", "run/"])
+    assert args.browser is False
+    cli._dashboard(args, data_path=args.path)
+    assert opened == [False]
+
+    args = cli.build_parser().parse_args(["view", "run/", "--browser"])
+    cli._dashboard(args, data_path=args.path)
+    assert opened == [False, True]
+
+
+def test_the_old_no_browser_flag_still_parses():
+    """It is in every job script already, and now asks for the default."""
+    from gmpas import cli
+
+    args = cli.build_parser().parse_args(["view", "run/", "--no-browser"])
+    assert args.browser is False
+
+
+def test_a_loopback_only_fqdn_is_not_offered_as_an_ssh_target(monkeypatch):
+    """A stock /etc/hosts maps the machine's own FQDN to 127.0.1.1.
+
+    That name looks perfectly plausible -- `box.example.dom` -- and is a
+    loopback alias, so the ssh command built from it connects to nothing.
+    """
+    import socket
+
+    from gmpas import viewer
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "box")
+    monkeypatch.setattr(socket, "getfqdn", lambda *a: "box.example.dom")
+    monkeypatch.setattr(viewer, "_loopback_only", lambda name, timeout=1.0: True)
+
+    assert viewer.ssh_target() == "box"
+
+
+def test_a_name_that_does_not_resolve_here_is_left_alone(monkeypatch):
+    """Unresolvable is not disproved: login nodes resolve from outside.
+
+    Dropping a correct hostname is the worse error, since the reader can
+    sanity-check one that is shown and cannot recover one that is not.
+    """
+    import socket
+
+    from gmpas import viewer
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+    monkeypatch.setattr(socket, "getfqdn", lambda *a: "dec1042.hpc.example.edu")
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no")))
+
+    assert viewer.ssh_target() == "dec1042.hpc.example.edu"
+
+
+def test_a_job_bound_to_loopback_is_told_the_one_thing_that_helps(monkeypatch):
+    """Inside a job there is no tunnel command that reaches loopback.
+
+    The hop lands on the login node, where 127.0.0.1 is a different machine.
+    Printing a tunnel there would be printing a command that cannot work.
+    """
+    import socket
+
+    from gmpas.viewer import reach_lines
+
+    monkeypatch.setattr(socket, "gethostname", lambda: "dec1042")
+    monkeypatch.setenv("PBS_JOBID", "123456.desched1")
+    monkeypatch.setenv("PBS_O_HOST", "derecho7")
+
+    text = "\n".join(reach_lines("127.0.0.1", 8765))
+    assert "--host 0.0.0.0" in text
+    assert "derecho7" in text
+    assert "ssh -N -L" not in text            # no command that cannot land
+
+
+def test_nothing_launches_a_browser_behind_the_guards():
+    """`webbrowser.open` walks its whole list, and that list ends in elinks.
+
+    `gmpas prep view` and `gmpas prep hfun` each carried their own copy of
+    serve() that called it directly, so neither the terminal-browser refusal
+    nor the opt-in default applied to them: they opened a text browser over
+    the running server's own log. The single guarded path in viewer.py, which
+    resolves exactly one controller and vets it, is the only one left.
+    """
+    import pathlib
+
+    import gmpas
+
+    root = pathlib.Path(gmpas.__file__).parent
+    users = sorted(p.relative_to(root).as_posix()
+                   for p in root.rglob("*.py")
+                   if "webbrowser" in p.read_text())
+    assert users == ["viewer.py"]
+
+    assert "webbrowser.open(" not in (root / "viewer.py").read_text()


### PR DESCRIPTION
Releases **0.4.6**.

- Patch fix for terminal-based gmpas support.
- Removed terminal issues.

`gmpas view` now serves the viewer to a terminal instead of rendering into
one: the terminal prints a link and the browser draws.

Also carried in this branch, since the viewer change builds directly on it:

- `timing.py` — `GMPAS_TIMING=1/2` stage instrumentation, off by default and
  allocation-free when off, so "one to two minutes to open a 41M-cell run"
  becomes an attributable number per subcommand.
- `cache.py` — one bounded, concurrent get-or-build cache shared by all four
  viewers, bounded by bytes rather than entry count, and never holding the
  lock across a build.

Version bumped in `pyproject.toml`, `src/gmpas/__init__.py` and
`CITATION.cff`. `docs/why.md` deliberately keeps 0.4.5 — it records the
versions a benchmark was measured under.

Local run: 414 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)