### PR TITLE
release: 0.4.7

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ type: software
 authors:
   - given-names: Nirmal Mathew
     family-names: Alex
-version: 0.4.6
-date-released: "2026-09-03"
+version: 0.4.7
+date-released: "2026-09-04"
 repository-code: "https://github.com/nmathewa/gmpas-lib"
 url: "https://github.com/nmathewa/gmpas-lib"
 doi: 10.5281/zenodo.21987068

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install "gmpas[plot]"    # + matplotlib and cartopy, for plotting
 conda env create -f environment.yml && conda activate gmpas && pip install -e . --no-deps
 ```
 
-mesh generation requires [JIGSAW](https://github.com/dengwirda/jigsaw) and, MPI and PnetCDF
+Mesh generation requires [JIGSAW](https://github.com/dengwirda/jigsaw), MPI and PnetCDF.
 
 ```bash
 gmpas --version

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-As of 0.4.6, gmpas covers the pipeline from both ends.
+As of 0.4.7, gmpas covers the pipeline from both ends.
 
 **Postprocessing** — plotting, the interactive viewer, and conservative
 remapping — is implemented. `gmpas remap` writes the grid files ESMF needs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmpas"
-version = "0.4.6"
+version = "0.4.7"
 description = "Fast plotting of MPAS output on its own native variable-resolution mesh"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmpas/__init__.py
+++ b/src/gmpas/__init__.py
@@ -31,7 +31,7 @@ from .style import CMAPS, EXTENTS, Style, resolve_extent, save_figure
 
 # kept in step with pyproject.toml by test_version.py -- `gmpas --version` and
 # the built wheel disagreeing is the kind of thing only noticed after a release
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 __all__ = [
     # entry points


### PR DESCRIPTION
Cuts 0.4.7, the first release that will publish itself.

`publish.yml` merged ~12 hours after v0.4.6 was tagged, so the tag predates
the workflow and nothing has exercised the PyPI path yet. This release does.

- README: `mesh generation requires JIGSAW and, MPI and PnetCDF` had a stray
  comma and started mid-sentence.
- Version bumped in `pyproject.toml`, `src/gmpas/__init__.py` and
  `CITATION.cff`, plus the `docs/status.md` opening line — the same four files
  `release: 0.4.5` touched. `docs/why.md` keeps its own version string, which
  records what a benchmark was measured under.

Local run: 414 passed, 5 skipped. `gmpas --version` reports 0.4.7.

After merge, `gh release create v0.4.7` should trigger `publish.yml` and put
gmpas on PyPI for the first time since 0.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)